### PR TITLE
Fix comparison when building the available disk bus type list

### DIFF
--- a/src/components/vm/disks/diskEdit.jsx
+++ b/src/components/vm/disks/diskEdit.jsx
@@ -80,7 +80,7 @@ const CacheRow = ({ onValueChanged, dialogValues, idPrefix, shutoff }) => {
 
 const BusRow = ({ onValueChanged, dialogValues, idPrefix, shutoff }) => {
     const busTypes = ['sata', 'scsi', 'usb', 'virtio'].map(type => ({ value: type }));
-    if (!busTypes.includes(dialogValues.busType))
+    if (busTypes.find(busType => busType.value == dialogValues.busType) == undefined)
         busTypes.push({ value: dialogValues.busType, disabled: true });
 
     return (


### PR DESCRIPTION
Previously we were comparing the current disk bus type value (string)
with the list of objects, therefore the current disk bus type was always
added as disabled option in the end of the list.

Relevant to https://bugzilla.redhat.com/show_bug.cgi?id=1948366