### PR TITLE
workflows: Use cockpituous instead of github token for npm/po updates

### DIFF
--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -16,10 +16,13 @@ jobs:
       - name: Set up configuration and secrets
         run: |
           printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
-          echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
+          echo '${{ secrets.COCKPITUOUS_TOKEN }}' > ~/.config/github-token
 
       - name: Clone repository
         uses: actions/checkout@v2
+        with:
+          # the default GITHUB_TOKEN would override our ~/.git-credentials from above
+          token: '${{ secrets.COCKPITUOUS_TOKEN }}'
 
       - name: Run npm-update bot
         run: |

--- a/.github/workflows/po-refresh.yml
+++ b/.github/workflows/po-refresh.yml
@@ -18,13 +18,16 @@ jobs:
       - name: Set up configuration and secrets
         run: |
           printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
-          echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
+          echo '${{ secrets.COCKPITUOUS_TOKEN }}' > ~/.config/github-token
           # po-refresh pushes to weblate repo via https://github.com, that needs our cockpituous token
           git config --global credential.helper store
           echo 'https://token:${{ secrets.COCKPITUOUS_TOKEN }}@github.com' >> ~/.git-credentials
 
       - name: Clone repository
         uses: actions/checkout@v2
+        with:
+          # the default GITHUB_TOKEN would override our ~/.git-credentials from above
+          token: '${{ secrets.COCKPITUOUS_TOKEN }}'
 
       - name: Run po-refresh bot
         run: |


### PR DESCRIPTION
The default `GITHUB_TOKEN` does not have the privileges to trigger
further workflows, in particular running unit tests. This is deliberate
behaviour [1].

So follow the recommendation and use our Cockpituous token instead, like
we did in cockpit [2][3]

[1] https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
[2] https://github.com/cockpit-project/cockpit/commit/4950ac6ed3
[2] https://github.com/cockpit-project/cockpit/commit/d65d4c3789