### PR TITLE
test: Clean up OS special cases

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -145,7 +145,7 @@ class TestMachinesCreate(VirtualMachinesCase):
 
         # try to CREATE few machines
         # --cloud-init user-data option exists since virt-install >= 3.0.0
-        if m.image in ['fedora-32', 'centos-8-stream', 'rhel-8-3', 'rhel-8-3-distropkg', "rhel-8-4", "rhel-8-4-distropkg", 'ubuntu-stable', 'ubuntu-2004', 'debian-stable']:
+        if m.image in ['centos-8-stream', "rhel-8-4", 'ubuntu-stable', 'ubuntu-2004', 'debian-stable']:
             b.click("#create-new-vm")
             b.wait_visible("#create-vm-dialog")
             self.browser.wait_not_present('select option[value=cloud]')
@@ -184,7 +184,7 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                                       start_vm=True))
 
             # user-login option exists since virt-install >= 3.0.0
-            if m.image not in ['fedora-32', 'centos-8-stream', 'rhel-8-3', 'rhel-8-3-distropkg', "rhel-8-4", "rhel-8-4-distropkg", 'ubuntu-stable', 'ubuntu-2004']:
+            if m.image not in ['centos-8-stream', "rhel-8-4", 'ubuntu-stable', 'ubuntu-2004']:
                 runner.createDownloadAnOSTest(TestMachinesCreate.VmDialog(self, sourceType='os',
                                                                           is_unattended=True, profile="desktop",
                                                                           user_password="catsaremybestfr13nds",
@@ -224,7 +224,7 @@ class TestMachinesCreate(VirtualMachinesCase):
             # name already used from a VM that is currently being created
             # https://bugzilla.redhat.com/show_bug.cgi?id=1780451
             # os option exists only in virt-install >= 2.2.1 which is the reason we have the condition for the OSes list below
-            if self.machine.image in ['debian-stable', 'debian-testing', 'centos-8-stream']:
+            if self.machine.image in ['debian-stable']:
                 self.browser.wait_not_present('select option[value=os]')
             else:
                 runner.createDownloadAnOSTest(TestMachinesCreate.VmDialog(self, name='existing-name', sourceType='os',
@@ -290,7 +290,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         # We don't want to use start_vm == False because if we get a separate install phase
         # virt-install will overwrite our changes.
 
-        if self.machine.image not in ["fedora-33", "fedora-34", "fedora-testing", "debian-testing"]:
+        if self.machine.image in ["debian-stable", "ubuntu-2004", "ubuntu-stable", "centos-8-stream", "rhel-8-4"]:
             # https://bugzilla.redhat.com/show_bug.cgi?id=1818089
             # After shutting it off virt-install will restart the domain and exit because of the above bug
             self.machine.execute("virsh destroy pxe-guest")
@@ -1393,8 +1393,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         m.execute("virsh attach-interface --persistent VmNotInstalled bridge virbr0")
 
         # Change the os boot firmware configuration
-        supports_firmware_config = m.image in ['fedora-32', 'fedora-33', 'fedora-34', 'fedora-testing', 'centos-8-stream',
-                                               'rhel-8-3', 'rhel-8-3-distropkg', "rhel-8-4", "rhel-8-4-distropkg", 'debian-testing', 'ubuntu-stable', 'ubuntu-2004']
+        supports_firmware_config = m.image not in ['debian-stable']
         if supports_firmware_config:
             b.wait_in_text("#vm-VmNotInstalled-firmware", "BIOS")
             b.click("#vm-VmNotInstalled-firmware")
@@ -1423,9 +1422,9 @@ class TestMachinesCreate(VirtualMachinesCase):
             # https://bugzilla.redhat.com/show_bug.cgi?id=1807198
             def hack_broken_caps():
                 if m.image in [
-                    "fedora-32", "fedora-33", "fedora-34", "fedora-testing",
-                    "centos-8-stream", "rhel-8-3", "rhel-8-3-distropkg", "rhel-8-4", "rhel-8-4-distropkg",
-                    "ubuntu-2004", "ubuntu-stable", "debian-testing"
+                    "fedora-33", "fedora-34", "fedora-testing",
+                    "centos-8-stream", "rhel-8-4",
+                    "ubuntu-2004", "ubuntu-stable", "debian-stable", "debian-testing"
                 ]:
                     m.execute("systemctl restart libvirtd")
                     # We don't get events for shut off VMs so reload the page
@@ -1452,7 +1451,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         logfile = "/var/log/libvirt/qemu/VmNotInstalled.log"
         m.execute("> {0}".format(logfile))  # clear logfile
         self.performAction("VmNotInstalled", "forceOff", False)
-        if m.image not in ["fedora-33", "fedora-34", "fedora-testing", "debian-testing"]:
+        if m.image in ["debian-stable", "ubuntu-2004", "ubuntu-stable", "centos-8-stream", "rhel-8-4"]:
             # https://bugzilla.redhat.com/show_bug.cgi?id=1818089
             # After shutting it off virt-install will restart the domain and exit because of the above bug
             # We need to wait till it's restarted and shut if off again in order to edit the offline VM configuration

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -60,8 +60,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
 
     # FIXME remove this skipImage
     @skipImage('Fails with Rejected send message, 1 matched rules; type="method_call"',
-               "rhel-8-3", "rhel-8-3-distropkg", "rhel-8-4", "rhel-8-4-distropkg",
-               "ubuntu-stable", "ubuntu-2004", "debian-testing", "debian-stable", "centos-8-stream")
+               "rhel-8-4", "ubuntu-stable", "ubuntu-2004", "debian-testing", "debian-stable", "centos-8-stream")
     def testBasicLibvirtUserUnprivileged(self):
         user = self.createUser(user_group='libvirt')
         self._testBasic(user, False)
@@ -252,7 +251,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
 
         # newer libvirtd versions use socket activation
         # we should test that separately, but here we test only using the service unit
-        if m.image not in ["debian-stable", "ubuntu-stable", "rhel-8-3", "rhel-8-3-distropkg", "rhel-8-4", "rhel-8-4-distropkg", "centos-8-stream"]:
+        if m.image not in ["debian-stable", "ubuntu-stable", "rhel-8-4", "centos-8-stream"]:
             m.execute("systemctl stop libvirtd-ro.socket libvirtd.socket libvirtd-admin.socket")
             self.addCleanup(m.execute, "systemctl start libvirtd-ro.socket libvirtd.socket libvirtd-admin.socket")
 

--- a/test/check-machines-snapshots
+++ b/test/check-machines-snapshots
@@ -30,7 +30,7 @@ sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
 from machineslib import VirtualMachinesCase  # noqa
 from testlib import nondestructive, skipImage, test_main  # noqa
 
-distrosWithoutSnapshot = ["centos-8-stream", "debian-stable", "fedora-32", "fedora-coreos", "rhel-8-3", "rhel-8-3-distropkg", "rhel-8-4", "rhel-8-4-distropkg", "ubuntu-2004", "ubuntu-stable"]
+distrosWithoutSnapshot = ["centos-8-stream", "debian-stable", "fedora-coreos", "rhel-8-4", "ubuntu-2004", "ubuntu-stable"]
 
 
 @skipImage("Atomic cannot run virtual machines", "fedora-coreos")


### PR DESCRIPTION
 * Drop fedora-32 and rhel-8-3*, not supported from main branch any more.

 * Drop -distropkg, this is not a thing on the standalone project.

 * Invert [OS list where stuff works] to [OS list where stuff is broken].
   The former is really awkward and error prone to maintain, especially
   if there is no "else" branch to explicitly verify that a bug is still
   present.

 * #1780451 should be fixed in Debian testing and CentOS 8 Stream, drop
   these from the "broken" list.