### PR TITLE
Generate and download pre-built dist tarballs

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -1,0 +1,36 @@
+name: build-dist
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          # need this to also fetch tags
+          fetch-depth: 0
+          # avoid checking out the default pull/NNN/head ref, as that gives
+          # mismatching SHAs in generated tarballs
+          ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+
+      - name: Set up dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y --no-install-recommends npm make gettext sassc
+
+      - name: Build dist tarball
+        run: make dist-gzip
+
+      - name: Create dist tarball artifact
+        uses: actions/upload-artifact@v2
+        with:
+          # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
+          # for pull_requests, use HEAD of the proposed branch, for pushes to origin the current SHA
+          name: "dist-${{ github.event.pull_request.head.sha || github.sha }}"
+          path: cockpit-machines-*.tar.gz
+          retention-days: 7

--- a/.github/workflows/prune-dist.yml
+++ b/.github/workflows/prune-dist.yml
@@ -1,0 +1,39 @@
+# truncate the -dist history every Sunday night, to avoid unbounded growth
+name: prune-dist
+on:
+  schedule:
+    - cron: '0 1 * * 0'
+  # can be run manually on https://github.com/cockpit-project/cockpit-machines/actions
+  workflow_dispatch:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up configuration and secrets
+        run: |
+          printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
+          echo '${{ secrets.COCKPITUOUS_TOKEN }}' > ~/.config/github-token
+          # we push to -dist repo via https://github.com, that needs our cockpituous token
+          git config --global credential.helper store
+          echo 'https://token:${{ secrets.COCKPITUOUS_TOKEN }}@github.com' >> ~/.git-credentials
+
+      - name: Clone -dist repo
+        run: |
+          git clone https://github.com/${{ github.repository }}-dist.git dist-repo
+
+      - name: Truncate history of -dist repo
+        run: |
+          set -ex
+          cd dist-repo
+          # oldest commit that applies to any still present tarball
+          REF=$(git log --pretty=format:%H * | tail -n1)
+
+          git checkout --orphan temp $REF
+          git commit -m "Truncated history"
+          git rebase --onto temp $REF main
+          git branch -D temp
+          git reflog expire --expire=now --all
+
+      - name: Force-push -dist repo
+        run: git -C dist-repo push -f

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -1,0 +1,65 @@
+name: publish-dist
+on:
+  workflow_run:
+    workflows: build-dist
+    types: [completed]
+
+jobs:
+  run:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build-dist artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-dist
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Set up configuration and secrets
+        run: |
+          printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
+          echo '${{ secrets.COCKPITUOUS_TOKEN }}' > ~/.config/github-token
+          # we push to -dist repo via https://github.com, that needs our cockpituous token
+          git config --global credential.helper store
+          echo 'https://token:${{ secrets.COCKPITUOUS_TOKEN }}@github.com' >> ~/.git-credentials
+
+      - name: Commit dist tarball dist repo
+        run: |
+          set -ex
+
+          # we need a fully predictable name/URL, and git introduces these
+          # additional numbers into the version; so wrap it in a predictable named tar
+          sha=$(ls -d dist-* | sed 's/dist-//')
+
+          # multiple parallel workflows race against each other, so the final
+          # `git push` may fail
+          rc=1
+          for retry in $(seq 5); do
+              git clone https://github.com/${{ github.repository }}-dist.git dist-repo
+              tar -cvf "dist-repo/${sha}.tar" -C "dist-$sha" .
+
+              # freshly created empty repo?
+              cd dist-repo
+              git rev-parse HEAD >/dev/null 2>&1 || git init -b main
+              git add "${sha}.tar"
+              git commit -m "Build for $sha"
+
+              # remove tarballs older than a week
+              now=$(date +%s)
+              for f in *.tar; do
+                  fmtime=$(git log --pretty=%at -n1 -- $f)
+                  [ $(($now - $fmtime)) -lt 604800 ] || git rm $f
+              done
+              [ -z "$(git status --short)" ] || git commit -m 'Drop old builds'
+
+              if git push; then
+                  rc=0
+                  break
+              else
+                  echo "ERROR: conflict? Retrying git commit"
+                  cd ..
+                  rm -rf dist-repo
+              fi
+          done
+          exit $rc
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bots/
+dist/
 lib/
 test/common/
 cockpit-machines-*.rpm

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,11 @@ devel-install: $(WEBPACK_TEST)
 dist-gzip: $(TARFILE)
 	@ls -1 $(TARFILE)
 
+# ensure that LIB_TEST and spec are older than the unpacked tarball
+download-dist: $(LIB_TEST) cockpit-machines.spec
+	test/download-dist
+	@ls -1 $(TARFILE)
+
 # when building a distribution tarball, call webpack with a 'production' environment
 # we don't ship node_modules for license and compactness reasons; we ship a
 # pre-built dist/ (so it's not necessary) and ship packge-lock.json (so that

