### PR TITLE
tests: set q35 machine type for our test VM

### DIFF
--- a/test/machinesxmls.py
+++ b/test/machinesxmls.py
@@ -116,7 +116,7 @@ DOMAIN_XML = """
   <name>{name}</name>
   <vcpu>1</vcpu>
   <os>
-    <type arch='x86_64'>hvm</type>
+    <type arch='x86_64' machine='q35'>hvm</type>
     <boot dev='hd'/>
     <boot dev='network'/>
   </os>
@@ -126,6 +126,17 @@ DOMAIN_XML = """
     <acpi/>
   </features>
   <devices>
+    <controller type='pci' model='pcie-root'/>
+    <controller type='pci' model='pcie-root-port'/>
+    <controller type='pci' model='pcie-root-port'/>
+    <controller type='pci' model='pcie-root-port'/>
+    <controller type='pci' model='pcie-root-port'/>
+    <controller type='pci' model='pcie-root-port'/>
+    <controller type='pci' model='pcie-root-port'/>
+    <controller type='pci' model='pcie-root-port'/>
+    <controller type='pci' model='pcie-root-port'/>
+    <controller type='pci' model='pcie-root-port'/>
+    <controller type='pci' model='pcie-to-pci-bridge'/>
     <disk type='file'>
       <driver name='qemu' type='qcow2'/>
       <source file='{image}'/>


### PR DESCRIPTION
This is the default machine type for cirros VMs in all distros we test
against. If we could create the VM with virt-install and supply the os
variant that machine type would have been chosen for us, but since we
define from the XML we need to pass it explicitely.

If not set, we end up with some archaic defaults when attaching nics and
disks, and seeing the future of our tests, these will make operations like migration fail.

For hotplugging multiple PCI devices (which we do in the tests) we need
to add explicitely extra pci controllers.
See https://libvirt.org/pci-hotplug.html


Split out from : https://github.com/cockpit-project/cockpit-machines/pull/15