### PR TITLE
fmf: Fix tests on RHEL/CentOS

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -44,8 +44,6 @@ if [ "$ID" = "fedora" ]; then
            TestMachinesSettings.testVCPU
            TestMachinesSnapshots.testSnapshots
            "
-else
-    TESTS="$TestMachines"
 fi
 
 # pre-download cirros image for Machines tests
@@ -59,7 +57,7 @@ done
 # execute run-tests
 RC=0
 test/common/run-tests --nondestructive $exclude_options \
-    --machine localhost:22 --browser localhost:9090 $TESTS || RC=$?
+    --machine localhost:22 --browser localhost:9090 ${TESTS:-} || RC=$?
 
 echo $RC > "$LOGS/exitcode"
 cp --verbose Test* "$LOGS" || true


### PR DESCRIPTION
Fix typo, `$TestMachines` is not a variable (and not supposed to be
one). Just drop $TESTS on non-Fedora entirely, we want to run all tests
anyway.