### PR TITLE
test: Fix TestMachinesNetworks.testNetworkSettings

### DIFF
--- a/test/check-machines-networks
+++ b/test/check-machines-networks
@@ -624,6 +624,12 @@ class TestMachinesNetworks(VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-network-1-type", "network")
         b.wait_in_text("#vm-subVmTest1-network-1-source", "test_network")
 
+        # Remove test_network from the VM again
+        b.click("#delete-vm-subVmTest1-iface-1")
+        b.wait_in_text(".pf-c-modal-box__title-text", "Delete Network Interface")
+        b.click(".pf-c-modal-box button.pf-m-danger")
+        b.wait_not_present("#vm-subVmTest1-network-1-type")
+
         # Remove all Virtual Networks and confirm that trying to choose
         # Virtual Networks type for a NIC disables the save button
         m.execute("virsh net-dumpxml default > /tmp/net-default.xml")
@@ -640,11 +646,9 @@ class TestMachinesNetworks(VirtualMachinesCase):
 
         self.goToVmPage("subVmTest1")
 
-        # Remove the network interface
-        m.execute("virsh detach-interface --persistent --type network --domain subVmTest1")
-
         # Start the VM in order that the UI picks up the new interface, since we don't get events of shut off domains
         m.execute("virsh start subVmTest1")
+        b.wait_in_text("#vm-subVmTest1-state", "Running")
 
         # Create a second bridge to LAN NIC
         m.execute("ip link add name br1 type bridge && virsh attach-interface --current subVmTest1 bridge br1")


### PR DESCRIPTION
This was getting seriously confused because the test removed the
test_network before detaching it from the domain. That seems to be a
corner case in libvirt, and different versions have subtly different
behaviour wrt. sending events. In that case, the original test_network
was removed from the UI very late, at the time when the test already
tried to add a new one, and thus the UI raced on the network's "Edit"
button.

Fix that by detaching the network from the VM before deleting the entire
network. As this happens on a shut-off VM, we don't get an event/UI
update for this when it's done on the CLI. So do that on the UI instead,
and ensure that it updates correctly.