### PR TITLE
Rework pre-built dist upload/download

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -15,7 +15,7 @@ jobs:
           # need this to also fetch tags
           fetch-depth: 0
           # avoid checking out the default pull/NNN/head ref, as that gives
-          # mismatching SHAs in generated tarballs
+          # mismatching SHAs in generated artifacts
           ref: "${{ github.event.pull_request.head.sha || github.sha }}"
 
       - name: Set up dependencies
@@ -23,14 +23,19 @@ jobs:
           sudo apt update
           sudo apt install -y --no-install-recommends npm make gettext sassc
 
-      - name: Build dist tarball
-        run: make dist-gzip
+      - name: Build
+        run: |
+          NODE_ENV=production make
+           # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
+           # for pull_requests, use HEAD of the proposed branch, for pushes to origin the current SHA
+          echo "${{ github.event.pull_request.head.sha || github.sha }}" > SHA
 
-      - name: Create dist tarball artifact
+      - name: Create dist artifact
         uses: actions/upload-artifact@v2
         with:
-          # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
-          # for pull_requests, use HEAD of the proposed branch, for pushes to origin the current SHA
-          name: "dist-${{ github.event.pull_request.head.sha || github.sha }}"
-          path: cockpit-machines-*.tar.gz
+          name: dist
+          path: |
+            SHA
+            dist/
+            package-lock.json
           retention-days: 1

--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -33,4 +33,4 @@ jobs:
           # for pull_requests, use HEAD of the proposed branch, for pushes to origin the current SHA
           name: "dist-${{ github.event.pull_request.head.sha || github.sha }}"
           path: cockpit-machines-*.tar.gz
-          retention-days: 7
+          retention-days: 1

--- a/.github/workflows/prune-dist.yml
+++ b/.github/workflows/prune-dist.yml
@@ -26,8 +26,11 @@ jobs:
         run: |
           set -ex
           cd dist-repo
+          # keep one week of builds
           # oldest commit that applies to any still present tarball
-          REF=$(git log --pretty=format:%H * | tail -n1)
+          REF=$(git log --before '7 days ago' --pretty=format:%H -1)
+          # empty if there are no old commits
+          [ -n "$REF" ] || exit 0
 
           git checkout --orphan temp $REF
           git commit -m "Truncated history"
@@ -35,5 +38,4 @@ jobs:
           git branch -D temp
           git reflog expire --expire=now --all
 
-      - name: Force-push -dist repo
-        run: git -C dist-repo push -f
+          git push -f

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -12,6 +12,7 @@ jobs:
       - name: Download build-dist artifacts
         uses: dawidd6/action-download-artifact@v2
         with:
+          name: dist
           workflow: build-dist
           run_id: ${{ github.event.workflow_run.id }}
 
@@ -23,40 +24,37 @@ jobs:
           git config --global credential.helper store
           echo 'https://token:${{ secrets.COCKPITUOUS_TOKEN }}@github.com' >> ~/.git-credentials
 
-      - name: Commit dist tarball dist repo
+      - name: Commit to dist repo
         run: |
           set -ex
-
-          # we need a fully predictable name/URL, and git introduces these
-          # additional numbers into the version; so wrap it in a predictable named tar
-          sha=$(ls -d dist-* | sed 's/dist-//')
+          SHA=$(cat SHA)
 
           # multiple parallel workflows race against each other, so the final
           # `git push` may fail
           rc=1
           for retry in $(seq 5); do
               git clone https://github.com/${{ github.repository }}-dist.git dist-repo
-              tar -cvf "dist-repo/${sha}.tar" -C "dist-$sha" .
+              rm -rf dist-repo/dist
+              cp -r dist/ package-lock.json dist-repo/
 
               # freshly created empty repo?
               cd dist-repo
               git rev-parse HEAD >/dev/null 2>&1 || git init -b main
-              git add "${sha}.tar"
-              git commit -m "Build for $sha"
 
-              # remove tarballs older than a week
-              now=$(date +%s)
-              for f in *.tar; do
-                  fmtime=$(git log --pretty=%at -n1 -- $f)
-                  [ $(($now - $fmtime)) -lt 604800 ] || git rm $f
-              done
-              [ -z "$(git status --short)" ] || git commit -m 'Drop old builds'
+              # commit the updated files
+              git add .
+              # may have no changes
+              git diff --cached --quiet || git commit -m "Build for $SHA"
+              tag="sha-$SHA"
+              git tag $tag
 
