### PR TITLE
publish/prune dist workflow cleanups

### DIFF
--- a/.github/workflows/po-refresh.yml
+++ b/.github/workflows/po-refresh.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
           echo '${{ secrets.COCKPITUOUS_TOKEN }}' > ~/.config/github-token
-          # po-refresh pushes to weblate repo via https://github.com, that needs our cockpituous token
+          # po-refresh pushes to weblate repo via https, that needs our cockpituous token
           git config --global credential.helper store
           echo 'https://token:${{ secrets.COCKPITUOUS_TOKEN }}@github.com' >> ~/.git-credentials
 

--- a/.github/workflows/prune-dist.yml
+++ b/.github/workflows/prune-dist.yml
@@ -13,20 +13,20 @@ jobs:
       - name: Set up configuration and secrets
         run: |
           printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
-          # we push to -dist repo via https://github.com, that needs our cockpituous token
+          # we push to -dist repo via https, that needs our cockpituous token
           git config --global credential.helper store
           echo 'https://token:${{ secrets.COCKPITUOUS_TOKEN }}@github.com' >> ~/.git-credentials
 
       - name: Clone -dist repo
         run: |
-          git clone https://github.com/${{ github.repository }}-dist.git dist-repo
+          git clone "${GITHUB_SERVER_URL}/${{ github.repository }}-dist.git" dist-repo
 
       - name: Delete old tags
         run: |
           set -ex
 
           # head commit SHA of default branch
-          HEAD=$(git ls-remote 'https://github.com/${{ github.repository }}' main master | cut -f1 | head -n1)
+          HEAD=$(git ls-remote "${GITHUB_SERVER_URL}/${{ github.repository }}" main master | cut -f1 | head -n1)
 
           cd dist-repo
           now="$(date +%s)"

--- a/.github/workflows/prune-dist.yml
+++ b/.github/workflows/prune-dist.yml
@@ -10,9 +10,6 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
       - name: Set up configuration and secrets
         run: |
           printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
@@ -28,14 +25,15 @@ jobs:
         run: |
           set -ex
 
-          HEAD=$(git rev-parse HEAD)
+          # head commit SHA of default branch
+          HEAD=$(git ls-remote 'https://github.com/${{ github.repository }}' main master | cut -f1 | head -n1)
 
           cd dist-repo
           now="$(date +%s)"
           for tag in $(git tag -l); do
               tag_time="$(git show -s --format=%at $tag)"
               if [ "$tag" = "sha-${HEAD}" ]; then
-                  echo "$tag refers to current project HEAD, keeping"
+                  echo "$tag refers to current project default branch HEAD, keeping"
               elif [ $((now - tag_time)) -ge 604800 ]; then
                   echo "$tag is older than 7 days, deleting..."
                   git push origin ":$tag"

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -17,11 +17,11 @@ jobs:
           name: dist
           workflow: build-dist
           run_id: ${{ github.event.workflow_run.id }}
+          path: dist-repo
 
       - name: Set up configuration and secrets
         run: |
           printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
-          echo '${{ secrets.COCKPITUOUS_TOKEN }}' > ~/.config/github-token
           # we push to -dist repo via https://github.com, that needs our cockpituous token
           git config --global credential.helper store
           echo 'https://token:${{ secrets.COCKPITUOUS_TOKEN }}@github.com' >> ~/.git-credentials
@@ -29,16 +29,11 @@ jobs:
       - name: Commit to dist repo
         run: |
           set -ex
-
-          mkdir dist-repo
           cd dist-repo
           git init
-          cp -r ../dist/ ../package-lock.json .
-
           git add .
-          git commit -m "Build for ${{ github.event.workflow_run.head_sha }}"
-          tag="sha-${{ github.event.workflow_run.head_sha }}"
+          git commit -m 'Build for ${{ github.event.workflow_run.head_sha }}'
+          tag='sha-${{ github.event.workflow_run.head_sha }}'
           git tag "$tag"
 
           git push https://github.com/${{ github.repository }}-dist.git "$tag"
-

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up configuration and secrets
         run: |
           printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
-          # we push to -dist repo via https://github.com, that needs our cockpituous token
+          # we push to -dist repo via https, that needs our cockpituous token
           git config --global credential.helper store
           echo 'https://token:${{ secrets.COCKPITUOUS_TOKEN }}@github.com' >> ~/.git-credentials
 
@@ -36,4 +36,4 @@ jobs:
           tag='sha-${{ github.event.workflow_run.head_sha }}'
           git tag "$tag"
 
-          git push https://github.com/${{ github.repository }}-dist.git "$tag"
+          git push "${GITHUB_SERVER_URL}/${{ github.repository }}-dist.git" "$tag"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,4 @@ jobs:
           cd /build
           # Wait for build-dist and publish-dist workflows to complete
           export DOWNLOAD_DIST_OPTIONS=--wait
-          release-runner -r https://github.com/$GITHUB_REPOSITORY -t $(basename $GITHUB_REF) ./cockpituous-release
+          release-runner -r "${GITHUB_SERVER_URL}/${{ github.repository }}" -t $(basename "$GITHUB_REF") ./cockpituous-release


### PR DESCRIPTION
Spotted in #143 and https://github.com/cockpit-project/cockpit/pull/15748

Tested on my fork, with a [publish-dist run](https://github.com/martinpitt/cockpit-machines/runs/2490460206?check_suite_focus=true) successfully creating the tag in the [dist repo](https://github.com/martinpitt/cockpit-machines-dist/tags), [prune-dist](https://github.com/martinpitt/cockpit-machines/runs/2490478097?check_suite_focus=true) correctly recognizing current main HEAD, and `GITHUB_BASE=martinpitt/cockpit-machines test/download-dist` succeeds.