### PR TITLE
Fix random test failures due to user libvirt crashes

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -543,27 +543,27 @@ class TestMachinesCreate(VirtualMachinesCase):
 
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='url',
                                                       location=config.VALID_URL,
-                                                      memory_size=512, memory_size_unit='MiB',
+                                                      memory_size=128, memory_size_unit='MiB',
                                                       storage_pool="NoStorage",
                                                       os_name=config.FEDORA_28))
 
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='url',
                                                       location=config.VALID_URL,
-                                                      memory_size=512, memory_size_unit='MiB',
+                                                      memory_size=128, memory_size_unit='MiB',
                                                       storage_pool="NoStorage",
                                                       os_name=config.FEDORA_28,
                                                       start_vm=False))
 
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='url',
                                                       location=config.VALID_URL,
-                                                      memory_size=256, memory_size_unit='MiB',
+                                                      memory_size=128, memory_size_unit='MiB',
                                                       storage_size=128, storage_size_unit='MiB',
                                                       start_vm=False))
 
         # Test detection of ISO file in URL
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='url',
                                                       location=config.ISO_URL,
-                                                      memory_size=256, memory_size_unit='MiB',
+                                                      memory_size=128, memory_size_unit='MiB',
                                                       storage_pool="NoStorage",
                                                       start_vm=True))
 

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -52,7 +52,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         # so make sure that there are no leftover user processes that bleed into the next test
         self.addCleanup(self.machine.execute, "pkill -u {0}; while pgrep -u {0}; do sleep 0.5; done".format(user_name))
         # HACK: ...but it still tends to crash during shutdown (without known stack trace)
-        self.allow_journal_messages('Process .*libvirtd* of user 10.* dumped core.*')
+        self.allow_journal_messages('Process .*libvirtd.* of user 10.* dumped core.*')
 
         return user_name
 

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -303,6 +303,9 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         # Make sure that unprivileged users can see the VM list when libvirtd is not running
         m.execute("systemctl stop libvirtd.service")
         m.execute("useradd nonadmin; echo nonadmin:foobar | chpasswd")
+        # user libvirtd instance tends to SIGABRT with "Failed to find user record for uid .." on shutdown during cleanup
+        # so make sure that there are no leftover user processes that bleed into the next test
+        self.addCleanup(self.machine.execute, "pkill -u nonadmin; while pgrep -u nonadmin; do sleep 0.5; done")
         self.login_and_go("/machines", user="nonadmin", superuser=False)
         b.wait_in_text("body", "Virtual machines")
         b.wait_in_text("#virtual-machines-listing .pf-c-empty-state", "No VM is running")

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -213,6 +213,10 @@ class VirtualMachinesCase(MachineCase, VirtualMachinesCaseHelpers, StorageHelper
         # we don't have configuration to open the firewall for local libvirt machines, so just stop firewalld
         m.execute("systemctl stop firewalld; systemctl try-restart libvirtd")
 
+        # user libvirtd instance tends to SIGABRT with "Failed to find user record for uid .." on shutdown during cleanup
+        # so make sure that there are no leftover user processes that bleed into the next test
+        self.addCleanup(self.machine.execute, '''pkill -u admin; while [ -n "$(pgrep -au admin | grep -v 'systemd --user')" ]; do sleep 0.5; done''')
+
         # FIXME: report downstream; AppArmor noisily denies some operations, but they are not required for us
         self.allow_journal_messages(r'.* type=1400 .* apparmor="DENIED" operation="capable" profile="\S*libvirtd.* capname="sys_rawio".*')
         # AppArmor doesn't like the non-standard path for our storage pools


### PR DESCRIPTION
This should fix test failures like [this](https://logs.cockpit-project.org/logs/pull-130-20210423-153144-8e4365d1-fedora-33-firefox/log.html#43) or [this](https://logs.cockpit-project.org/logs/pull-130-20210423-155555-8e4365d1-ubuntu-stable-bots-1952/log.html#45)