### PR TITLE
Stop using branch for -dist cache

### DIFF
--- a/.github/workflows/prune-dist.yml
+++ b/.github/workflows/prune-dist.yml
@@ -10,10 +10,12 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
       - name: Set up configuration and secrets
         run: |
           printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
-          echo '${{ secrets.COCKPITUOUS_TOKEN }}' > ~/.config/github-token
           # we push to -dist repo via https://github.com, that needs our cockpituous token
           git config --global credential.helper store
           echo 'https://token:${{ secrets.COCKPITUOUS_TOKEN }}@github.com' >> ~/.git-credentials
@@ -22,20 +24,22 @@ jobs:
         run: |
           git clone https://github.com/${{ github.repository }}-dist.git dist-repo
 
-      - name: Truncate history of -dist repo
+      - name: Delete old tags
         run: |
           set -ex
+
+          HEAD=$(git rev-parse HEAD)
+
           cd dist-repo
-          # keep one week of builds
-          # oldest commit that applies to any still present tarball
-          REF=$(git log --before '7 days ago' --pretty=format:%H -1)
-          # empty if there are no old commits
-          [ -n "$REF" ] || exit 0
-
-          git checkout --orphan temp $REF
-          git commit -m "Truncated history"
-          git rebase --onto temp $REF main
-          git branch -D temp
-          git reflog expire --expire=now --all
-
-          git push -f
+          now="$(date +%s)"
+          for tag in $(git tag -l); do
+              tag_time="$(git show -s --format=%at $tag)"
+              if [ "$tag" = "sha-${HEAD}" ]; then
+                  echo "$tag refers to current project HEAD, keeping"
+              elif [ $((now - tag_time)) -ge 604800 ]; then
+                  echo "$tag is older than 7 days, deleting..."
+                  git push origin ":$tag"
+              else
+                  echo "$tag is younger than 7 days, keeping"
+              fi
+          done

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -28,39 +28,19 @@ jobs:
       - name: Commit to dist repo
         run: |
           set -ex
-          SHA=$(cat SHA)
+          SHA="$(cat SHA)"
 
-          # multiple parallel workflows race against each other, so the final
-          # `git push` may fail
-          rc=1
-          for retry in $(seq 5); do
-              git clone https://github.com/${{ github.repository }}-dist.git dist-repo
-              rm -rf dist-repo/dist
-              cp -r dist/ package-lock.json dist-repo/
+          mkdir dist-repo
+          cd dist-repo
+          git init
+          cp -r ../dist/ ../package-lock.json .
 
-              # freshly created empty repo?
-              cd dist-repo
-              git rev-parse HEAD >/dev/null 2>&1 || git init -b main
+          git add .
+          git commit -m "Build for $SHA"
+          tag="sha-$SHA"
+          git tag "$tag"
 
-              # commit the updated files
-              git add .
-              # may have no changes
-              git diff --cached --quiet || git commit -m "Build for $SHA"
-              tag="sha-$SHA"
-              git tag $tag
-
-              # push commit and tag
-              if git push origin HEAD $tag; then
-                  rc=0
-                  break
-              else
-                  echo "ERROR: conflict? Retrying git commit"
-                  git push origin :$tag || true
-                  cd ..
-                  rm -rf dist-repo
-              fi
-          done
-          exit $rc
+          git push https://github.com/${{ github.repository }}-dist.git $tag
 
       - name: Trigger integration tests for PRs
         run: |

--- a/test/download-dist
+++ b/test/download-dist
@@ -62,9 +62,9 @@ def download_dist(wait=False):
 
     if not os.path.exists(dist_git_checkout):
         message(f"download-dist: Creating dist cache {dist_git_checkout}")
-        # we can't directly clone a tag with clone -b, so always fetch main initially
-        # this is usually very close to what we are interested in anyway
-        subprocess.check_call(["git", "clone", "--quiet", "--depth=1", "--bare", "https://github.com/" + REPO, dist_git_checkout])
+        os.makedirs(dist_git_checkout)
+        subprocess.check_call(["git", "-C", dist_git_checkout, "init", "--bare", "--quiet"])
+        subprocess.check_call(["git", "-C", dist_git_checkout, "remote", "add", "origin", "https://github.com/" + REPO])
 
     retries = 50 if wait else 1  # 25 minutes, once every 30s
     while retries > 0:


### PR DESCRIPTION
Push every build as an individual tag only, without having them on a
branch.

For the cleanup, just delete all tags which are older than a week, so
that they become unreferenced and can be garbage collected; do that
right in publish-dist.yml, to have fewer moving parts and avoid
duplicating the secrets setup.

This fixes a lot of the previous problems:

 * We don't need any force-pushing and history rewriting any more, which
   fixes the race of publish-dist against prune-dist.

 * There is no more race condition on multiple publish-dist workflows
   pushing to main.

 * prune-dist.yml did not actually clean up anything on GitHub, as it
   did not remove the tags from origin.

Thanks to Allison Karlitskaya for this idea!

---

I tested this on my fork. The [publish-dist run](https://github.com/martinpitt/cockpit-machines/actions/runs/770574221) committed the dist, I can download it with `GITHUB_BASE=martinpitt/cockpit-machines test/download-dist`, it cleaned up the 20-something tags from 8 days ago, and kept the two recent ones. These commits are *not* visible in https://github.com/martinpitt/cockpit-machines-dist now. I didn't reset that repo as I wanted to have some old repo to play with.

But once this is approved, I'll reset the cockpit-machines-dist repo, so that it starts afresh without any branch at all.