-              if git push; then
+              # push commit and tag
+              if git push origin HEAD $tag; then
                   rc=0
                   break
               else
                   echo "ERROR: conflict? Retrying git commit"
+                  git push origin :$tag || true
                   cd ..
                   rm -rf dist-repo
               fi

--- a/test/download-dist
+++ b/test/download-dist
@@ -54,7 +54,7 @@ def download_dist(wait=False):
         message("download-dist: not a git repository")
         return False
 
-    if subprocess.call(["git", "diff", "--quiet", "--", ":^test", ":^packit.yaml", ":^packaging"]) > 0:
+    if subprocess.call(["git", "diff", "--quiet", "--", ":^test", ":^packit.yaml", ":^packaging", ":^.github"]) > 0:
         message("download-dist: uncommitted local changes, skipping download")
         return False
 

--- a/test/download-dist
+++ b/test/download-dist
@@ -16,14 +16,14 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-import io
+import argparse
 import os
-import urllib.request
 import subprocess
 import sys
-import tarfile
 import time
-import argparse
+
+REPO = os.getenv("GITHUB_BASE", "cockpit-project/cockpit-machines") + "-dist"
+PROJECT = REPO.split('/')[1]
 
 
 def message(*args):
@@ -31,7 +31,7 @@ def message(*args):
 
 
 def download_dist(wait=False):
-    '''Download and unpack dist/ for current git SHA from GitHub
+    '''Download pre-built dist/ for current git SHA from GitHub
 
     These are produced by .github/workflows/build-dist.yml for every PR and push.
     This is a lot faster than having to npm install and run webpack.
@@ -58,66 +58,36 @@ def download_dist(wait=False):
         message("download-dist: uncommitted local changes, skipping download")
         return False
 
