### PR TITLE
test: Only ignore #storage-size-helper when it is present

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -970,8 +970,10 @@ class TestMachinesCreate(VirtualMachinesCase):
         def assert_pixels(self, subtag=None):
             if self.pixel_test_tag:
                 tag = self.pixel_test_tag + ("-" + subtag if subtag else "")
-                self.browser.assert_pixels("#create-vm-dialog", tag,
-                                           ignore=["#storage-size-helper", "#memory-size-helper"])
+                ignore = ["#memory-size-helper"]
+                if self.storage_pool != "NoStorage":
+                    ignore += ["#storage-size-helper"]
+                self.browser.assert_pixels("#create-vm-dialog", tag, ignore=ignore)
             return self
 
     class CreateVmRunner:


### PR DESCRIPTION
The "assert_pixels" function used to skip selectors in the "ignore"
list that aren't actually present, but this will soon no longer be the
case.  It is better to be explicit in tests, and it is very easy in
this case, too.