### PR TITLE
Fix string in 'Share host directory' dialog

### DIFF
--- a/src/components/vm/filesystems/vmFilesystemsCard.jsx
+++ b/src/components/vm/filesystems/vmFilesystemsCard.jsx
@@ -141,7 +141,7 @@ const VmFilesystemAddModal = ({ connectionName, dispatch, memory, memoryBacking,
     };
     return (
         <Modal position="top" isOpen variant="medium" onClose={() => setIsOpen(false)}
-               title={_("Share a shared host directory with the guest")}
+               title={_("Share a host directory with the guest")}
                footer={
                    <>
                        {dialogError && <ModalError dialogError={_("Failed to add shared directory")} dialogErrorDetail={dialogError} />}


### PR DESCRIPTION
This should be either:
* Add a shared host ...
or
* Share a host ...

The current string was a mix and obviously wrong.