### PR TITLE
Always just unpack dist/ and package-lock.json from downloaded dist tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           # override GitHub's bind mount from host, we don't want anything from there and it interferes with ssh
           export HOME=$(getent passwd $(id -u) | cut -f6 -d:)
-          # This will make download-dist to fail in order to create dist manually instead
-          export GITHUB_BASE=fake/nonexisting
           cd /build
+          # Wait for build-dist and publish-dist workflows to complete
+          export DOWNLOAD_DIST_OPTIONS=--wait
           release-runner -r https://github.com/$GITHUB_REPOSITORY -t $(basename $GITHUB_REF) ./cockpituous-release

--- a/packit.yaml
+++ b/packit.yaml
@@ -6,7 +6,7 @@ downstream_package_name: cockpit-machines
 actions:
   post-upstream-clone: make cockpit-machines.spec
   create-archive:
-    - test/download-dist --wait
+    - make dist-gzip DOWNLOAD_DIST_OPTIONS=--wait
     - find -name 'cockpit-machines-*.tar.gz'
 jobs:
   - job: tests

--- a/test/download-dist
+++ b/test/download-dist
@@ -47,7 +47,7 @@ def download_dist(wait=False):
         message("download-dist: not a git repository")
         return None
 
-    if subprocess.call(["git", "diff", "--quiet", "--", ":^test", "^packit.yaml", "^packaging"]) > 0:
+    if subprocess.call(["git", "diff", "--quiet", "--", ":^test", ":^packit.yaml", ":^packaging"]) > 0:
         message("download-dist: uncommitted local changes, skipping download")
         return None
 

--- a/test/download-dist
+++ b/test/download-dist
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-import glob
 import io
 import os
 import urllib.request
@@ -32,29 +31,32 @@ def message(*args):
 
 
 def download_dist(wait=False):
-    '''Download dists tarball for current git SHA from GitHub
+    '''Download and unpack dist/ for current git SHA from GitHub
 
     These are produced by .github/workflows/build-dist.yml for every PR and push.
     This is a lot faster than having to npm install and run webpack.
 
