### PR TITLE
test: Retry most of -disks, -networks, and -nics tests when changed

### DIFF
--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -43,7 +43,6 @@ def release_target(used_targets, target):
 
 
 @nondestructive
-@no_retry_when_changed
 class TestMachinesDisks(VirtualMachinesCase):
 
     def wait_for_disk_stats(self, name, target):
@@ -454,6 +453,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         if m.image in ["debian-testing"]:
             self.allow_journal_messages('.* type=1400 .* apparmor="DENIED" operation="open" profile="libvirt.* name="%s.*' % self.vm_tmpdir)
 
+    @no_retry_when_changed
     def testAddDiskNFS(self):
         b = self.browser
         m = self.machine
@@ -564,6 +564,7 @@ class TestMachinesDisks(VirtualMachinesCase):
             self.allow_journal_messages('.* type=1400 .* apparmor="DENIED" operation="open" profile="libvirt.* name="%s.*' % self.vm_tmpdir)
 
     @timeout(900)
+    @no_retry_when_changed
     def testAddDiskDirPool(self):
         b = self.browser
         m = self.machine
@@ -748,6 +749,7 @@ class TestMachinesDisks(VirtualMachinesCase):
             mode='custom-path'
         ).execute()
 
+    @no_retry_when_changed
     def testAddDiskAdditionalOptions(self):
         b = self.browser
         m = self.machine

--- a/test/check-machines-networks
+++ b/test/check-machines-networks
@@ -26,7 +26,7 @@ sys.path.append(os.path.join(TEST_DIR, "common"))
 sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
 
 from machineslib import VirtualMachinesCase  # noqa
-from testlib import no_retry_when_changed, nondestructive, test_main, wait  # noqa
+from testlib import nondestructive, test_main, wait  # noqa
 from machinesxmls import TEST_NETWORK2_XML, TEST_NETWORK3_XML, TEST_NETWORK4_XML, TEST_NETWORK_XML  # noqa
 
 
@@ -44,7 +44,6 @@ def getNetworkDevice(m):
 
 
 @nondestructive
-@no_retry_when_changed
 class TestMachinesNetworks(VirtualMachinesCase):
 
     def testNetworks(self):

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -31,9 +31,9 @@ from machinesxmls import TEST_NETWORK_XML  # noqa
 
 
 @nondestructive
-@no_retry_when_changed
 class TestMachinesNICs(VirtualMachinesCase):
 
+    @no_retry_when_changed
     def testVmNICs(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
These are now stable enough, aside from
TestMachinesDisks.testAddDiskPool and TestMachinesNICs.testVmNICs.