### PR TITLE
spec: Add missing make and libappstream-glib build dependencies

### DIFF
--- a/cockpit-machines.spec.in
+++ b/cockpit-machines.spec.in
@@ -24,6 +24,9 @@ URL:            https://github.com/cockpit-project/cockpit-machines
 
 Source0:        https://github.com/cockpit-project/cockpit-machines/releases/download/%{version}/cockpit-machines-%{version}.tar.gz
 BuildArch:      noarch
+BuildRequires:  libappstream-glib
+BuildRequires:  make
+
 Requires: cockpit-bridge >= 215
 %if 0%{?suse_version}
 Requires: libvirt-daemon-qemu


### PR DESCRIPTION
This broke the [release](https://github.com/cockpit-project/cockpit-machines/runs/2167448820?check_suite_focus=true) in the copr build. starter-kit and podman have them as well, I suppose they were accidentally dropped when copying things over.

@KKoukiou : I suggest to remove the tag and re-tag/re-release after this lands.