### PR TITLE
Fix false submission in dialog's form

### DIFF
--- a/src/components/vm/disks/diskAdd.jsx
+++ b/src/components/vm/disks/diskAdd.jsx
@@ -549,7 +549,7 @@ export class AddDiskModalBody extends React.Component {
             defaultBody = <Spinner isSVG />;
         } else {
             defaultBody = (
-                <Form isHorizontal>
+                <Form onSubmit={e => e.preventDefault()} isHorizontal>
                     <FormGroup fieldId={`${idPrefix}-source`}
                                label={_("Source")} isInline hasNoPaddingTop>
                         <Radio id={`${idPrefix}-createnew`}

--- a/src/components/vm/nics/nicAdd.jsx
+++ b/src/components/vm/nics/nicAdd.jsx
@@ -131,7 +131,7 @@ export class AddNIC extends React.Component {
         const { idPrefix, vm } = this.props;
 
         const defaultBody = (
-            <Form isHorizontal>
+            <Form onSubmit={e => e.preventDefault()} isHorizontal>
                 <NetworkTypeAndSourceRow idPrefix={idPrefix}
                                          dialogValues={this.state}
                                          onValueChanged={this.onValueChanged}

--- a/src/components/vm/nics/nicEdit.jsx
+++ b/src/components/vm/nics/nicEdit.jsx
@@ -140,7 +140,7 @@ export class EditNICModal extends React.Component {
         const { idPrefix, vm, network } = this.props;
 
         const defaultBody = (
-            <Form isHorizontal>
+            <Form onSubmit={e => e.preventDefault()} isHorizontal>
                 <NetworkTypeAndSourceRow idPrefix={idPrefix}
                                          dialogValues={this.state}
                                          onValueChanged={this.onValueChanged}

--- a/src/components/vm/snapshots/vmSnapshotsCreateModal.jsx
+++ b/src/components/vm/snapshots/vmSnapshotsCreateModal.jsx
@@ -124,7 +124,7 @@ export class CreateSnapshotModal extends React.Component {
         const validationError = this.onValidate(submitted);
 
         const body = (
-            <Form isHorizontal>
+            <Form onSubmit={e => e.preventDefault()} isHorizontal>
                 <NameRow name={name} validationError={validationError} onValueChanged={this.onValueChanged} />
                 <DescriptionRow description={description} onValueChanged={this.onValueChanged} />
             </Form>

--- a/src/components/vm/vmCloneDialog.jsx
+++ b/src/components/vm/vmCloneDialog.jsx
@@ -76,7 +76,11 @@ export const CloneDialog = ({ name, connectionName, toggleModal }) => {
                    </Button>
                </>
            }>
-            <Form isHorizontal>
+            <Form onSubmit={e => {
+                e.preventDefault();
+                onClone();
+            }}
+            isHorizontal>
                 <FormGroup label={_("Name")} fieldId="vm-name"
                            id="vm-name-group"
                            helperTextInvalid={validationFailed.name}

--- a/src/components/vm/vmMigrateDialog.jsx
+++ b/src/components/vm/vmMigrateDialog.jsx
@@ -156,7 +156,7 @@ export const MigrateDialog = ({ vm, connectionName, toggleModal }) => {
     }
 
     const body = (
-        <Form isHorizontal>
+        <Form onSubmit={e => e.preventDefault()} isHorizontal>
             <DestUriRow destUri={destUri}
                         setDestUri={setDestUri}
                         validationFailed={validationFailed} />


### PR DESCRIPTION
If you open a modal, select a text input and then press enter, a form
submission is trigerred, which leads to a page reloading.

Fixes #161