### PR TITLE
When creating VMs use the XML file virt-install prints for adding metadata

### DIFF
--- a/src/scripts/create_machine.sh
+++ b/src/scripts/create_machine.sh
@@ -191,7 +191,7 @@ fi
 
 if [ "$START_VM" = "true" ]; then
     vmExists "$VM_NAME" || handleFailure $?
-    virsh -c "$CONNECTION_URI" -q dumpxml "$VM_NAME" > "$XMLS_FILE"
+    virsh -c "$CONNECTION_URI" -q dumpxml --inactive "$VM_NAME" > "$XMLS_FILE"
 fi
 
 # LAST STEP ONLY - virt-install can output 1 or 2 steps

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1234,13 +1234,16 @@ class TestMachinesCreate(VirtualMachinesCase):
         def _assertDomainDefined(self, name, connection):
             listCmd = ""
             if connection == "session":
-                listCmd = "runuser -l admin -c 'virsh -c qemu:///session dumpxml --inactive {0} | grep cockpit_machines | wc -l'".format(name)
+                listCmd = "runuser -l admin -c 'virsh -c qemu:///session dumpxml --inactive {0}'".format(name)
             else:
                 # When creating VMs from the UI default connection is the system
                 # In this case don't use runuser -l admin because we get errors 'authentication unavailable'
-                listCmd = "virsh -c qemu:///system dumpxml --inactive {0} | grep cockpit_machines | wc -l".format(name)
+                listCmd = "virsh -c qemu:///system dumpxml --inactive {0}".format(name)
 
-            wait(lambda: "6" in self.machine.execute(listCmd))
+            wait(lambda: "6" in self.machine.execute(listCmd + " | grep cockpit_machines | wc -l"))
+            # The running XML has always substituted port
+            # This checks that the defined domain is using the proper inactive XML
+            wait(lambda: self.machine.execute(listCmd + " | grep \"type='vnc' port='-1'\""))
 
             return self
 


### PR DESCRIPTION
Previously we were using an XML we fetched once the virt-install
command finished. This was wrong since it was using the live XML
which can differ from the offline XML.

example: When the CPU type is chosen as 'host-model' libvirt will copy the host CPU
definition from capabilities XML into domain XML once the domain is started.
In that case the offline XML is different than the live XML.


This was reported by @yunmingyang, he plans to create a BZ for it. Also we need to add a test for this ideally as well. 