### PR TITLE
Adding and removing VM's host devices

### DIFF
--- a/src/components/vm/hostdevs/hostDevAdd.jsx
+++ b/src/components/vm/hostdevs/hostDevAdd.jsx
@@ -1,0 +1,238 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import React, { useState, useEffect } from "react";
+import cockpit from "cockpit";
+import {
+    Table,
+    TableBody,
+    TableHeader,
+    TableVariant,
+} from '@patternfly/react-table';
+import {
+    Button,
+    DescriptionList,
+    Form,
+    FormGroup,
+    Modal,
+    Radio
+} from "@patternfly/react-core";
+
+import { ModalError } from "cockpit-components-inline-notification.jsx";
+import { domainAttachHostDevice, domainGet } from "../../../libvirtApi/domain.js";
+import { findHostNodeDevice } from "../../../helpers.js";
+import { getOptionalValue } from "./hostDevCard.jsx";
+import "./hostDevAdd.scss";
+
+const _ = cockpit.gettext;
+
+const TypeRow = ({ idPrefix, type, setType }) => {
+    return (
+        <FormGroup fieldId="usb_device"
+                   label={_("Type")}
+                   isInline
+                   hasNoPaddingTop>
+            <Radio id="usb_device"
+                   name="type"
+                   label={_("USB")}
+                   isChecked={type === "usb_device"}
+                   onChange={() => setType("usb_device")} />
+            <Radio id="pci"
+                   name="type"
+                   label={_("PCI")}
+                   isChecked={type === "pci"}
+                   onChange={() => setType("pci")} />
+        </FormGroup>
+    );
+};
+
+function devicesHaveAChild(selectableDevices) {
+    const all = {};
+
+    selectableDevices.forEach(item => {
+        all[item.name] = { ...item };
+        all[item.name].hasChildren = false;
+    });
+
+    Object.values(all).forEach(item => {
+        if (item.parent && item.parent !== "computer" && (item.capability.type === "usb_device" || item.capability.type === "pci")) {
+            all[item.parent].hasChildren = true;
+        }
+    });
+
+    return Object.values(all).sort(a => a.hasChildren ? 1 : -1);
+}
+
+const DevRow = ({ idPrefix, type, selectableDevices, setSelectableDevices }) => {
+    function getSource(nodeDev, id) {
+        const cells = [];
+        if (nodeDev.capability.type === "usb_device") {
+            const device = nodeDev.devnum;
+            const bus = nodeDev.busnum;
+
+            cells.push(getOptionalValue(device, `${id}-device`, _("Device")));
+            cells.push(getOptionalValue(bus, `${id}-bus`, _("Bus")));
+        } else if (nodeDev.capability.type === "pci") {
+            let domain = nodeDev.capability.domain;
+            let bus = nodeDev.capability.bus;
+            let slot = nodeDev.capability.slot;
+            let func = nodeDev.capability.function;
+
+            domain = domain.toString(16).padStart(4, '0');
+            bus = bus.toString(16).padStart(2, '0');
+            slot = slot.toString(16).padStart(2, '0');
+            func = func.toString(16).padStart(1, '0');
+
+            cells.push(getOptionalValue(`${domain}:${bus}:${slot}.${func}`, `${id}-slot`, _("Slot")));
+        }
+
+        return cells;
+    }
+
+    function onSelect(event, isSelected, rowId) {
+        let newDevs;
+        if (rowId === -1) {
+            newDevs = selectableDevices.map(oneRow => {
+                oneRow.selected = isSelected;
+                return oneRow;
+            });
+        } else {
+            newDevs = [...selectableDevices];
+            newDevs[rowId].selected = isSelected;
+        }
+
+        setSelectableDevices(newDevs);
+    }
+
+    return (
+        <FormGroup fieldId={`${idPrefix}-dev`} label={_("Device")} hasNoPaddingTop isInline>
+            <Table onSelect={onSelect}
+                   variant={TableVariant.compact}
+                   canSelectAll={false}
+                   className="vm-device-table"
+                   aria-label={_("Table of selectable host devices")}
+                   cells={[_("Product"), _("Vendor"), _("Location")]}
+                   rows={selectableDevices.map((dev, idx) => {
+                       return {
+                           selected: dev.selected, disableSelection: dev.nodeDev.hasChildren, cells: [
+                               dev.nodeDev.capability.product._value || "(" + _("Undefined") + ")",
+                               dev.nodeDev.capability.vendor._value,
+                               { title: <DescriptionList key='source' isHorizontal>{getSource(dev.nodeDev, idx)}</DescriptionList> }
+                           ]
+                       };
+                   })}>
+                <TableHeader />
+                <TableBody />
+            </Table>
+        </FormGroup>
+    );
+};
+
+function getSelectableDevices(nodeDevices, vm, type) {
+    const devicesNotAlreadyAttached = [];
+
+    const devicesWithCorrectType = nodeDevices.filter(dev => dev.capability && dev.capability.type === type);
+    devicesWithCorrectType.filter(dev => dev.capability && dev.capability.type === type).forEach(nodeDev => {
+        let deviceIsAlreadyAttached = false;
+
+        vm.hostDevices.forEach(hostDev => {
+            const foundNodeDevice = findHostNodeDevice(hostDev, nodeDevices);
+
+            if (foundNodeDevice && nodeDev.path === foundNodeDevice.path)
+                deviceIsAlreadyAttached = true;
+        });
+
+        if (!deviceIsAlreadyAttached)
+            devicesNotAlreadyAttached.push({ selected: false, nodeDev });
+    });
+
+    return devicesNotAlreadyAttached;
+}
+
+const AddHostDev = ({ idPrefix, vm, nodeDevices, close }) => {
+    const [type, setType] = useState("usb_device");
+    const [selectableDevices, setSelectableDevices] = useState([]);
+    const [dialogError, setDialogError] = useState("");
+    const [dialogErrorDetail, setDialogErrorDetail] = useState("");
+
+    const allDevices = devicesHaveAChild([...nodeDevices]);
+
+    useEffect(() => {
+        setSelectableDevices(getSelectableDevices(allDevices, vm, type));
+    }, []);
+
+    const setTypeWrapper = (newType) => {
+        setSelectableDevices(getSelectableDevices(allDevices, vm, newType));
+        setType(newType);
+    };
+
+    const attach = () => {
+        Promise.all(selectableDevices.map(device => {
+            if (device.selected)
+                return domainAttachHostDevice({ connectionName: vm.connectionName, vmName: vm.name, live: vm.state !== "shut off", dev: device.nodeDev });
+        }))
+                .then(() => {
+                    domainGet({ connectionName: vm.connectionName, id: vm.id });
+                    close();
+                })
+                .catch(exc => {
+                    setDialogError(_("Host device could not be attached"));
+                    setDialogErrorDetail(exc.message);
+                });
+    };
+
+    const body = (
+        <Form isHorizontal>
+            <TypeRow idPrefix={idPrefix} type={type} setType={setTypeWrapper} />
+            <DevRow idPrefix={idPrefix} type={type} selectableDevices={selectableDevices} setSelectableDevices={setSelectableDevices} />
+        </Form>
+    );
+
+    const footer = (
+        <>
+            {dialogError &&
+                <ModalError dialogError={dialogError}
+                            dialogErrorDetail={dialogErrorDetail} />}
+            <Button id={`${idPrefix}-attach`}
+                    variant="primary"
+                    onClick={attach}>
+                {_("Add")}
+            </Button>
+            <Button id={`${idPrefix}-cancel`}
+                    variant="link"
+                    className="btn-cancel"
+                    onClick={close}>
+                {_("Cancel")}
+            </Button>
+        </>
+    );
+
+    return (
+        <Modal position="top"
+               variant="medium"
+               id={`${idPrefix}-dialog`}
+               onClose={close}
+               title={_("Add host device")}
+               footer={footer}
+               isOpen>
+            {body}
+        </Modal>
+    );
+};
+
+export default AddHostDev;

