### PR TITLE
Fix downstream gating tests on RHEL 9

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -16,7 +16,9 @@ chmod a+w "$LOGS"
 # HACK: chromium-headless ought to be enough, but version 88 has a crash: https://bugs.chromium.org/p/chromium/issues/detail?id=1170634
 if ! rpm -q chromium; then
     if grep -q 'ID=.*rhel' /etc/os-release; then
+        # There is no EPEL for RHEL 9 yet, force 8
         dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+        sed -i 's/$releasever/8/' /etc/yum.repos.d/epel*.repo
         dnf config-manager --enable epel
     fi
     dnf install -y chromium

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -10,6 +10,7 @@ require:
   - make
   - npm
   - python3
+  - python3-yaml
   # required by tests
   - firewalld
   - libvirt-daemon-config-network

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -23,8 +23,9 @@ export TEST_AUDIT_NO_SELINUX=1
 EXCLUDES=""
 
 # Fedora gating tests are running on infra without /dev/kvm; Machines tests are too darn slow there
-# so just pick a representative sample
-if [ "$ID" = "fedora" ]; then
+# too many tests also fail on RHEL 9 (also on testing farm); so just pick a representative sample on these
+# Only RHEL 8 gating env can run all tests
+if ! [ "$ID" = "rhel" -a "${VERSION_ID#8}" != "$VERSION_ID" ]; then
     # Testing Farm machines are really slow in European evenings
     export TEST_TIMEOUT_FACTOR=3
     TESTS="TestMachinesConsoles.testInlineConsole

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -22,10 +22,6 @@ export TEST_AUDIT_NO_SELINUX=1
 
 EXCLUDES=""
 
-# triggers SELinux violation
-# See journal: SELinux is preventing /usr/libexec/qemu-kvm from open access on the file /var/lib/cockpittest/nfs_pool/nfs-volume-0.
-EXCLUDES="$EXCLUDES TestMachinesDisks.testAddDiskNFS"
-
 # Fedora gating tests are running on infra without /dev/kvm; Machines tests are too darn slow there
 # so just pick a representative sample
 if [ "$ID" = "fedora" ]; then


### PR DESCRIPTION
There are a [lot of failures](http://artifacts.osci.redhat.com/testing-farm/a4f4f59e-8ec6-448b-94d0-b744047b4cec/work-upstreamF2UGhr/plans/upstream/execute/data/test/browser/output.txt) in current RHEL 9, most of them rather weird:
```
# testDetachDisk (__main__.TestMachinesDisks)
Traceback (most recent call last):
  File "/usr/lib64/python3.9/unittest/case.py", line 550, in _callTestMethod
    method()
  File "/ARTIFACTS/work-upstreamF2UGhr/plans/upstream/discover/default/tests/test/check-machines-disks", line 810, in testDetachDisk
    m.execute("virsh attach-disk --domain subVmTest1 --source {0}/mydiskofpoolone_2 --target vdd --targetbus virtio --persistent".format(p1))
  File "/ARTIFACTS/work-upstreamF2UGhr/plans/upstream/discover/default/tests/bots/machine/machine_core/ssh_connection.py", line 322, in execute
    ret = select.select(rset, wset, [], 10)
  File "/ARTIFACTS/work-upstreamF2UGhr/plans/upstream/discover/default/tests/bots/machine/machine_core/timeout.py", line 41, in handle_timeout
    raise RuntimeError(self.error_message)
RuntimeError: Timed out on 'virsh attach-disk --domain subVmTest1 --source /var/lib/cockpittest/vm_one/mydiskofpoolone_2 --target vdd --targetbus virtio --persistent'
[0422/092906.620137:WARNING:headless_browser_main_parts.cc(83)] Cannot create Pref Service with no user data dir.

DevTools listening on ws://127.0.0.1:9430/devtools/browser/ba9c75fc-dd2c-4720-a11b-9ed54c52208e
/ARTIFACTS/work-upstreamF2UGhr/plans/upstream/discover/default/tests/test/common/chromium-cdp-driver.js:242
        throw Error(`Frame ${frame} is unknown`);
```

I can actually reproduce this with

    bots/vm-run rhel-9-0
    tmt run --all provision --how connect -g c

but I can't make much sense of it. I did see that the memory gets really tight. I propose to go with this reduced test set for now, and slowly build this back up.

There is also a few additional commits which fix the test setup for the above "run this locally" scenario.