### PR TITLE
Add support for configuring/viewing shared directories between VMs and host

### DIFF
--- a/src/components/vm/filesystems/vmFilesystemsCard.jsx
+++ b/src/components/vm/filesystems/vmFilesystemsCard.jsx
@@ -1,0 +1,259 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import React, { useState } from 'react';
+import cockpit from 'cockpit';
+import {
+    Button,
+    Checkbox,
+    CodeBlock, CodeBlockCode,
+    ExpandableSection,
+    Form, FormGroup,
+    Grid,
+    List, ListItem,
+    Modal,
+    Popover,
+    Radio, TextInput, Tooltip
+} from "@patternfly/react-core";
+import { HelpIcon } from "@patternfly/react-icons";
+
+import { ListingTable } from "cockpit-components-table.jsx";
+import { ModalError } from 'cockpit-components-inline-notification.jsx';
+import { FileAutoComplete } from "cockpit-components-file-autocomplete.jsx";
+
+import { createFilesystem, setMemoryBacking } from "../../../libvirt-dbus.js";
+import { vmId } from "../../../helpers.js";
+
+import "./vmFilesystemsCard.scss";
+
+const _ = cockpit.gettext;
+
+export const VmFilesystemsCard = ({ vmName, filesystems }) => {
+    const columnTitles = [_("Source path"), _("Mount tag")];
+
+    const rows = filesystems.map(filesystem => {
+        const sourceKey = Object.keys(filesystem.source).find(key => filesystem.source[key]);
+        const filesystemSource = sourceKey ? filesystem.source[sourceKey] : undefined;
+        const filesystemTarget = filesystem.target.dir;
+        const rowId = `${vmId(vmName)}-filesystem-${filesystemSource}-${filesystemTarget}`;
+
+        const columns = [
+            { title: filesystemSource },
+            { title: filesystemTarget },
+        ];
+
+        return {
+            columns,
+            props: { key: rowId, 'data-row-id': rowId }
+        };
+    });
+
+    return (
+        <ListingTable variant='compact'
+                      gridBreakPoint='grid-xl'
+                      emptyCaption={_("No directories shared between the host and this VM")}
+                      columns={columnTitles}
+                      rows={rows} />
+    );
+};
+
+export const VmFilesystemActions = ({ connectionName, dispatch, memory, memoryBacking, objPath, vmName, vmState }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const idPrefix = `${vmId(vmName)}-filesystems`;
+    const addButton = (
+        <Button id={`${idPrefix}-add`}
+                isAriaDisabled={vmState != 'shut off'}
+                onClick={() => setIsOpen(true)}
+                variant="secondary">
+            {_("Add shared directory")}
+        </Button>
+    );
+
+    return (
+        <>
+            {vmState == 'shut off' ? addButton : <Tooltip content={_("Adding shared directories is possible only when the guest is shut off")}>{addButton}</Tooltip>}
+            {isOpen &&
+            <VmFilesystemAddModal connectionName={connectionName}
+                                  dispatch={dispatch}
+                                  memory={memory}
+                                  memoryBacking={memoryBacking}
+                                  objPath={objPath}
+                                  vmName={vmName}
+                                  vmState={vmState}
+                                  setIsOpen={setIsOpen} />}
+        </>
+    );
+};
+
+const VmFilesystemAddModal = ({ connectionName, dispatch, memory, memoryBacking, objPath, setIsOpen, vmName, vmState }) => {
+    const [additionalOptionsExpanded, setAdditionalOptionsExpanded] = useState(false);
+    const [dialogError, setDialogError] = useState();
+    const [memoryBackingType, setMemoryBackingType] = useState("file");
+    const [mountTag, setMountTag] = useState("");
+    const [source, setSource] = useState("");
+    const [validationFailed, setValidationFailed] = useState({});
+    const [xattr, setXattr] = useState(false);
+    const idPrefix = `${vmId(vmName)}-filesystems`;
+
+    const onAddClicked = () => {
+        const validationFailed = {};
+
+        if (!mountTag)
+            validationFailed.mountTag = _("Mount tag must not be empty");
+        if (!source)
+            validationFailed.source = _("Source must not be empty");
+
+        setValidationFailed(validationFailed);
+
+        if (Object.getOwnPropertyNames(validationFailed).length == 0) {
+            setMemoryBacking({
+                connectionName, objPath,
+                type: memoryBackingType,
+                memory
+            })
+                    .then(() => {
+                        createFilesystem({
+                            connectionName, objPath,
+                            source, target: mountTag,
+                            xattr,
+                        });
+                    })
+                    .then(
+                        () => setIsOpen(false),
+                        exc => setDialogError(exc.message)
+                    );
+        }
+    };
+    return (
+        <Modal position="top" isOpen variant="medium" onClose={() => setIsOpen(false)}
+               title={_("Share a shared host directory with the guest")}
+               footer={
+                   <>
+                       {dialogError && <ModalError dialogError={_("Failed to add shared directory")} dialogErrorDetail={dialogError} />}
+                       <Button id={`${idPrefix}-modal-add`}
+                               variant='primary'
+                               onClick={onAddClicked}>
+                           {_("Share")}
+                       </Button>
+                       <Button id={`${idPrefix}-modal-cancel`}
+                               variant='link'
+                               onClick={() => setIsOpen(false)}>
+                           {_("Cancel")}
+                       </Button>
+                   </>
+               }
+               description={
+                   <>
+                       {_("Shared host directories need to be manually mounted inside the VM")}
+                       <Popover
+                           headerContent={_("You can mount the shared folder using:")}
+                           bodyContent={
+                               <CodeBlock>
+                                   <CodeBlockCode>mount -t virtiofs {mountTag || 'hostshare'} [mount point]</CodeBlockCode>
+                               </CodeBlock>
+                           }
+                           footerContent={
+                               <List>
+                                   <ListItem>{_("mount point: The mount point inside the guest")}</ListItem>
+                               </List>
+                           }
+                           hasAutoWidth>
+                           <Button variant="plain" aria-label={_("more info")}>
+                               <HelpIcon />
+                           </Button>
+                       </Popover>
+                   </>
+               }>
+            <Form isHorizontal>
+                <FormGroup fieldId={`${idPrefix}-modal-source`}
+                           id={`${idPrefix}-modal-source-group`}
+                           label={_("Source path")}
+                           labelIcon={
+                               <Popover headerContent={_("The host path that is to be exported.")}>
+                                   <button aria-label={_("More info for source path field")}
+                                           className="pf-c-form__group-label-help"
+                                           onClick={e => e.preventDefault()}
+                                           type="button">
+                                       <HelpIcon noVerticalAlign />
+                                   </button>
+                               </Popover>
+                           }
+                           helperTextInvalid={validationFailed.source}
+                           validated={validationFailed.mountTag ? "error" : "default"}>
+                    <FileAutoComplete id={`${idPrefix}-modal-source`}
+                                      onChange={value => setSource(value)}
+                                      placeholder="/export/to/guest"
+                                      superuser="try"
+                                      value={source} />
+                </FormGroup>
+                <FormGroup fieldId={`${idPrefix}-modal-mountTag`}
+                           label={_("Mount tag")}
+                           labelIcon={
+                               <Popover headerContent={_("The tag name to be used by the guest to mount this export point.")}>
+                                   <button aria-label={_("More info for mount tag field")}
+                                           className="pf-c-form__group-label-help"
+                                           onClick={e => e.preventDefault()}
+                                           type="button">
+                                       <HelpIcon noVerticalAlign />
+                                   </button>
+                               </Popover>
+                           }
+                           helperTextInvalid={validationFailed.mountTag}
+                           validated={validationFailed.mountTag ? "error" : "default"}>
+                    <TextInput id={`${idPrefix}-modal-mountTag`}
+                               onChange={value => setMountTag(value)}
+                               placeholder="hostshare"
+                               value={mountTag}
+                               validated={validationFailed.mountTag ? "error" : "default"} />
+                </FormGroup>
+                <ExpandableSection toggleText={ additionalOptionsExpanded ? _("Hide additional options") : _("Show additional options")}
+                                   onToggle={() => setAdditionalOptionsExpanded(!additionalOptionsExpanded)}
+                                   isExpanded={additionalOptionsExpanded}>
+                    <Grid hasGutter>
+                        {!memoryBacking &&
+                        <FormGroup hasNoPaddingTop
+                                   helperText={_("Using virtiofs requires setting up shared memory")}
+                                   fieldId={`${idPrefix}-modal-file-backed`}
+                                   label={_("Memory backing")}>
+                            <Radio id={`${idPrefix}-modal-file-backed`}
+                                   isChecked={memoryBackingType == "file" }
+                                   label={_("File backed")}
+                                   name="memoryBackingType"
+                                   onChange={(_, event) => setMemoryBackingType(event.currentTarget.value)}
+                                   value="file" />
+                            <Radio id={`${idPrefix}-modal-hugepages`}
+                                   isChecked={memoryBackingType == "hugepages" }
+                                   label={_("Hugepages")}
+                                   name="memoryBackingType"
+                                   onChange={(_, event) => setMemoryBackingType(event.currentTarget.value)}
+                                   value="hugepages" />
+                        </FormGroup>}
+                        <FormGroup hasNoPaddingTop
+                                   fieldId={`${idPrefix}-modal-xattr`}
+                                   label="Extended attributes">
+                            <Checkbox id={`${idPrefix}-modal-xattr`}
+                                      isChecked={xattr}
+                                      label={_("Enable/disable extended attributes (xattr) on files and directories")}
+                                      onChange={xattr => setXattr(xattr)} />
+                        </FormGroup>
+                    </Grid>
+                </ExpandableSection>
+            </Form>
+        </Modal>
+    );
+};

