### PR TITLE
Fix editing the MAC address of NICs

### DIFF
--- a/src/components/vm/nics/nicEdit.jsx
+++ b/src/components/vm/nics/nicEdit.jsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import cockpit from 'cockpit';
 import PropTypes from 'prop-types';
-import { Button, Alert, Form, FormGroup, Modal, TextInput } from '@patternfly/react-core';
+import { Button, Alert, Form, FormGroup, Modal, TextInput, Tooltip } from '@patternfly/react-core';
 
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
 import { NetworkTypeAndSourceRow, NetworkModelRow } from './nicBody.jsx';
@@ -30,12 +30,19 @@ import 'form-layout.scss';
 
 const _ = cockpit.gettext;
 
-const NetworkMacRow = ({ mac, onValueChanged, idPrefix }) => {
+const NetworkMacRow = ({ mac, onValueChanged, idPrefix, isShutoff }) => {
+    let macInput = (
+        <TextInput id={`${idPrefix}-edit-dialog-mac`}
+                   isReadOnly={!isShutoff}
+                   value={mac}
+                   onChange={value => onValueChanged("networkMac", value)} />
+    );
+    if (!isShutoff)
+        macInput = <Tooltip content={_("Only editable when the guest is shut off")}>{macInput}</Tooltip>;
+
     return (
         <FormGroup fieldId={`${idPrefix}-edit-dialog-mac`} label={_("MAC address")}>
-            <TextInput id={`${idPrefix}-edit-dialog-mac`}
-                       value={mac}
-                       onChange={value => onValueChanged("networkMac", value)} />
+            {macInput}
         </FormGroup>
     );
 };
@@ -145,7 +152,10 @@ export class EditNICModal extends React.Component {
                                  onValueChanged={this.onValueChanged}
                                  osTypeArch={vm.arch}
                                  osTypeMachine={vm.emulatedMachine} />
-                <NetworkMacRow mac={this.state.networkMac} onValueChanged={this.onValueChanged} idPrefix={idPrefix} />
+                <NetworkMacRow mac={this.state.networkMac}
+                               onValueChanged={this.onValueChanged}
+                               idPrefix={idPrefix}
+                               isShutoff={vm.state == "shut off"} />
             </Form>
         );
         const showWarning = () => {

--- a/src/libvirt-dbus.js
+++ b/src/libvirt-dbus.js
@@ -1364,19 +1364,17 @@ export function changeNetworkSettings({
     flags |= Enum.VIR_DOMAIN_AFFECT_CONFIG;
 
     if (newMacAddress && newMacAddress !== macAddress) {
-        return detachIface(macAddress, connectionName, objPath, hotplug, persistent, dispatch)
-                .then(() => {
-                    return attachIface({
-                        connectionName,
-                        hotplug,
-                        vmId: objPath,
-                        mac: newMacAddress,
-                        permanent: persistent,
-                        sourceType: networkType,
-                        source: networkSource,
-                        model: networkModel
-                    });
-                });
+        return attachIface({
+            connectionName,
+            hotplug,
+            vmId: objPath,
+            mac: newMacAddress,
+            permanent: persistent,
+            sourceType: networkType,
+            source: networkSource,
+            model: networkModel
+        })
+                .then(() => detachIface(macAddress, connectionName, objPath, hotplug, persistent, dispatch));
     } else {
         // Error handling inside the modal dialog this function is called
         return call(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_INACTIVE], { timeout, type: 'u' })

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -220,6 +220,7 @@ class TestMachinesNICs(VirtualMachinesCase):
 
         b.click("#vm-subVmTest1-network-2-edit-dialog")
         b.select_from_dropdown("#vm-subVmTest1-network-2-select-source", "eth42")
+        b.wait_attr("#vm-subVmTest1-network-2-edit-dialog-mac", "readonly", "")
         b.wait_visible("#vm-subVmTest1-network-2-edit-dialog-idle-message")
         b.click("#vm-subVmTest1-network-2-edit-dialog-save")
         b.wait_not_present("#vm-subVmTest1-network-2-edit-dialog-modal-window")


### PR DESCRIPTION
If attaching the NIC after changing the MAC address failed we previously
ended up with the original NIC being removed as well.

Let's fix it in the following way:

* First attach the new interface (new MAC address) and only if the
operation is successful remove the obsoleted NIC
* In order that the attachment and removal of the obsoleted NIC is
guaranteed let's allow this operation for offline VMs only.
Hotplugging and hot-unplugging NICs is not guaranteed to succeed,
as it relies on the OS being responsive, enough PCI slots being
available etc.

Fixes #185