### PR TITLE
test: discover also python files which don't contain hash-bang when running pylint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ WEBLATE_REPO=tmp/weblate-repo
 WEBLATE_REPO_URL=https://github.com/cockpit-project/cockpit-machines-weblate.git
 WEBLATE_REPO_BRANCH=main
 
-PYEXEFILES=$(shell git grep -lI '^#!.*python')
+PYTHONFILES=$(shell git grep -lI '^#!.*python') $(shell git ls-tree -r --name-only HEAD | grep '\.py')
 
 all: $(WEBPACK_TEST)
 
@@ -154,8 +154,8 @@ vm: $(VM_IMAGE)
 
 # run static code checks for python code
 codecheck:
-	python3 -m pyflakes $(PYEXEFILES)
-	python3 -m pycodestyle --max-line-length=195 $(PYEXEFILES) # TODO: Fix long lines
+	python3 -m pyflakes $(PYTHONFILES)
+	python3 -m pycodestyle --max-line-length=195 $(PYTHONFILES) # TODO: Fix long lines
 
 # run the browser integration tests; skip check for SELinux denials
 check: $(NODE_MODULES_TEST) $(VM_IMAGE) test/common

--- a/test/files/mock-range-server.py
+++ b/test/files/mock-range-server.py
@@ -76,7 +76,7 @@ class RangeHTTPRequestHandler(SimpleHTTPRequestHandler):
 
         start, end = self.range
         infile.seek(start)
-        bufsize = 64 * 1024 # 64KB
+        bufsize = 64 * 1024  # 64KB
         while True:
             buf = infile.read(bufsize)
             if not buf:

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -15,10 +15,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-from testlib import MachineCase, no_retry_when_changed, nondestructive, skipImage, test_main, wait
+from testlib import MachineCase
 from netlib import NetworkHelpers
 from storagelib import StorageHelpers
-from machinesxmls import *
+import machinesxmls
 
 
 class VirtualMachinesCaseHelpers:
@@ -117,16 +117,16 @@ class VirtualMachinesCaseHelpers:
         }
 
         if ptyconsole:
-            args["console"] = PTYCONSOLE_XML
+            args["console"] = machinesxmls.PTYCONSOLE_XML
         else:
             m.execute("chmod 777 /var/log/libvirt")
             args["logfile"] = "/var/log/libvirt/console-{0}.log".format(name)
-            args["console"] = CONSOLE_XML.format(log=args["logfile"])
+            args["console"] = machinesxmls.CONSOLE_XML.format(log=args["logfile"])
 
         if graphics == 'spice':
-            cxml = SPICE_XML
+            cxml = machinesxmls.SPICE_XML
         elif graphics == 'vnc':
-            cxml = VNC_XML
+            cxml = machinesxmls.VNC_XML
         elif graphics == 'none':
             cxml = ""
         else:
@@ -134,11 +134,11 @@ class VirtualMachinesCaseHelpers:
         args["graphics"] = cxml.format(**args)
 
         if not self.created_pool:
-            xml = POOL_XML.format(path="/var/lib/libvirt/images")
+            xml = machinesxmls.POOL_XML.format(path="/var/lib/libvirt/images")
             m.execute("echo \"{0}\" > /tmp/xml && virsh pool-define /tmp/xml && virsh pool-start images".format(xml))
             self.created_pool = True
 
-        xml = DOMAIN_XML.format(**args)
+        xml = machinesxmls.DOMAIN_XML.format(**args)
         m.execute("echo \"{0}\" > /tmp/xml && virsh define /tmp/xml{1}".format(xml,
                                                                                " && virsh start {}".format(name) if running else ""))
 

--- a/test/netlib.py
+++ b/test/netlib.py
@@ -17,12 +17,6 @@
 
 # This is a Trimmed version from NetworkHelpers from cockpit-project/cockpit/test/verify/netlib
 
-import re
-import subprocess
-
-from testlib import *
-
-
 class NetworkHelpers:
     '''Mix-in class for tests that require network setup'''
 

--- a/test/storagelib.py
+++ b/test/storagelib.py
@@ -17,12 +17,6 @@
 
 # This is a Trimmed version from StorageHelpers from cockpit-project/cockpit/test/verify/storagelib
 
-import re
-import os.path
-
-from testlib import *
-
-
 class StorageHelpers:
     '''Mix-in class for using in tests that derive from something else than MachineCase or StorageCase'''
     def add_ram_disk(self, size=50):


### PR DESCRIPTION
And fix all the errors that appear.