### PR TITLE
workflows: Trigger integration tests from publish-dist

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -24,11 +24,17 @@ jobs:
           sudo apt install -y --no-install-recommends npm make gettext sassc
 
       - name: Build
+        run: NODE_ENV=production make
+
+      - name: Save event information
+        env:
+          GITHUB_EVENT: ${{ toJSON(github.event) }}
         run: |
-          NODE_ENV=production make
-           # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
-           # for pull_requests, use HEAD of the proposed branch, for pushes to origin the current SHA
+          # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
+          # for pull_requests, use HEAD of the proposed branch, for pushes to origin the current SHA
           echo "${{ github.event.pull_request.head.sha || github.sha }}" > SHA
+          # Save event for follow-up workflows
+          echo "$GITHUB_EVENT" > event.json
 
       - name: Create dist artifact
         uses: actions/upload-artifact@v2
@@ -38,4 +44,5 @@ jobs:
             SHA
             dist/
             package-lock.json
+            event.json
           retention-days: 1

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -62,3 +62,28 @@ jobs:
           done
           exit $rc
 
+      - name: Trigger integration tests for PRs
+        run: |
+          if ! grep -q '"pull_request"' event.json; then
+              echo "build-dist event was not a pull request"
+              exit 0
+          fi
+          # support running this from forks
+          if [ -z '${{ secrets.AMQP_CLIENT_KEY }}' ]; then
+              echo "No AMQP secrets, skipping tests-scan"
+              exit 0
+          fi
+
+          pip install pika
+
+          git clone --depth=1 https://github.com/cockpit-project/bots
+
+          # tests-scan does not currently have a --secrets-dir option
+          sudo mkdir -p /run/secrets/webhook
+          echo '${{ secrets.COCKPIT_CA_PEM }}' | sudo dd status=none of=/run/secrets/webhook/ca.pem
+          echo '${{ secrets.AMQP_CLIENT_PEM }}' | sudo dd status=none of=/run/secrets/webhook/amqp-client.pem
+          echo '${{ secrets.AMQP_CLIENT_KEY }}' | sudo dd status=none of=/run/secrets/webhook/amqp-client.key
+
+          # FIXME: make this nicer in tests-scan
+          AMQP_SERVER=$(PYTHONPATH=bots python3 -c 'from task.distributed_queue import *; print(DEFAULT_AMQP_SERVER)')
+          GITHUB_BASE=${{ github.repository }} bots/tests-scan -d --pull-data "$(cat event.json)" --amqp "$AMQP_SERVER"


### PR DESCRIPTION
With that, the tests can use the pre-built dist cache instead of each
test rebuilding it again. This lessens the strain on our CI and
npmjs.com.

Put the tests directly into our AMQP queue. This removes the
pull_request webhook, reacting to it, and calling tests-scan inside our
CI from the webhook queue. This decreases latency and the number of
moving parts.

-----

This is a bit of a trade-off. It's more efficient and reduces the number of moving parts in our infra a bit, but now we will not get the "pending" statuses immediately after pushing again, just after "build-dist" has finished. That may need some getting used to. Perhaps we try it out for a bit, and either we like it and transplant it to cockpit as well,or we just put it to the shelf and declare it a dead end. @marusak , @KKoukiou , opinions?

I tested this on my fork. I sent [this PR](https://github.com/martinpitt/cockpit-machines/pull/4), which triggered [this publish-dist workflow](https://github.com/martinpitt/cockpit-machines/runs/2330640890?check_suite_focus=true#step:5:126), which correctly triggered a debian-stable test in the PR after {build,publish}-dist finished.

For that I used a [temporary bots fork](https://github.com/martinpitt/cockpit-machines/commit/2f7c6f1a3c143) which adjusted the testmap for martinpitt/cockpit-machines.

Note: the actual test run failed to download the dist cache, as it was looking into cockpit-project/cockpit-machines instead of martinpitt/c-m. This is just an artifact of testing on my fork.