### PR TITLE
Bump cockpit test/common to 246

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 244; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 246; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 


### PR DESCRIPTION
This adds support for OS specific messages maintained in bots:
https://github.com/cockpit-project/cockpit/commit/f754e5f72dcd08c