-    Returns path to downloaded tarball, or None if it isn't available.
-    This can happen because the current directory is not a git checkout, or it is
-    a SHA which is not pushed/PRed.
+    Returns True when successful, or False if the download isn't available.
+    This can happen because dist/ already exists, or the current directory is not a git checkout,
+    or it is a SHA which is not pushed/PRed.
     '''
+    if os.path.exists("dist"):
+        message("download-dist: dist/ already exists")
+        return False
+
+    if os.getenv("NODE_ENV") == "development":
+        message("download-dist: pre-built dist/ are for NODE_ENV=production")
+        return False
+
     try:
         sha = subprocess.check_output(["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL).decode().strip()
     except subprocess.CalledProcessError:
         message("download-dist: not a git repository")
-        return None
+        return False
 
     if subprocess.call(["git", "diff", "--quiet", "--", ":^test", ":^packit.yaml", ":^packaging"]) > 0:
         message("download-dist: uncommitted local changes, skipping download")
-        return None
-
-    dists = glob.glob(f"cockpit-machines-*{sha[:8]}*.tar.gz")
-    if dists:
-        message("download-dist: already downloaded", dists[0])
-        return os.path.abspath(dists[0])
+        return False
 
     download_url = f"https://github.com/{ os.getenv('GITHUB_BASE', 'cockpit-project/cockpit-machines') }-dist/raw/main/{sha}.tar"
     request = urllib.request.Request(download_url)
@@ -91,7 +93,7 @@ def download_dist(wait=False):
 
             if retries == 0:
                 message(f"download-dist: Downloading {download_url} failed:", e)
-                return None
+                return False
 
             message(f"download-dist: {download_url} not yet available, waiting...")
             time.sleep(30)
@@ -105,38 +107,23 @@ def download_dist(wait=False):
             pass
         if len(names) != 1 or not names[0].endswith(".tar.gz"):
             message("download-dist: expected tar with exactly one tar.gz member")
-            return None
+            return False
         ftar.extract(names[0])
         tar_path = os.path.realpath(names[0])
 
-    # Rename tar to what Makefile expects for a release
-    try:
-        tag = subprocess.check_output(['git', 'describe', '--exact-match'],
-                                      stderr=subprocess.DEVNULL, universal_newlines=True).strip()
-        new_path = os.path.join(os.path.dirname(tar_path), f"cockpit-machines-{tag}.tar.gz")
-        message(f"download-dist: renamed tarball to {new_path} for tag {tag}")
-        os.rename(tar_path, new_path)
-        tar_path = new_path
-    except subprocess.CalledProcessError:
-        pass
+    # Extract relevant files
+    unpack_paths = ["dist", "package-lock.json"]
+    message("download-dist: Extracting paths from tarball:", ' '.join(unpack_paths))
+    prefixed_unpack_paths = ["cockpit-machines/" + d for d in unpack_paths]
+    subprocess.check_call(["tar", "--touch", "--strip-components=1", "-xf", tar_path] + prefixed_unpack_paths)
 
-    # Extract some files locally for speeding up the build and allowing integration tests to run
-    unpack_paths = [d for d in ["dist", "package-lock.json"] if not os.path.exists(d)]
-    if unpack_paths:
-        message("download-dist: Extracting paths from tarball:", ' '.join(unpack_paths))
-        prefixed_unpack_paths = ["cockpit-machines/" + d for d in unpack_paths]
-        subprocess.check_call(["tar", "--touch", "--strip-components=1", "-xf", tar_path] + prefixed_unpack_paths)
-        # ensure that tarball appears new, to avoid make rebuilding it
-        subprocess.check_call(["touch", tar_path])
-
-    return tar_path
+    os.remove(tar_path)
+    return True
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Download release tarball")
+    parser = argparse.ArgumentParser(description="Download pre-built dist/ for current commit")
     parser.add_argument('-w', '--wait', action='store_true', help="Wait for up to 20 minutes for download tarball")
     args = parser.parse_args()
-    dist = download_dist(args.wait)
-    if not dist:
+    if not download_dist(args.wait):
         sys.exit(1)
-    print(dist)


### PR DESCRIPTION
Downloading and directly using the actual dist tarballs used to be
problematic for releases: After pushing a tag, the downloaded tarball
still had the wrong name such as cockpit-machines-241.1.g1234abc.tar.gz,
and inside it the pre-built .spec file's `Version:` was the same.
This led to various crappy workarounds like commit 9b4a1773dd and
e69a0a857804, and not using the pre-built tarballs at all for releases.

The expensive (for building) and precious (for re-using a webpack that
was previously validated) part is the dist/ directory, *not* the tar
file itself -- once dist/ exists, the remaining version-dependent files
(only the .spec for now) and the .tar can be built in a split second.

So change download-dist to always just unpack dist/ and
package-lock.json and not keep the actual tar file. Also refuse to do
anything if dist/ already exists or NODE_ENV==development, like in
cockpit [1].

Call download-dist from the Makefile's main "build webpack" rule.
Structurally this makes a lot more sense, as now `npm run build` and
`download-dist` do the same -- they produce dist/. This greatly
simplifies the `dist-gzip` rule, as this once again always does the same
thing: Ensure the .spec file is up to date and build a tar from the
sources and dist/.

Change Makefile's NODE_MODULES_TEST to actually test something in
node_modules/, to ensure that `npm install` will actually run when
necessary -- package-lock.json is not good enough, as that gets
extracted from the downloaded tarballs also.

Bring back commit d9b3b601679 to wait for the downloads to exist for
packit and releases.

[1] https://github.com/cockpit-project/cockpit/commit/5434aeebee5e0fe
