### PR TITLE
Harden publish-dist

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -23,13 +23,6 @@ jobs:
       - name: Build
         run: NODE_ENV=production make
 
-      - name: Save event information
-        env:
-          GITHUB_EVENT: ${{ toJSON(github.event) }}
-        run: |
-          # Save event for follow-up workflows
-          echo "$GITHUB_EVENT" > event.json
-
       - name: Create dist artifact
         uses: actions/upload-artifact@v2
         with:
@@ -37,5 +30,4 @@ jobs:
           path: |
             dist/
             package-lock.json
-            event.json
           retention-days: 1

--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -14,9 +14,6 @@ jobs:
         with:
           # need this to also fetch tags
           fetch-depth: 0
-          # avoid checking out the default pull/NNN/head ref, as that gives
-          # mismatching SHAs in generated artifacts
-          ref: "${{ github.event.pull_request.head.sha || github.sha }}"
 
       - name: Set up dependencies
         run: |
@@ -30,9 +27,6 @@ jobs:
         env:
           GITHUB_EVENT: ${{ toJSON(github.event) }}
         run: |
-          # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
-          # for pull_requests, use HEAD of the proposed branch, for pushes to origin the current SHA
-          echo "${{ github.event.pull_request.head.sha || github.sha }}" > SHA
           # Save event for follow-up workflows
           echo "$GITHUB_EVENT" > event.json
 
@@ -41,7 +35,6 @@ jobs:
         with:
           name: dist
           path: |
-            SHA
             dist/
             package-lock.json
             event.json

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -42,28 +42,3 @@ jobs:
 
           git push https://github.com/${{ github.repository }}-dist.git "$tag"
 
-      - name: Trigger integration tests for PRs
-        run: |
-          if ! grep -q '"pull_request"' event.json; then
-              echo "build-dist event was not a pull request"
-              exit 0
-          fi
-          # support running this from forks
-          if [ -z '${{ secrets.AMQP_CLIENT_KEY }}' ]; then
-              echo "No AMQP secrets, skipping tests-scan"
-              exit 0
-          fi
-
-          pip install pika
-
-          git clone --depth=1 https://github.com/cockpit-project/bots
-
-          # tests-scan does not currently have a --secrets-dir option
-          sudo mkdir -p /run/secrets/webhook
-          echo '${{ secrets.COCKPIT_CA_PEM }}' | sudo dd status=none of=/run/secrets/webhook/ca.pem
-          echo '${{ secrets.AMQP_CLIENT_PEM }}' | sudo dd status=none of=/run/secrets/webhook/amqp-client.pem
-          echo '${{ secrets.AMQP_CLIENT_KEY }}' | sudo dd status=none of=/run/secrets/webhook/amqp-client.key
-
-          # FIXME: make this nicer in tests-scan
-          AMQP_SERVER=$(PYTHONPATH=bots python3 -c 'from task.distributed_queue import *; print(DEFAULT_AMQP_SERVER)')
-          GITHUB_BASE=${{ github.repository }} bots/tests-scan -d --pull-data "$(cat event.json)" --amqp "$AMQP_SERVER"

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Commit to dist repo
         run: |
           set -ex
-          SHA="$(cat SHA)"
 
           mkdir dist-repo
           cd dist-repo
@@ -37,11 +36,11 @@ jobs:
           cp -r ../dist/ ../package-lock.json .
 
           git add .
-          git commit -m "Build for $SHA"
-          tag="sha-$SHA"
+          git commit -m "Build for ${{ github.event.workflow_run.head_sha }}"
+          tag="sha-${{ github.event.workflow_run.head_sha }}"
           git tag "$tag"
 
-          git push https://github.com/${{ github.repository }}-dist.git $tag
+          git push https://github.com/${{ github.repository }}-dist.git "$tag"
 
       - name: Trigger integration tests for PRs
         run: |

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -11,7 +11,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Download build-dist artifacts
-        uses: dawidd6/action-download-artifact@v2
+        # 2.14.0; if you update this, audit the diff and ensure that it does not leak/abuse secrets
+        uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74
         with:
           name: dist
           workflow: build-dist


### PR DESCRIPTION
This avoids all recently discussed attack vectors of our build-dist/publish-dist workflow pair.

I tested this on my fork, for both a [push](https://github.com/martinpitt/cockpit-machines/runs/2476801243?check_suite_focus=true) and a [pull_request](https://github.com/martinpitt/cockpit-machines/runs/2476801243?check_suite_focus=true) from https://github.com/martinpitt/cockpit-machines/pull/4.

In both cases publishing succeeded, committed the expected sha-TAG to the -dist repo, and I validated that the cache works with `GITHUB_BASE=martinpitt/cockpit-machines test/download-dist`.

 - [x] After landing this, re-enable `pull_request` webhook