### PR TITLE
fmf: Drop pillow test dependency

### DIFF
--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -11,7 +11,6 @@ require:
   - make
   - npm
   - python3
-  - python3-pillow
   - python3-yaml
   # required by tests
   - firewalld


### PR DESCRIPTION
It has been uninstallable in RHEL for a while, will eventually disappear
[1], and we don't really need pixel tests in downstream gating.

[1] https://github.com/minimization/content-resolver-input/blob/master/configs/sst_cs_apps-unwanted-python3.yaml