### PR TITLE
workflow: break download-dist when done for the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,5 +28,7 @@ jobs:
         run: |
           # override GitHub's bind mount from host, we don't want anything from there and it interferes with ssh
           export HOME=$(getent passwd $(id -u) | cut -f6 -d:)
+          # This will make download-dist to fail in order to create dist manually instead
+          export GITHUB_BASE=fake/nonexisting
           cd /build
           release-runner -r https://github.com/$GITHUB_REPOSITORY -t $(basename $GITHUB_REF) ./cockpituous-release

--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,7 @@ dist-gzip: $(TARFILE)
 # node_modules/ can be reconstructed if necessary)
 $(TARFILE): export NODE_ENV=production
 $(TARFILE): $(LIB_TEST) $(RPM_NAME).spec
-	test/download-dist || true
-	if ! test -f $(TARFILE); then \
+	if ! test/download-dist; then \
 	    $(MAKE) $(WEBPACK_TEST); \
 	    mv node_modules node_modules.release; \
 	    touch -r package.json $(NODE_MODULES_TEST); \


### PR DESCRIPTION
We actually want to use pre-built dist tarballs for releases but it needs more thought.

This also reverts previous hacks.