### PR TITLE
tests: create fake fedora-28 osinfo-db entry also for debian stable

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1057,6 +1057,9 @@ class TestMachinesCreate(VirtualMachinesCase):
             root.find('os').find('resources').find('minimum').find('storage').text = '134217728'
             if self.machine.image not in ["debian-stable"]:
                 root.find('os').find('eol-date').text = '9999-12-31'
+            else:
+                eol_date = ET.SubElement(root.find('os'), 'eol-date')
+                eol_date.text = '9999-12-31'
             new_fedora_28_xml = ET.tostring(root)
             self.machine.execute("echo \'{0}\' > {1}/fedora-28.xml".format(str(new_fedora_28_xml, 'utf-8'), self.test_obj.vm_tmpdir))
             self.machine.execute("mount -o bind  {0}/fedora-28.xml /usr/share/osinfo/os/fedoraproject.org/fedora-28.xml".format(self.test_obj.vm_tmpdir))


### PR DESCRIPTION
debian-stable image has some old osinfo-db version, namely
0.20181120-1+deb10u1, which does not contain the EOL date entry for
fedora-28.

Handle this case in the tests explicitely.