### PR TITLE
Test fixes

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1086,14 +1086,7 @@ class TestMachinesCreate(VirtualMachinesCase):
 
             # Make sure that the initial state goes away and then try to check what the new state is
             # because we might end up checking the text for the new state the momment it disappears
-            def waitStateWentAway(selector, state):
-                try:
-                    b.wait_text_not(selector, state)
-                    return True
-                except Error:
-                    return False
-
-            wait(lambda: waitStateWentAway(selector, before), delay=3)
+            wait(lambda: b.text(selector) != before, tries=30, delay=3)
             b.wait_in_text(selector, after)
 
         def _create(self, dialog):

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -240,4 +240,4 @@ class VirtualMachinesCase(MachineCase, VirtualMachinesCaseHelpers, StorageHelper
         m.execute("virsh net-define /etc/libvirt/qemu/networks/default.xml || true")
 
         # avoid error noise about resources getting cleaned up
-        self.addCleanup(self.browser.logout)
+        self.addCleanup(lambda: not self.browser.cdp.valid or self.browser.logout())

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -215,7 +215,7 @@ class VirtualMachinesCase(MachineCase, VirtualMachinesCaseHelpers, StorageHelper
         self.addCleanup(m.execute, "for n in $(virsh net-list --all --name); do virsh net-destroy $n || true; done")
 
         # we don't have configuration to open the firewall for local libvirt machines, so just stop firewalld
-        m.execute("systemctl stop firewalld; systemctl try-restart libvirtd")
+        m.execute("systemctl stop firewalld; systemctl reset-failed libvirtd; systemctl try-restart libvirtd")
 
         # user libvirtd instance tends to SIGABRT with "Failed to find user record for uid .." on shutdown during cleanup
         # so make sure that there are no leftover user processes that bleed into the next test


### PR DESCRIPTION
This fixes the mess that we saw in https://github.com/cockpit-project/bots/pull/2020 ([log](https://logs.cockpit-project.org/logs/pull-2020-20210517-150150-d470d5b6-rhel-8-5-cockpit-project-cockpit-machines/log.html)) and in the downstream RHEL 8.5 update.