### PR TITLE
test: Add test/reference to .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/reference"]
+	path = test/reference
+	url = ../pixel-test-reference


### PR DESCRIPTION
This helps Github and others to understand better what's going on, and
it stops "git submodule" invocations from throwing errors.

Also, implementing "pixel-tests pull" in terms of "git submodule"
looks like a very sensible thing anyway.