### PR TITLE
test: Don't use relative URL for test/reference module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "test/reference"]
 	path = test/reference
-	url = ../pixel-test-reference
+	url = https://github.com/cockpit-project/pixel-test-reference
+	branch = empty


### PR DESCRIPTION
Git will interpret this as relative to the URL of the remote tracking
branch of the current branch, and that is often a personal fork
instead of a repo in the cockpit-project organization.