### PR TITLE
packit: Enable tests on Rawhide, investigate TestMachinesNICs.testNICAdd regression

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -15,3 +15,4 @@ jobs:
       targets:
       - fedora-33
       - fedora-34
+      - fedora-rawhide


### PR DESCRIPTION
Yesterday's releases of cockpit, -machines, and -podman had all successful gating tests, except for [c-machines Rawhide](https://bodhi.fedoraproject.org/updates/FEDORA-2021-259e47e58c). That's the only one that we don't test upstream, and it failed twice in [TestMachinesNICs.testNICAdd](https://osci-jenkins-1.ci.fedoraproject.org/job/fedora-ci/job/dist-git-pipeline/job/master/36822/testReport/(root)/tests/_test_browser/).

I don't know where to get artifacts from Fedora gating runs, so I can't say much about the cause yet. But let's enable and investigate these upstream. I'll investigate/reproduce locally as well, but let's get an initial result for comparison.

 - [x] Add naughty: https://github.com/cockpit-project/bots/pull/1928