### PR TITLE
test: Skip libvirtd.service restarting test on Debian stable

### DIFF
--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -170,7 +170,8 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         self.waitVmRow("subVmTest1")
         self.waitVmRow("subVmTest2")
 
-        if superuser:
+        # Debian 10's libvirtd goes insane when restarting it with running VMs
+        if superuser and m.image not in ["debian-stable"]:
             # restart libvirtd
             m.execute("systemctl stop libvirtd.service")
             b.wait_in_text(".pf-c-empty-state", "Virtualization service (libvirt) is not active")

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -27,12 +27,11 @@ sys.path.append(os.path.join(TEST_DIR, "common"))
 sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
 
 from machineslib import VirtualMachinesCase  # noqa
-from testlib import no_retry_when_changed, nondestructive, skipImage, test_main, wait  # noqa
+from testlib import nondestructive, skipImage, test_main, wait  # noqa
 
 
 @skipImage("Atomic cannot run virtual machines", "fedora-coreos")
 @nondestructive
-@no_retry_when_changed
 class TestMachinesLifecycle(VirtualMachinesCase):
 
     def setUp(self):


### PR DESCRIPTION
That old libvirtd version goes quite crazy when trying to restart it
with a running VM -- it starts to send a huge amount of D-Bus messages,
causing OOM errors on itself and cockpit-bridge.

It's not that important to check this behaviour on every old OS, but
it's good to make sure it stays fixed from now on. So keep that check,
but skip it on Debian stable (10). This should be reverted once Debian
11 becomes stable.

----

This addresses our number 1 (by a very wide margin) broken test right now (the only one besides #18 on the dashboard).