### PR TITLE
Remove css imports which should be autoimported

### DIFF
--- a/src/components/vm/consoles/consoles.css
+++ b/src/components/vm/consoles/consoles.css
@@ -1,6 +1,4 @@
-@import '@patternfly/react-styles/css/components/Consoles/AccessConsoles.css';
 @import '@patternfly/react-styles/css/components/Consoles/SerialConsole.css';
-@import '@patternfly/react-styles/css/components/Consoles/DesktopViewer.css';
 
 /* Make the VNC canvas scale down to available width */
 .pf-c-console__vnc canvas {


### PR DESCRIPTION
The stylesheets for AccessConsole and DesktopViewer are autoimported
when importing the React components.

This also fixes the missing borders on the console type selector.