### PR TITLE
Add test for deleting an interface of a running VM

### DIFF
--- a/src/libvirt-dbus.js
+++ b/src/libvirt-dbus.js
@@ -1473,7 +1473,7 @@ export function detachIface(mac, connectionName, id, live, persistent) {
                 if (ifaceInactiveXML && persistent)
                     detachFlags |= Enum.VIR_DOMAIN_AFFECT_CONFIG;
 
-                return call(connectionName, id, 'org.libvirt.Domain', 'DetachDevice', [ifaceXML, detachFlags], { timeout, type: 'su' });
+                return call(connectionName, id, 'org.libvirt.Domain', 'DetachDevice', [(ifaceInactiveXML && persistent) ? ifaceInactiveXML : ifaceXML, detachFlags], { timeout, type: 'su' });
             })
             .then(() => getVm({ connectionName, id }));
 }

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -32,6 +32,12 @@ from machinesxmls import TEST_NETWORK_XML  # noqa
 
 @nondestructive
 class TestMachinesNICs(VirtualMachinesCase):
+    def deleteIface(self, iface):
+        b = self.browser
+
+        b.click("#delete-vm-subVmTest1-iface-{0}".format(iface))
+        b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Delete Network Interface")
+        b.click(".pf-c-modal-box__footer button:contains(Delete)")
 
     @no_retry_when_changed
     def testVmNICs(self):
@@ -79,6 +85,22 @@ class TestMachinesNICs(VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-network-3-source", "virbr0")
         b.wait_in_text("#vm-subVmTest1-network-3-ipv4-address", "192.168.122.")
 
+    def testNICDelete(self):
+        b = self.browser
+
+        args = self.createVm("subVmTest1")
+
+        self.login_and_go("/machines")
+        b.wait_in_text("body", "Virtual machines")
+        self.waitVmRow("subVmTest1")
+        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        wait(lambda: "login as 'cirros' user." in self.machine.execute("cat {0}".format(args["logfile"])), delay=3)
+        self.goToVmPage("subVmTest1")
+
+        self.deleteIface(1)
+        b.wait_not_present(".pf-c-modal-box")
+        b.wait_not_present("#vm-subVmTest1-network-1-mac")
+
     def testNICAdd(self):
         b = self.browser
         m = self.machine
@@ -89,7 +111,6 @@ class TestMachinesNICs(VirtualMachinesCase):
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual machines")
-
         # Shut off domain
         b.click("#vm-subVmTest1-action-kebab button")
         b.click("#vm-subVmTest1-forceOff")
@@ -169,9 +190,7 @@ class TestMachinesNICs(VirtualMachinesCase):
 
         # Now there are three NICs present - try to delete the second one and make sure that it's deleted and the dialog is not present anymore
         b.wait_visible("#vm-subVmTest1-network-3-mac")
-        b.click("#delete-vm-subVmTest1-iface-2")
-        b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Delete Network Interface")
-        b.click(".pf-c-modal-box__footer button:contains(Delete)")
+        self.deleteIface(2)
         # Check NIC is no longer in list
         b.wait_not_present("#vm-subVmTest1-network-3-mac")
         b.wait_not_present(".pf-c-modal-box")
@@ -253,6 +272,7 @@ class TestMachinesNICs(VirtualMachinesCase):
             self.browser = test_obj.browser
             self.machine = test_obj.machine
             self.assertEqual = test_obj.assertEqual
+            self.deleteIface = test_obj.deleteIface
 
             self.pixel_test_tag = pixel_test_tag
 
@@ -337,11 +357,8 @@ class TestMachinesNICs(VirtualMachinesCase):
                 self.browser.enter_page('/machines')
                 self.browser.wait_in_text("body", "Virtual machines")
             else:
-                self.browser.click("#delete-vm-subVmTest1-iface-{0}".format(self.nic_num))
-                # Confirm in confirmation window
-                self.browser.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Delete Network Interface")
+                self.deleteIface(self.nic_num)
                 vm_state = self.browser.text("#vm-subVmTest1-state")
-                self.browser.click(".pf-c-modal-box__footer button:contains(Delete)")
                 # On a running VM detaching NIC takes longer and we can see the spinner
                 if vm_state == "Running":
                     self.browser.wait_visible(".pf-c-modal-box__footer button.pf-m-in-progress")


### PR DESCRIPTION
This has regressed on RHEL-9- an unfortunately we did not have a test for this.

https://bugzilla.redhat.com/show_bug.cgi?id=1976945

Will add the naughty as well. 