### PR TITLE
fmf: Clean up broken stub epel repo

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -17,6 +17,8 @@ chmod a+w "$LOGS"
 if ! rpm -q chromium; then
     if grep -q 'ID=.*rhel' /etc/os-release; then
         # There is no EPEL for RHEL 9 yet, force 8
+        # RHEL 9 has a broken stub epel.repo
+        rm -f /etc/yum.repos.d/epel.repo
         dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
         sed -i 's/$releasever/8/' /etc/yum.repos.d/epel*.repo
         dnf config-manager --enable epel


### PR DESCRIPTION
Current RHEL 9 Testing Farm instances have a broken and mostly empty
epel.repo file. Clean it up before installing the real epel-release rpm,
otherwise that rpm won't overwrite the stub.

----

Tested in 1minutetip, spotted by downstream gating test.