### PR TITLE
Bump up pkg/lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ test/reference: test/common
 # checkout Cockpit's PF/React/build library; again this has no API stability guarantee, so check out a stable tag
 $(LIB_TEST):
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 242; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 4e553647a81b6ec49e9fa13e2ed72d472c52965b; \
 	    git checkout --force FETCH_HEAD -- pkg/lib; \
 	    git reset -- pkg/lib'
 	mv pkg/lib src/ && rmdir -p pkg

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "null-loader": "^3.0.0",
     "po2json": "^1.0.0-alpha",
     "raw-loader": "^4.0.0",
+    "sass": "^1.35.0",
+    "sass-loader": "^12.1.0",
     "sizzle": "^2.3.3",
     "stdio": "^2.1.0",
     "string-replace-loader": "^3.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require("path");
-const childProcess = require('child_process');
 
 const copy = require("copy-webpack-plugin");
 const extract = require("mini-css-extract-plugin");
@@ -35,18 +34,6 @@ if (production) {
         test: /\.(js|html|css)$/,
         deleteOriginalAssets: true
     }));
-}
-
-/* check if sassc is available, to avoid unintelligible error messages */
-try {
-    childProcess.execFileSync('sassc', ['--version'], { stdio: ['pipe', 'inherit', 'inherit'] });
-} catch (e) {
-    if (e.code === 'ENOENT') {
-        console.error("ERROR: You need to install the 'sassc' package to build this project.");
-        process.exit(1);
-    } else {
-        throw e;
-    }
 }
 
 module.exports = {
@@ -149,7 +136,23 @@ module.exports = {
                             ]
                         },
                     },
-                    'sassc-loader',
+                    {
+                        loader: 'sass-loader',
+                        options: {
+                            sourceMap: !production,
+                            sassOptions: {
+                                quietDeps: true,
+                                outputStyle: production ? 'compressed' : undefined,
+                                includePaths: [
+                                    // Teach webpack to resolve these references in order to build PF3 scss
+                                    path.resolve(nodedir),
+                                    path.resolve(nodedir, 'font-awesome-sass', 'assets', 'stylesheets'),
+                                    path.resolve(nodedir, 'patternfly', 'dist', 'sass'),
+                                    path.resolve(nodedir, 'bootstrap-sass', 'assets', 'stylesheets'),
+                                ],
+                            },
+                        },
+                    },
                 ]
             },
             {
@@ -178,7 +181,16 @@ module.exports = {
                             ]
                         },
                     },
-                    'sassc-loader',
+                    {
+                        loader: 'sass-loader',
+                        options: {
+                            sourceMap: !production,
+                            sassOptions: {
+                                quietDeps: true,
+                                outputStyle: production ? 'compressed' : undefined,
+                            },
+                        },
+                    },
                 ]
             },
             {
@@ -193,7 +205,18 @@ module.exports = {
                             url: false
                         }
                     },
-                    'sassc-loader',
+                    {
+                        loader: 'sass-loader',
+                        options: {
+                            sourceMap: !production,
+                            sassOptions: {
+                                quietDeps: true,
+                                outputStyle: production ? 'compressed' : undefined,
+                            },
+                        },
+                    },
+
+
                 ]
             },
             {


### PR DESCRIPTION
We can't just use tag 247 (latest) because the needed lib changes for
muting some sass related deprecation warnings are contained in
4e553647a81b6ec49e9fa13e2ed72d472c52965b.

This now indeed enables us to use dart sass.