--- a/src/components/vm/hostdevs/hostDevAdd.scss
+++ b/src/components/vm/hostdevs/hostDevAdd.scss
@@ -1,0 +1,12 @@
+@import "../../../lib/_global-variables.scss";
+
+.pf-c-table.vm-device-table {
+  /* Set overflow with a limiter on the list, so it scrolls instead of the dialog */
+  max-height: min(50vh, 50rem);
+  overflow: auto;
+
+  /* The list is used within a table; remove excess padding */
+  th {
+    --pf-c-table--m-compact-th--PaddingTop: 0;
+  }
+}

--- a/src/components/vm/hostdevs/hostDevCard.jsx
+++ b/src/components/vm/hostdevs/hostDevCard.jsx
@@ -34,24 +34,21 @@ const _ = cockpit.gettext;
 
 /* Adds an optional description-value pair to an array which represents multiple values of a table cell
  *
- * @param chunks an array into which element is added to
  * @param value a value of the descr-value pair
  * @param descr a description of the descr-value pair
  * @param id
  */
-function addOptionalToCell(chunks, value, id, descr) {
-    if (value) {
-        chunks.push(
-            <DescriptionListGroup key={descr}>
-                <DescriptionListTerm>
-                    {descr}
-                </DescriptionListTerm>
-                <DescriptionListDescription id={id}>
-                    {value}
-                </DescriptionListDescription>
-            </DescriptionListGroup>
-        );
-    }
+export function getOptionalValue(value, id, descr) {
+    return (
+        <DescriptionListGroup key={descr}>
+            <DescriptionListTerm>
+                {descr}
+            </DescriptionListTerm>
+            <DescriptionListDescription id={id}>
+                {value}
+            </DescriptionListDescription>
+        </DescriptionListGroup>
+    );
 }
 
 export const VmHostDevCard = ({ vm, nodeDevices, config }) => {
@@ -85,14 +82,14 @@ export const VmHostDevCard = ({ vm, nodeDevices, config }) => {
     }
 
     function getSource(hostDev, hostdevId) {
-        const cell = [];
+        const cells = [];
         const nodeDev = findHostNodeDevice(hostDev, nodeDevices);
         if (hostDev.type === "usb" && nodeDev) {
             const device = nodeDev.devnum;
             const bus = nodeDev.busnum;
 
-            addOptionalToCell(cell, device, `${hostdevId}-device`, _("Device"));
-            addOptionalToCell(cell, bus, `${hostdevId}-bus`, _("Bus"));
+            cells.push(getOptionalValue(device, `${hostdevId}-device`, _("Device")));
+            cells.push(getOptionalValue(bus, `${hostdevId}-bus`, _("Bus")));
         } else if (hostDev.type === "pci") {
             let domain = hostDev.source.address.domain.split('x')[1];
             let bus = hostDev.source.address.bus.split('x')[1];
@@ -104,40 +101,40 @@ export const VmHostDevCard = ({ vm, nodeDevices, config }) => {
             slot = String(slot).padStart(2, '0');
             func = String(func).padStart(1, '0');
 
-            addOptionalToCell(cell, `${domain}:${bus}:${slot}.${func}`, `${hostdevId}-slot`, _("Slot"));
+            cells.push(getOptionalValue(`${domain}:${bus}:${slot}.${func}`, `${hostdevId}-slot`, _("Slot")));
         } else if (hostDev.type === "scsi") {
             const bus = hostDev.source.address.bus;
             const target = hostDev.source.address.target;
             const unit = hostDev.source.address.lun;
 
-            addOptionalToCell(cell, bus, `${hostdevId}-bus`, _("Bus"));
-            addOptionalToCell(cell, unit, `${hostdevId}-unit`, _("Slot"));
-            addOptionalToCell(cell, target, `${hostdevId}-target`, _("Target"));
+            cells.push(getOptionalValue(bus, `${hostdevId}-bus`, _("Bus")));
+            cells.push(getOptionalValue(unit, `${hostdevId}-unit`, _("Slot")));
+            cells.push(getOptionalValue(target, `${hostdevId}-target`, _("Target")));
         } else if (hostDev.type === "scsi_host") {
             const protocol = hostDev.source.protocol;
             const wwpn = hostDev.source.wwpn;
 
-            addOptionalToCell(cell, protocol, `${hostdevId}-protocol`, _("Protocol"));
-            addOptionalToCell(cell, wwpn, `${hostdevId}-wwpn`, _("WWPN"));
+            cells.push(getOptionalValue(protocol, `${hostdevId}-protocol`, _("Protocol")));
+            cells.push(getOptionalValue(wwpn, `${hostdevId}-wwpn`, _("WWPN")));
         } else if (hostDev.type === "mdev") {
             const uuid = hostDev.source.address.uuid;
 
-            addOptionalToCell(cell, uuid, `${hostdevId}-uuid`, _("UUID"));
+            cells.push(getOptionalValue(uuid, `${hostdevId}-uuid`, _("UUID")));
         } else if (hostDev.type === "storage") {
             const block = hostDev.source.block;
 
-            addOptionalToCell(cell, block, `${hostdevId}-block`, _("Path"));
+            cells.push(getOptionalValue(block, `${hostdevId}-block`, _("Path")));
         } else if (hostDev.type === "misc") {
             const ch = hostDev.source.char;
 
-            addOptionalToCell(cell, ch, `${hostdevId}-char`, _("Path"));
+            cells.push(getOptionalValue(ch, `${hostdevId}-char`, _("Path")));
         } else if (hostDev.type === "net") {
             const iface = hostDev.source.interface;
 
-            addOptionalToCell(cell, iface, `${hostdevId}-interface`, _("Interface"));
+            cells.push(getOptionalValue(iface, `${hostdevId}-interface`, _("Interface")));
         }
 
-        return <DescriptionList isHorizontal>{cell}</DescriptionList>;
+        return <DescriptionList isHorizontal>{cells}</DescriptionList>;
     }
 
     const id = vmId(vm.name);

--- a/src/components/vm/hostdevs/hostDevCard.jsx
+++ b/src/components/vm/hostdevs/hostDevCard.jsx
@@ -16,10 +16,11 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import {
+    Button,
     DescriptionList,
     DescriptionListTerm,
     DescriptionListGroup,
@@ -29,8 +30,29 @@ import {
 import cockpit from 'cockpit';
 import { vmId, findHostNodeDevice } from "../../../helpers.js";
 import { ListingTable } from "cockpit-components-table.jsx";
+import AddHostDev from "./hostDevAdd.jsx";
 
 const _ = cockpit.gettext;
+
+export const VmHostDevActions = ({ vm, nodeDevices }) => {
+    const [showAttachModal, setShowAttachModal] = useState(false);
+
+    const idPrefix = `${vmId(vm.name)}-hostdevs`;
+
+    return (
+        <>
+            <Button id={`${idPrefix}-add`} variant='secondary' onClick={() => setShowAttachModal(true)}>
+                {_("Add host device")}
+            </Button>
+            {showAttachModal &&
+                <AddHostDev close={() => setShowAttachModal(false)}
+                            idPrefix={idPrefix}
+                            vm={vm}
+                            nodeDevices={nodeDevices} />
+            }
+        </>
+    );
+};
 
 /* Adds an optional description-value pair to an array which represents multiple values of a table cell
  *

--- a/src/components/vm/vmDetailsPage.jsx
+++ b/src/components/vm/vmDetailsPage.jsx
@@ -37,7 +37,7 @@ import { vmId } from "../../helpers.js";
 import { VmFilesystemsCard, VmFilesystemActions } from './filesystems/vmFilesystemsCard.jsx';
 import { VmDisksCardLibvirt, VmDisksActions } from './disks/vmDisksCard.jsx';
 import { VmNetworkTab, VmNetworkActions } from './nics/vmNicsCard.jsx';
-import { VmHostDevCard } from './hostdevs/hostDevCard.jsx';
+import { VmHostDevCard, VmHostDevActions } from './hostdevs/hostDevCard.jsx';
 import Consoles from './consoles/consoles.jsx';
 import VmOverviewCard from './overview/vmOverviewCard.jsx';
 import VmUsageTab from './vmUsageCard.jsx';
@@ -152,6 +152,7 @@ export const VmDetailsPage = ({
             id: `${vmId(vm.name)}-hostdevs`,
             className: "hostdevs-card",
             title: _("Host devices"),
+            actions: <VmHostDevActions vm={vm} nodeDevices={nodeDevices} />,
             body: <VmHostDevCard vm={vm} nodeDevices={nodeDevices} config={config} />,
         }
     ];

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -855,3 +855,28 @@ export function getNextAvailableTarget(existingTargets, busType) {
         i++;
     }
 }
+
+export function getNodeDevSource(dev) {
+    let source;
+
+    if (dev.capability.type === "pci") {
+        let domain = Number(dev.capability.domain);
+        let bus = Number(dev.capability.bus);
+        let slot = Number(dev.capability.slot);
+        let func = Number(dev.capability.function);
+
+        domain = domain.toString(16).padStart(4, '0');
+        bus = bus.toString(16).padStart(2, '0');
+        slot = slot.toString(16).padStart(2, '0');
+        func = func.toString(16).padStart(1, '0');
+
+        source = `${domain}:${bus}:${slot}.${func}`;
+    } else if (dev.capability.type === "usb_device") {
+        const device = dev.devnum;
+        const bus = dev.busnum;
+
+        source = `${bus}.${device}`;
+    }
+
+    return source;
+}

--- a/src/libvirt-xml-parse.js
+++ b/src/libvirt-xml-parse.js
@@ -795,6 +795,8 @@ export function parseNodeDeviceDumpxml(nodeDevice) {
     const name = deviceElem.getElementsByTagName("name")[0].childNodes[0].nodeValue;
     const pathElem = getSingleOptionalElem(deviceElem, 'path');
     const path = pathElem ? pathElem.childNodes[0].nodeValue : undefined;
+    const parentElem = getSingleOptionalElem(deviceElem, 'parent');
+    const parentName = parentElem ? parentElem.childNodes[0].nodeValue : undefined;
     const capabilityElem = deviceElem.getElementsByTagName("capability")[0];
 
     const capability = {};
@@ -871,7 +873,7 @@ export function parseNodeDeviceDumpxml(nodeDevice) {
             capability.uuid = uuidElem.childNodes[0] ? uuidElem.childNodes[0].nodeValue : undefined;
     }
 
-    return { name, path, capability };
+    return { name, path, parent: parentName, capability };
 }
 
 export function parseStoragePoolDumpxml(connectionName, storagePoolXml, id_overwrite) {

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -468,6 +468,18 @@ export function domainDetachDisk({
             });
 }
 
+export function domainDetachHostDevice({ connectionName, vmName, live, dev }) {
+    const source = getNodeDevSource(dev);
+    const args = ["virt-xml", "-c", `qemu:///${connectionName}`, vmName, "--remove-device", "--hostdev", source];
+    if (live)
+        args.push("--update");
+
+    return cockpit.spawn(
+        args,
+        { superuser: "try", err: "message" }
+    );
+}
+
 export function domainDetachIface({ connectionName, mac, vmName, live, persistent }) {
     const options = { err: "message" };
     if (connectionName === "system")

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -53,6 +53,7 @@ import {
     convertToUnit,
     DOMAINSTATE,
     fileDownload,
+    getNodeDevSource,
     logDebug,
     units,
 } from '../helpers.js';
@@ -133,6 +134,18 @@ export function domainAttachDisk({
     const xmlDesc = getDiskXML(type, file, device, poolName, volumeName, format, target, cacheMode, shareable, busType);
 
     return domainAttachDevice({ connectionName, vmId, permanent, hotplug, xmlDesc });
+}
+
+export function domainAttachHostDevice({ connectionName, vmName, live, dev }) {
+    const source = getNodeDevSource(dev);
+    const args = ["virt-xml", "-c", `qemu:///${connectionName}`, vmName, "--add-device", "--hostdev", source];
+    if (live)
+        args.push("--update");
+
+    return cockpit.spawn(
+        args,
+        { superuser: "try", err: "message" }
+    );
 }
 
 export function domainAttachIface({ connectionName, vmName, mac, permanent, hotplug, sourceType, source, model }) {

--- a/test/check-machines-hostdevs
+++ b/test/check-machines-hostdevs
@@ -107,7 +107,7 @@ class TestMachinesHostDevs(VirtualMachinesCase):
 
         class HostDevAddDialog(object):
             def __init__(
-                self, test_obj, dev_type="usb_device", dev_id=0, vm_dev_id=1, fail_message=None
+                self, test_obj, dev_type="usb_device", dev_id=0, vm_dev_id=1, remove=True, fail_message=None
             ):
                 self.test_obj = test_obj
                 self.dev_type = dev_type
@@ -124,6 +124,8 @@ class TestMachinesHostDevs(VirtualMachinesCase):
                 if not self.fail_message:
                     self.verify()
                     self.verify_backend()
+                    if self.remove:
+                        self.remove()
 
             def open(self):
                 b.wait_not_present("#vm-subVmTest1-hostdev-{0}-product".format(self.vm_dev_id))
@@ -189,12 +191,16 @@ class TestMachinesHostDevs(VirtualMachinesCase):
 
                 raise Exception("Verification failed. No matching node device was found in VM's xml.")
 
+            def remove(self):
+                b.click("#delete-vm-subVmTest1-hostdev-{0}".format(self.vm_dev_id))
+                b.click('.pf-c-modal-box__footer button:contains("Remove")')
+                b.wait_not_present("#vm-subVmTest1-hostdev-{0}-product".format(self.vm_dev_id))
+
         output = m.execute("virsh nodedev-list --cap usb_device")
         if output.strip() != "":
             HostDevAddDialog(
                 self,
                 dev_type="usb_device",
-                vm_dev_id=1
             ).execute()
 
         output = m.execute("virsh nodedev-list --cap pci")
@@ -202,7 +208,6 @@ class TestMachinesHostDevs(VirtualMachinesCase):
             HostDevAddDialog(
                 self,
                 dev_type="pci",
-                vm_dev_id=2
             ).execute()
 
         m.execute("mv /usr/bin/virt-xml /tmp/virt-xml")

--- a/test/check-machines-hostdevs
+++ b/test/check-machines-hostdevs
@@ -20,6 +20,7 @@
 import os
 import sys
 import subprocess
+import re
 
 # import Cockpit's machinery for test VMs and its browser test API
 TEST_DIR = os.path.dirname(__file__)
@@ -29,6 +30,10 @@ sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
 from machineslib import VirtualMachinesCase  # noqa
 from testlib import nondestructive, test_main  # noqa
 from machinesxmls import USB_HOSTDEV, PCI_HOSTDEV  # noqa
+
+virt_xml_mock = """#!/usr/bin/python
+
+raise Exception("Mock error message")"""
 
 
 @nondestructive
@@ -84,6 +89,131 @@ class TestMachinesHostDevs(VirtualMachinesCase):
             pass
 
         b.wait_in_text("#vm-subVmTest1-hostdev-1-source #1-slot", "0000:00:0f.0")
+
+    def testHostDevAdd(self):
+        b = self.browser
+        m = self.machine
+
+        self.createVm("subVmTest1")
+
+        self.login_and_go("/machines")
+        b.wait_in_text("body", "Virtual machines")
+
+        self.goToVmPage("subVmTest1")
+        b.wait_visible("#vm-subVmTest1-hostdevs")
+
+        # Shut off domain
+        self.performAction("subVmTest1", "forceOff")
+
+        class HostDevAddDialog(object):
+            def __init__(
+                self, test_obj, dev_type="usb_device", dev_id=0, vm_dev_id=1, fail_message=None
+            ):
+                self.test_obj = test_obj
+                self.dev_type = dev_type
+                self.dev_id = dev_id
+                self.vm_dev_id = vm_dev_id
+                self._vendor = None
+                self._model = None
+                self.fail_message = fail_message
+
+            def execute(self):
+                self.open()
+                self.fill()
+                self.add()
+                if not self.fail_message:
+                    self.verify()
+                    self.verify_backend()
+
+            def open(self):
+                b.wait_not_present("#vm-subVmTest1-hostdev-{0}-product".format(self.vm_dev_id))
+                b.click("button#vm-subVmTest1-hostdevs-add")
+                b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Add host device")
+                b.assert_pixels(".pf-c-modal-box", "vm-hostdevs-add-dialog")
+
+            def fill(self):
+                b.click("input#{0}".format(self.dev_type))
+                b.set_checked(".pf-c-table input[name='checkrow{0}']".format(self.dev_id), True)
+                self._model = b.text("#vm-subVmTest1-hostdevs-dialog table tbody tr:nth-child({0}) td:nth-child(2)".format(self.dev_id + 1))
+                self._vendor = b.text("#vm-subVmTest1-hostdevs-dialog table tbody tr:nth-child({0}) td:nth-child(3)".format(self.dev_id + 1))
+                if self.dev_type == "pci":
+                    self._slot = b.text("#vm-subVmTest1-hostdevs-dialog table tbody tr:nth-child({0}) td:nth-child(4) dd".format(self.dev_id + 1))
+
+            def cancel(self):
+                b.click(".pf-c-modal-box__footer button:contains(Cancel)")
+                b.wait_not_present("#vm-subVmTest1-hostdevs-dialog")
+
+            def add(self):
+                m.execute("virsh dumpxml subVmTest1 > /tmp/vmxml1")
+                b.click(".pf-c-modal-box__footer button:contains(Add)")
+                if self.fail_message:
+                    b.wait_in_text(".pf-c-modal-box__footer .pf-c-alert__title", self.fail_message)
+                    b.click(".pf-c-modal-box__footer button:contains(Cancel)")
+                b.wait_not_present("#vm-subVmTest1-hostdevs-dialog")
+
+            def verify(self):
+                b.wait_visible("#vm-subVmTest1-hostdev-{0}-product".format(self.vm_dev_id))
+                b.wait_in_text("#vm-subVmTest1-hostdev-{0}-product".format(self.vm_dev_id), self._model)
+                b.wait_in_text("#vm-subVmTest1-hostdev-{0}-vendor".format(self.vm_dev_id), self._vendor)
+
+            def verify_backend(self):
+                m.execute("virsh dumpxml subVmTest1 > /tmp/vmxml2")
+                m.execute("diff /tmp/vmxml1 /tmp/vmxml2 | sed -e 's/^>//;1d' > /tmp/vmdiff")
+
+                if self.dev_type == "usb_device":
+                    vendor_id = m.execute("cat /tmp/vmdiff | xmllint --xpath 'string(//hostdev/source/vendor/@id)' - 2>&1 || true").strip()
+                    product_id = m.execute("cat /tmp/vmdiff | xmllint --xpath 'string(//hostdev/source/product/@id)' - 2>&1 || true").strip()
+
+                    output = m.execute("virsh nodedev-list --cap {0}".format(self.dev_type))
+                    devices = output.splitlines()
+                    devices = list(filter(None, devices))
+                    for dev in devices:
+                        if self.dev_type == "usb_device":
+                            m.execute("virsh nodedev-dumpxml --device {0} > /tmp/nodedevxml".format(dev))
+                            vendor = m.execute("cat /tmp/nodedevxml | xmllint --xpath 'string(//device/capability/vendor[starts-with(@id, \"{0}\")])' - 2>&1 || true".format(vendor_id))
+                            product = m.execute("cat /tmp/nodedevxml | xmllint --xpath 'string(//device/capability/product[starts-with(@id, \"{0}\")])' - 2>&1 || true".format(product_id))
+
+                            if vendor.strip() == self._vendor and product.strip() == self._model:
+                                return
+
+                elif self.dev_type == "pci":
+                    domain = int(m.execute("cat /tmp/vmdiff | xmllint --xpath 'string(//hostdev/source/address/@domain)' - 2>&1 || true"), base=16)
+                    bus = int(m.execute("cat /tmp/vmdiff | xmllint --xpath 'string(//hostdev/source/address/@bus)' - 2>&1 || true"), base=16)
+                    slot = int(m.execute("cat /tmp/vmdiff | xmllint --xpath 'string(//hostdev/source/address/@slot)' - 2>&1 || true"), base=16)
+                    func = int(m.execute("cat /tmp/vmdiff | xmllint --xpath 'string(//hostdev/source/address/@function)' - 2>&1 || true"), base=16)
+
+                    slot_parts = re.split(r":|\.", self._slot)
+
+                    if int(slot_parts[0]) == domain and int(slot_parts[1]) == bus and int(slot_parts[2]) == slot and int(slot_parts[3]) == func:
+                        return
+
+                raise Exception("Verification failed. No matching node device was found in VM's xml.")
+
+        output = m.execute("virsh nodedev-list --cap usb_device")
+        if output.strip() != "":
+            HostDevAddDialog(
+                self,
+                dev_type="usb_device",
+                vm_dev_id=1
+            ).execute()
+
+        output = m.execute("virsh nodedev-list --cap pci")
+        if output.strip() != "":
+            HostDevAddDialog(
+                self,
+                dev_type="pci",
+                vm_dev_id=2
+            ).execute()
+
+        m.execute("mv /usr/bin/virt-xml /tmp/virt-xml")
+        m.execute("echo '{0}' > /usr/bin/virt-xml".format(virt_xml_mock))
+        m.execute("chmod 777 /usr/bin/virt-xml")
+        HostDevAddDialog(
+            self,
+            dev_type="pci",
+            fail_message="Host device could not be attached",
+        ).execute()
+        m.execute("mv /tmp/virt-xml /usr/bin/virt-xml")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Machines: Support adding and removing host devices

Host devices are physical devices of the host. This includes PCI (for example NICs, GPUs), and USB (for example mice, cameras, and keyboards) types. Users can now assign host USB and PCI devices to a VM and also detach them again. When a device is assigned to a VM it can on longer be used by the host.

![Screen Shot 2021-09-24 at 09 14 34](https://user-images.githubusercontent.com/14921356/134633722-9e8628ba-4f6a-46d5-b00c-59adc7425a11.png)
![Screen Shot 2021-09-24 at 09 13 48](https://user-images.githubusercontent.com/14921356/134633726-e19245fa-cf15-48d2-a4ff-a7529c41c461.png)