--- a/src/components/vm/filesystems/vmFilesystemsCard.scss
+++ b/src/components/vm/filesystems/vmFilesystemsCard.scss
@@ -1,0 +1,4 @@
+// PF4 sets some border to <pre> - remove this rule once we drop PF3 dependency
+pre.pf-c-code-block__pre {
+    border: unset;
+}

--- a/src/components/vm/vmDetailsPage.scss
+++ b/src/components/vm/vmDetailsPage.scss
@@ -47,7 +47,7 @@
     }
   }
 
-  .networks-card, .disks-card, .snapshots-card {
+  .networks-card, .disks-card, .snapshots-card, .filesystems-card {
     grid-column: 1 / -1;
   }
 

--- a/src/xmlCreator.js
+++ b/src/xmlCreator.js
@@ -260,3 +260,57 @@ export function getSnapshotXML(name, description) {
 
     return new XMLSerializer().serializeToString(doc.documentElement);
 }
+
+export function getFilesystemXML(source, target, xattr) {
+    const doc = document.implementation.createDocument('', '', null);
+
+    const filesystemElem = doc.createElement('filesystem');
+
+    const driverElem = doc.createElement('driver');
+    driverElem.setAttribute('type', 'virtiofs');
+    filesystemElem.appendChild(driverElem);
+
+    if (xattr) {
+        const binaryElem = doc.createElement('binary');
+        binaryElem.setAttribute('xattr', 'on');
+        filesystemElem.appendChild(binaryElem);
+    }
+
+    const sourceElem = doc.createElement('source');
+    sourceElem.appendChild(doc.createTextNode(name));
+    sourceElem.setAttribute('dir', source);
+    filesystemElem.appendChild(sourceElem);
+
+    const targetElem = doc.createElement('target');
+    targetElem.appendChild(doc.createTextNode(name));
+    targetElem.setAttribute('dir', target);
+    filesystemElem.appendChild(targetElem);
+
+    doc.appendChild(filesystemElem);
+
+    return new XMLSerializer().serializeToString(doc.documentElement);
+}
+
+export function getMemoryBackingXML(type, memory) {
+    const doc = document.implementation.createDocument('', '', null);
+
+    const memoryBackingElem = doc.createElement('memoryBacking');
+
+    const accessElem = doc.createElement('access');
+    accessElem.setAttribute('mode', 'shared');
+    memoryBackingElem.appendChild(accessElem);
+
+    if (type == "hugepages") {
+        const hugepagesElem = doc.createElement('hugepages');
+        const pageElem = doc.createElement('page');
+        pageElem.setAttribute('size', memory);
+        pageElem.setAttribute('unit', 'KiB');
+
+        hugepagesElem.appendChild(pageElem);
+        memoryBackingElem.appendChild(hugepagesElem);
+    }
+
+    doc.appendChild(memoryBackingElem);
+
+    return new XMLSerializer().serializeToString(doc.documentElement);
+}

--- a/test/check-machines-filesystems
+++ b/test/check-machines-filesystems
@@ -1,0 +1,117 @@
+#!/usr/bin/python3
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2021 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+
+# import Cockpit's machinery for test VMs and its browser test API
+TEST_DIR = os.path.dirname(__file__)
+sys.path.append(os.path.join(TEST_DIR, "common"))
+sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
+
+from machineslib import VirtualMachinesCase  # noqa
+from testlib import nondestructive, test_main  # noqa
+
+
+@nondestructive
+class TestMachinesFilesystems(VirtualMachinesCase):
+
+    def testBasic(self):
+        b = self.browser
+        m = self.machine
+
+        m.execute("mkdir -p /tmp/dir1 /tmp/dir2")
+
+        self.createVm("subVmTest1", running=False)
+        self.login_and_go("/machines")
+        self.goToVmPage("subVmTest1")
+
+        if m.image in ["rhel-8-5", "centos-8-stream", "debian-stable", "ubuntu-2004", "fedora-33"]:
+            b.wait_not_present("#vm-subVmTest1-filesystems-add")
+            return
+
+        # Form validation
+        b.click("#vm-subVmTest1-filesystems-add")
+        b.click("#vm-subVmTest1-filesystems-modal-add")
+        b.wait_visible("#vm-subVmTest1-filesystems-modal-source-helper")
+        b.wait_visible("#vm-subVmTest1-filesystems-modal-mountTag-helper")
+        b.click("#vm-subVmTest1-filesystems-modal-cancel")
+
+        # Add a new shared fileystem
+        b.click("#vm-subVmTest1-filesystems-add")
+        b.set_file_autocomplete_val("#vm-subVmTest1-filesystems-modal-source-group", "/tmp/dir1/")
+        b.set_input_text("#vm-subVmTest1-filesystems-modal-mountTag", "dir1")
+        b.click(".pf-c-expandable-section__toggle")
+        b.wait_visible("#vm-subVmTest1-filesystems-modal-xattr:not(:checked)")
+        b.set_checked("#vm-subVmTest1-filesystems-modal-xattr", True)
+        b.wait_visible("#vm-subVmTest1-filesystems-modal-file-backed")
+
+        b.click("#vm-subVmTest1-filesystems-modal-add")
+        b.wait_visible("tr[data-row-id='vm-subVmTest1-filesystem-/tmp/dir1/-dir1']")
+        b.wait_in_text("tr[data-row-id='vm-subVmTest1-filesystem-/tmp/dir1/-dir1'] td[data-label='Source path']", "/tmp/dir1/")
+        b.wait_in_text("tr[data-row-id='vm-subVmTest1-filesystem-/tmp/dir1/-dir1'] td[data-label='Mount tag']", "dir1")
+
+        domain_xml = "virsh -c qemu:///system dumpxml {0}".format("subVmTest1")
+        xmllint_element = "{0} | xmllint --xpath 'string(//domain/{{prop}})' - 2>&1 || true".format(domain_xml)
+
+        self.assertEqual('/tmp/dir1/', self.machine.execute(xmllint_element.format(prop='devices/filesystem/source/@dir')).strip())
+        self.assertEqual('dir1', self.machine.execute(xmllint_element.format(prop='devices/filesystem/target/@dir')).strip())
+        self.assertEqual('on', self.machine.execute(xmllint_element.format(prop='devices/filesystem/binary/@xattr')).strip())
+        self.assertEqual('shared', self.machine.execute(xmllint_element.format(prop='memoryBacking/access/@mode')).strip())
+
+        # Add a new shared fileystem - now the memoryBacking is configured and hidden from the dialog
+        b.click("#vm-subVmTest1-filesystems-add")
+        b.set_file_autocomplete_val("#vm-subVmTest1-filesystems-modal-source-group", "/tmp/dir2/")
+        b.set_input_text("#vm-subVmTest1-filesystems-modal-mountTag", "dir2")
+        b.click(".pf-c-expandable-section__toggle")
+        b.set_checked("#vm-subVmTest1-filesystems-modal-xattr", False)
+        b.wait_not_present("#vm-subVmTest1-filesystems-modal-file-backed")
+
+        b.click("#vm-subVmTest1-filesystems-modal-add")
+        b.wait_visible("tr[data-row-id='vm-subVmTest1-filesystem-/tmp/dir2/-dir2']")
+        b.wait_in_text("tr[data-row-id='vm-subVmTest1-filesystem-/tmp/dir2/-dir2'] td[data-label='Source path']", "/tmp/dir2/")
+        b.wait_in_text("tr[data-row-id='vm-subVmTest1-filesystem-/tmp/dir2/-dir2'] td[data-label='Mount tag']", "dir2")
+
+        self.assertEqual('/tmp/dir2/', self.machine.execute(xmllint_element.format(prop='devices/filesystem[2]/source/@dir')).strip())
+        self.assertEqual('dir2', self.machine.execute(xmllint_element.format(prop='devices/filesystem[2]/target/@dir')).strip())
+        self.assertEqual('', self.machine.execute(xmllint_element.format(prop='devices/filesystem[2]/binary/@xattr')).strip())
+
+        # Try to add a new shared filesystem with the same mount tag
+        # Due to a libvirt bug this will be actually added without an error
+        # Keep the test here and add the expected behavior when the BZ is fixed
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1972218
+        b.click("#vm-subVmTest1-filesystems-add")
+        b.set_file_autocomplete_val("#vm-subVmTest1-filesystems-modal-source-group", "/tmp/dir1/")
+        b.set_input_text("#vm-subVmTest1-filesystems-modal-mountTag", "dir1")
+        b.click("#vm-subVmTest1-filesystems-modal-add")
+        b.wait_visible("tr:nth-child(3)[data-row-id='vm-subVmTest1-filesystem-/tmp/dir1/-dir1']")
+
+        # Try to add a new shared filesystem with non existing source directory
+        b.click("#vm-subVmTest1-filesystems-add")
+        b.set_input_text("#vm-subVmTest1-filesystems-modal-source-group input", "dir3")
+        b.wait_in_text("#vm-subVmTest1-filesystems-modal-source", "No such file or directory")
+        b.click("#vm-subVmTest1-filesystems-modal-cancel")
+
+        # Start VM and ensure that adding filesystem is disabled
+        b.click("#vm-subVmTest1-run")
+        b.wait_visible("#vm-subVmTest1-filesystems-add[aria-disabled=true]")
+
+
+if __name__ == '__main__':
+    test_main()


### PR DESCRIPTION
    Add support for configuring/viewing shared directories between VMs and host
    
    The shared directories can be mounted using VirtIO-FS [1].
    
    Status of VirtIO-FS
    -------------------
    
    Available in mainline since Linux 5.4, QEMU 5.0, libvirt 6.2.
    
    VirtIO-FS vs VirtIO-9p
    ----------------------
    
    VirtIO-FS is generally recommended over VirtIO-9p, as a faster and with better
    POSIX compliance shared filesystem solution for VMs.
    
    However:
    
    * osinfo-db still does not have support for it. This means that if the
    guest operating system does not support it we can't warn the users
    
    * virt-install does not have support for it (not interesting for us,
    since we allow configuring shared directories after installing the
    guest)
    
    * and neither libvirt exposes an option in domcapabilities for us to detect if the
    virtualization host supports VirtIO-FS
    
    On the othger hand virtIO-9p is not supported at all in RHEL/centos-8
    since the relevant module is not included in the default kernel.
    
    The tests
    ---------
    
    DO:
    * test if adding a filesystem makes it appear correctly in the UI
    
    DON'T:
    * test the actual sharing, meaning that the disk shared from the host
    can be actually written/read from the guest and vise-versa. This is
    because we *don't* have the test tooling at this point to run commands
    inside test VMs.
    
    Notes
    -----
    
    Setting explicitely the xattr is not needed since 5.12 kernel:
    https://lore.kernel.org/selinux/20210113123802.63563-1-omosnace@redhat.com/T/
    
    This is quite unfortunate because it's too much of a technicality to
    document in the UI, but will probably leave some users wondering why
    SELinux is preventing the mount operation they are attempting.
    
    Fixes #103
    
    [1] https://virtio-fs.gitlab.io/

filesystems card:

![Screen Shot 2021-06-02 at 16 23 55](https://user-images.githubusercontent.com/14921356/120339904-cef6f800-c2f5-11eb-8a81-1104087f6ecb.png)


dialog if memory backing is already setup or for every new filesystem, apart from the first one.
![Screen Shot 2021-06-02 at 16 23 25](https://user-images.githubusercontent.com/14921356/120339907-d0282500-c2f5-11eb-9b65-651a3962aec1.png)

dialog if memory backing is not set up:
![Screen Shot 2021-06-02 at 16 20 43](https://user-images.githubusercontent.com/14921356/120339908-d0282500-c2f5-11eb-8f1e-1d564a69ebad.png)



