### PR TITLE
When the disk bus type is not in the predefined list show it disabled in the edit dialog

### DIFF
--- a/src/components/vm/disks/diskEdit.jsx
+++ b/src/components/vm/disks/diskEdit.jsx
@@ -79,7 +79,9 @@ const CacheRow = ({ onValueChanged, dialogValues, idPrefix, shutoff }) => {
 };
 
 const BusRow = ({ onValueChanged, dialogValues, idPrefix, shutoff }) => {
-    const busTypes = ['sata', 'scsi', 'usb', 'virtio'];
+    const busTypes = ['sata', 'scsi', 'usb', 'virtio'].map(type => ({ value: type }));
+    if (!busTypes.includes(dialogValues.busType))
+        busTypes.push({ value: dialogValues.busType, disabled: true });
 
     return (
         <FormGroup fieldId={`${idPrefix}-bus-type`} label={_("Bus")}
@@ -95,8 +97,9 @@ const BusRow = ({ onValueChanged, dialogValues, idPrefix, shutoff }) => {
                 isDisabled={!shutoff}>
                 {busTypes.map(busType => {
                     return (
-                        <FormSelectOption value={busType} key={busType}
-                                          label={busType} />
+                        <FormSelectOption value={busType.value} key={busType.value}
+                                          isDisabled={busType.disabled}
+                                          label={busType.value} />
                     );
                 })}
             </FormSelect>


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1948366

Note: the linked bz uses an IDE disk for the reproducer. IDE
controllers are not supported when used with Q35 machine type, which is the
default machine type in RHEL >= 8. Therefore we don't show IDE in the
predefined list.