### PR TITLE
test: Stop explicitly installing cockpit-ws

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ VM_DEP=$(TARFILE) packaging/debian/rules packaging/debian/control
 VM_PACKAGE=--upload `pwd`/$(TARFILE):/var/tmp/ --upload `pwd`/packaging/debian:/var/tmp/
 else
 VM_DEP=$(RPMFILE)
-VM_PACKAGE=--install cockpit-ws --install `pwd`/$(RPMFILE)
+VM_PACKAGE=--no-network --upload `pwd`/$(RPMFILE):/var/tmp/
 endif
 
 # build a VM with locally built rpm/dsc installed

--- a/test/vm.install
+++ b/test/vm.install
@@ -3,7 +3,7 @@
 # The application RPM will be installed separately
 set -eu
 
-# for Debian based images, build and install debs; for RPM based ones, the locally built rpm gets installed separately
+# for Debian based images, build and install debs
 if [ -d /var/tmp/debian ]; then
     apt-get update
     if grep -q 'VERSION_ID="20.10"' /etc/os-release; then
@@ -37,7 +37,12 @@ if [ -d /var/tmp/debian ]; then
         dpkg-buildpackage -us -uc -b
     fi
     dpkg -i ../*.deb
+
+# install rpms
+elif [ -e /var/tmp/*.rpm ]; then
+    rpm -i --verbose /var/tmp/*.rpm
 fi
+
 
 # for Debian images, allow libvirtd coredumps
 if grep -q 'ID=debian' /etc/os-release; then


### PR DESCRIPTION
It is already present on all our test images, and trying to
install/upgrade it again touches the network. That is often unreliable
and makes tests less reproducible.

For cockpit-machines.rpm itself, upload that and install it with rpm, so
that dnf does not try and update the package metadata.

Ensure that this works without internet access with image-customize's
`--no-network` option.

---

I've seen [this failure](https://logs.cockpit-project.org/logs/pull-119-20210421-135514-b8b23496-rhel-9-0/log.html) at least four times today, and it's annoying and unnecessary.