-    download_url = f"https://github.com/{ os.getenv('GITHUB_BASE', 'cockpit-project/cockpit-machines') }-dist/raw/main/{sha}.tar"
-    request = urllib.request.Request(download_url)
-    tario = io.BytesIO()
+    dist_git_checkout = os.path.join(os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache")), "cockpit-dev", REPO)
+
+    if not os.path.exists(dist_git_checkout):
+        message(f"download-dist: Creating dist cache {dist_git_checkout}")
+        # we can't directly clone a tag with clone -b, so always fetch main initially
+        # this is usually very close to what we are interested in anyway
+        subprocess.check_call(["git", "clone", "--quiet", "--depth=1", "--bare", "https://github.com/" + REPO, dist_git_checkout])
+
     retries = 50 if wait else 1  # 25 minutes, once every 30s
     while retries > 0:
         try:
-            with urllib.request.urlopen(request) as response:
-                sys.stderr.write(f"download-dist: Downloading dist tarball from {download_url} ...\n")
-                if os.isatty(sys.stderr.fileno()):
-                    total_size = 0
-                else:
-                    total_size = None
-                MB = 10**6
-                # read tar into a stringio, as the stream is not seekable and tar requires that
-                while True:
-                    block = response.read(MB)
-                    if len(block) == 0:
-                        break
-                    if total_size is not None:
-                        total_size += len(block)
-                        sys.stderr.write(f"\r{ total_size // MB } MB")
-
-                    tario.write(block)
-
-                # clear the download progress in tty mode
-                if total_size is not None:
-                    sys.stderr.write("\r                             \r")
-
-                break
-
-        except urllib.error.HTTPError as e:
+            subprocess.check_call(["git", "-C", dist_git_checkout, "fetch", "origin", "sha-" + sha, "--depth=1"])
+            break
+        except subprocess.CalledProcessError:
             retries -= 1
 
             if retries == 0:
-                message(f"download-dist: Downloading {download_url} failed:", e)
+                message(f"download-dist: Downloading pre-built dist for SHA {sha} failed")
                 return False
 
-            message(f"download-dist: {download_url} not yet available, waiting...")
+            message(f"download-dist: pre-built dist for {sha} not yet available, waiting...")
             time.sleep(30)
 
-    tario.seek(0)
-    with tarfile.open(fileobj=tario) as ftar:
-        names = ftar.getnames()
-        try:
-            names.remove('.')
-        except ValueError:
-            pass
-        if len(names) != 1 or not names[0].endswith(".tar.gz"):
-            message("download-dist: expected tar with exactly one tar.gz member")
-            return False
-        ftar.extract(names[0])
-        tar_path = os.path.realpath(names[0])
+    message("download-dist: Extracting dist cache...")
+    p_git = subprocess.Popen(["git", "-C", dist_git_checkout, "archive", "FETCH_HEAD", "dist", "package-lock.json"],
+                             stdout=subprocess.PIPE)
+    # need this to have current time, not commit time, to satisfy make dependencies
+    subprocess.check_call(["tar", "--touch", "-x"], stdin=p_git.stdout)
+    assert p_git.wait() == 0
 
-    # Extract relevant files
-    unpack_paths = ["dist", "package-lock.json"]
-    message("download-dist: Extracting paths from tarball:", ' '.join(unpack_paths))
-    prefixed_unpack_paths = ["cockpit-machines/" + d for d in unpack_paths]
-    subprocess.check_call(["tar", "--touch", "--strip-components=1", "-xf", tar_path] + prefixed_unpack_paths)
-
-    os.remove(tar_path)
     return True
 
 


### PR DESCRIPTION
With test/download-dist now only ever using the pre-built dist/ and
package-lock.json instead of the full tarballs, there is no reason any
more to build and store the actual tarballs.

Simplify build-dist to have a constant artifact name "dist" (which
simplifies downloading/unpacking), and instead store the SHA as a plain
file inside the artifact. Do away with the intermediate tarball
(as there are not so many files in dist/ to make upload-artifact
inefficient).

In publish-dist, directly commit dist/ and package-lock.json to the
-dist repo, and tag the commit with the SHA, so that they are still easy
to look up. Drop the "old tarball" removal. This uses git in a much more
efficient way, as it now only stores the deltas. In particular, for
commits/PRs which don't change src/, that will just add an additional
tag to the previous build and store no extra files at all.

Rework download-dist to get the dist repo in ~/.cache/cockpit-dev/, so
that it persists across project checkouts, and shallow-fetch the desired
SHA build.

Change prune-dist to keep the commits of the last 7 days, and truncate
older ones.

-----

 - [ ] Re-initialize -dist repository before landing this

I tested all of this on my [fork](https://github.com/martinpitt/cockpit-machines/actions), first with a non-existing ~/.cache/cockpit-dev:
```
❱❱❱ git clean -ffdx; time GITHUB_BASE=martinpitt/cockpit-machines test/download-dist 
Removing dist/
Removing package-lock.json
download-dist: Creating dist cache /home/martin/.cache/cockpit-dev/martinpitt/cockpit-machines-dist
remote: Enumerating objects: 1, done.
remote: Counting objects: 100% (1/1), done.
remote: Total 1 (delta 0), reused 1 (delta 0), pack-reused 0
Unpacking objects: 100% (1/1), 195 bytes | 195.00 KiB/s, done.
From https://github.com/martinpitt/cockpit-machines-dist
 * tag               sha-1287884f90826914784bc24c9513c827c2b5b727 -> FETCH_HEAD
download-dist: Extracting dist cache...

real	0m2.776s
```

and after that, with a hot cache:
```
❱❱❱ git clean -ffdx; time GITHUB_BASE=martinpitt/cockpit-machines test/download-dist 
Removing dist/
Removing package-lock.json
remote: Enumerating objects: 1, done.
remote: Counting objects: 100% (1/1), done.
remote: Total 1 (delta 0), reused 1 (delta 0), pack-reused 0
Unpacking objects: 100% (1/1), 195 bytes | 195.00 KiB/s, done.
From https://github.com/martinpitt/cockpit-machines-dist
 * tag               sha-1287884f90826914784bc24c9513c827c2b5b727 -> FETCH_HEAD
download-dist: Extracting dist cache...

real	0m0.995s
```

You can see the commits and contents at https://github.com/martinpitt/cockpit-machines-dist/commits/main

I also tested history truncation with an additional [temporary commit that sets the time to "13 hours" instead of "7 days"](https://github.com/martinpitt/cockpit-machines/commit/1287884f908269147), and it [succeeded](https://github.com/martinpitt/cockpit-machines/actions/runs/731920857). I also did screenshots of the "before" state where it still had a few commits from yesterday, but foolishly deleted them before uploading. D'oh! But I promise that this worked fine.

I also [ran prune-dist again when there is nothing to prune](https://github.com/martinpitt/cockpit-machines/runs/2303141851?check_suite_focus=true), this worked fine as well.