### PR TITLE
Delete VM snapshots before deleting the VM to remove unusable overlays from image

### DIFF
--- a/src/components/vm/deleteDialog.jsx
+++ b/src/components/vm/deleteDialog.jsx
@@ -23,6 +23,7 @@ import { Button, Modal } from '@patternfly/react-core';
 
 import { vmId } from '../../helpers.js';
 import { deleteVm } from '../../actions/provider-actions.js';
+import { deleteSnapshot } from '../../libvirt-dbus.js';
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
 
 import './deleteDialog.css';
@@ -117,11 +118,16 @@ export class DeleteDialog extends React.Component {
 
     delete() {
         const storage = this.state.disks.filter(d => d.checked);
+        const vm = this.props.vm;
 
-        return this.props.dispatch(deleteVm(this.props.vm, { destroy: this.props.vm.state != 'shut off', storage: storage }, this.props.storagePools))
+        Promise.all(
+            (Array.isArray(vm.snapshots) ? vm.snapshots : [])
+                    .map(snapshot => deleteSnapshot({ connectionName: vm.connectionName, domainPath: vm.id, snapshotName: snapshot.name }))
+        )
+                .then(() => this.props.dispatch(deleteVm(vm, { destroy: vm.state != 'shut off', storage: storage }, this.props.storagePools)))
                 .then(() => cockpit.location.go(["vms"]))
                 .catch(exc => {
-                    this.dialogErrorSet(cockpit.format(_("VM $0 failed to get deleted"), this.props.vm.name), exc.message);
+                    this.dialogErrorSet(cockpit.format(_("VM $0 failed to get deleted"), vm.name), exc.message);
                 });
     }
 

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -29,6 +29,8 @@ sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
 from machineslib import VirtualMachinesCase  # noqa
 from testlib import nondestructive, skipImage, test_main, wait  # noqa
 
+distrosWithoutSnapshot = ["centos-8-stream", "debian-stable", "rhel-8-4", "rhel-8-5", "ubuntu-2004"]
+
 
 @nondestructive
 class TestMachinesLifecycle(VirtualMachinesCase):
@@ -400,6 +402,32 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         self.performAction(name, "delete")
         b.click("#vm-{0}-delete-modal-dialog button:contains(Delete)".format(name))
         self.waitVmRow(name, 'system', False)
+
+        if m.image not in distrosWithoutSnapshot:
+            # Delete a VM with snapshots and ensure the qcow2 image overlays get also cleaned up
+            name = "vm-with-snapshots"
+            self.createVm(name, running=False)
+
+            m.execute("virsh snapshot-create-as --domain {0} --name snapshotA --description 'Description of snapshotA'".format(name))
+
+            qemu_img_info = m.execute("qemu-img info /var/lib/libvirt/images/{0}-2.img".format(name))
+            self.assertIn("snapshotA", qemu_img_info)
+
+            # snapshots events not available yet: https://gitlab.com/libvirt/libvirt/-/issues/44
+            b.reload()
+            b.enter_page('/machines')
+            self.goToVmPage(name)
+            b.wait_in_text("#vm-{0}-snapshot-0-name".format(name), "snapshotA")
+
+            self.performAction(name, "delete")
+
+            # Unselect the disks - we don't want to delete them
+            b.click("#vm-vm-with-snapshots-delete-modal-dialog ul li:first-child #disk-source-file")
+            b.click("#vm-vm-with-snapshots-delete-modal-dialog button:contains(Delete)")
+            b.wait_not_present("#vm-{0}-delete-modal-dialog".format(name))
+
+            qemu_img_info = m.execute("qemu-img info /var/lib/libvirt/images/{0}-2.img".format(name))
+            self.assertNotIn("snapshotA", qemu_img_info)
 
         # Try to delete a transient VM
         name = "transient-VM"


### PR DESCRIPTION
Consider the following scenario:

* The user deletes the VM (let's call it testVm) but not the disk image
(testVm.qcow2), which has snapshot overlays and he want to reuse the
aforementioned image
* The user imports testVm.qcow2 into a new VM which of course can't parse the
snapshots of the previous VM, however the overlays still exist on the
testVm.qcow2 image

Since these snapshots are of not use anymore, let's delete these when
the first domain is deleted.

Relevant to: https://bugzilla.redhat.com/show_bug.cgi?id=1974216