### PR TITLE
cockpituous: Release into Fedora

### DIFF
--- a/cockpituous-release
+++ b/cockpituous-release
@@ -17,12 +17,11 @@ job release-srpm -V
 # Authenticate for pushing into Fedora dist-git (works in Cockpituous release container)
 cat ~/.fedora-password | kinit cockpit@FEDORAPROJECT.ORG
 # Do fedora builds for the tag, using tarball
-# FIXME: none of the dist-git branches in Fedora exist yet
-# job release-koji rawhide
-# job release-koji f33
-# job release-koji f34
-# job release-bodhi F33
-# job release-bodhi F34
+job release-koji rawhide
+job release-koji f33
+job release-koji f34
+job release-bodhi F33
+job release-bodhi F34
 
 # These are likely the first of your release targets; but run them after Fedora uploads,
 # so that failures there will fail the release early, before publishing on GitHub


### PR DESCRIPTION
I've created release but it is not in Fedora. I'll do this round manually.