### PR TITLE
workflows: Add timeout to publish-dist

### DIFF
--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -8,6 +8,7 @@ jobs:
   run:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Download build-dist artifacts
         uses: dawidd6/action-download-artifact@v2


### PR DESCRIPTION
This ought to be very fast. If it's not, something is seriously wrong
and we want to know about it immediately, rather than stalling a PR for
6 hours.