### PR TITLE
Fix reducers updating interfaces and node devices

### DIFF
--- a/src/reducers.js
+++ b/src/reducers.js
@@ -109,7 +109,7 @@ function interfaces(state, action) {
         }
 
         const updatedIface = Object.assign({}, state[index], iface);
-        return replaceResource({ state, updatedIface, index });
+        return replaceResource({ state, updatedResource: updatedIface, index });
     }
     default:
         return state;
@@ -174,7 +174,7 @@ function nodeDevices(state, action) {
         }
 
         const updatedNodedev = Object.assign({}, state[index], nodedev);
-        return replaceResource({ state, updatedNodedev, index });
+        return replaceResource({ state, updatedResource: updatedNodedev, index });
     }
     default:
         return state;

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -281,6 +281,18 @@ class TestMachinesLifecycle(VirtualMachinesCase):
             b.wait_not_present(".pf-c-empty-state")
             self.waitVmRow("subVmTest1")
 
+            # Ensure that create VM dialog does not crash after starting libvirt from the UI
+            # https://bugzilla.redhat.com/show_bug.cgi?id=1974228
+            b.click("#create-new-vm")
+            b.wait_visible("#create-vm-dialog")
+
+            self.browser.switch_to_top()
+            self.browser.wait_not_visible("#navbar-oops")
+
+            self.browser.reload()
+            self.browser.enter_page('/machines')
+            self.browser.wait_in_text("body", "Virtual machines")
+
         hack_libvirtd_crash()
         m.execute("systemctl stop {0}".format(libvirtServiceName))
         b.wait_in_text(".pf-c-empty-state", "Virtualization service (libvirt) is not active")


### PR DESCRIPTION
Previously the resources would be updated to an undefined object,
because of the misspelled named parameter, resulting in JS exceptions.

Relevant to https://bugzilla.redhat.com/show_bug.cgi?id=1974228