### PR TITLE
workflows: ensure there is a dist build available to consume when creating a tag for the release

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
   push:
     branches: [main]
+    tags:
+      # this is a glob, not a regexp
+      - '[0-9]*'
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,5 +28,7 @@ jobs:
         run: |
           # override GitHub's bind mount from host, we don't want anything from there and it interferes with ssh
           export HOME=$(getent passwd $(id -u) | cut -f6 -d:)
+          # Wait for build-dist and publish-dist workflows to complete
+          export DOWNLOAD_DIST_OPTIONS=--wait
           cd /build
           release-runner -r https://github.com/$GITHUB_REPOSITORY -t $(basename $GITHUB_REF) ./cockpituous-release

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ dist-gzip: $(TARFILE)
 # node_modules/ can be reconstructed if necessary)
 $(TARFILE): export NODE_ENV=production
 $(TARFILE): $(LIB_TEST) $(RPM_NAME).spec
-	if ! test/download-dist; then \
+	if ! test/download-dist ${DOWNLOAD_DIST_OPTIONS:-}; then \
 	    $(MAKE) $(WEBPACK_TEST); \
 	    mv node_modules node_modules.release; \
 	    touch -r package.json $(NODE_MODULES_TEST); \


### PR DESCRIPTION
I have not tested it - I will do it tomorrow. 