--- a/test/download-dist
+++ b/test/download-dist
@@ -1,0 +1,131 @@
+#!/usr/bin/python3
+# This file is part of Cockpit.
+#
+# Copyright (C) 2021 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import glob
+import io
+import os
+import urllib.request
+import subprocess
+import sys
+import tarfile
+import time
+import argparse
+
+
+def message(*args):
+    print(*args, file=sys.stderr)
+
+
+def download_dist(wait=False):
+    '''Download dists tarball for current git SHA from GitHub
+
+    These are produced by .github/workflows/build-dist.yml for every PR and push.
+    This is a lot faster than having to npm install and run webpack.
+
+    Returns path to downloaded tarball, or None if it isn't available.
+    This can happen because the current directory is not a git checkout, or it is
+    a SHA which is not pushed/PRed.
+    '''
+    try:
+        sha = subprocess.check_output(["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL).decode().strip()
+    except subprocess.CalledProcessError:
+        message("download-dist: not a git repository")
+        return None
+
+    if subprocess.call(["git", "diff", "--quiet", "--", ":^test"]) > 0:
+        message("download-dist: uncommitted local changes, skipping download")
+        return None
+
+    dists = glob.glob(f"cockpit-machines-*{sha[:8]}*.tar.gz")
+    if dists:
+        message("download-dist: already downloaded", dists[0])
+        return os.path.abspath(dists[0])
+
+    download_url = f"https://github.com/{ os.getenv('GITHUB_BASE', 'cockpit-project/cockpit-machines') }-dist/raw/main/{sha}.tar"
+    request = urllib.request.Request(download_url)
+    tario = io.BytesIO()
+    retries = 50 if wait else 1  # 25 minutes, once every 30s
+    while retries > 0:
+        try:
+            with urllib.request.urlopen(request) as response:
+                sys.stderr.write(f"download-dist: Downloading dist tarball from {download_url} ...\n")
+                if os.isatty(sys.stderr.fileno()):
+                    total_size = 0
+                else:
+                    total_size = None
+                MB = 10**6
+                # read tar into a stringio, as the stream is not seekable and tar requires that
+                while True:
+                    block = response.read(MB)
+                    if len(block) == 0:
+                        break
+                    if total_size is not None:
+                        total_size += len(block)
+                        sys.stderr.write(f"\r{ total_size // MB } MB")
+
+                    tario.write(block)
+
+                # clear the download progress in tty mode
+                if total_size is not None:
+                    sys.stderr.write("\r                             \r")
+
+                break
+
+        except urllib.error.HTTPError as e:
+            retries -= 1
+
+            if retries == 0:
+                message(f"download-dist: Downloading {download_url} failed:", e)
+                return None
+
+            message(f"download-dist: {download_url} not yet available, waiting...")
+            time.sleep(30)
+
+    tario.seek(0)
+    with tarfile.open(fileobj=tario) as ftar:
+        names = ftar.getnames()
+        try:
+            names.remove('.')
+        except ValueError:
+            pass
+        if len(names) != 1 or not names[0].endswith(".tar.gz"):
+            message("download-dist: expected tar with exactly one tar.gz member")
+            return None
+        ftar.extract(names[0])
+        tar_path = os.path.realpath(names[0])
+
+    # Extract some files locally for speeding up the build and allowing integration tests to run
+    unpack_paths = [d for d in ["dist", "package-lock.json"] if not os.path.exists(d)]
+    if unpack_paths:
+        message("download-dist: Extracting paths from tarball:", ' '.join(unpack_paths))
+        prefixed_unpack_paths = ["cockpit-machines/" + d for d in unpack_paths]
+        subprocess.check_call(["tar", "--touch", "--strip-components=1", "-xf", tar_path] + prefixed_unpack_paths)
+        # ensure that tarball appears new, to avoid make rebuilding it
+        subprocess.check_call(["touch", tar_path])
+
+    return tar_path
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Download release tarball")
+    parser.add_argument('-w', '--wait', action='store_true', help="Wait for up to 20 minutes for download tarball")
+    args = parser.parse_args()
+    dist = download_dist(args.wait)
+    if not dist:
+        sys.exit(1)
+    print(dist)


### PR DESCRIPTION
Copy and adjust the dist tarball workflows from cockpit. These tarballs
are required for packit (as its sandcastle containers are too small to
run webpack), and convenient for livetest and PR testing.

Also copy, simplify, and adjust cockpit's make_dist.py as
test/download-dist, and provide a `make download-dist` shortcut for it.

-----

I tested this on my fork: The [actions ran fine](https://github.com/martinpitt/cockpit-machines/actions), created a [dist repo](https://github.com/martinpitt/cockpit-machines-dist), and I can do this:
```
git clean -ffdx
GITHUB_BASE=martinpitt/cockpit-machines make download-dist
TEST_OS=fedora-34 make vm
```
This will download/unpack the pre-built dist tarball and use it for VM construction without `npm install` and webpack.