### PR TITLE
Don't round or floor memory and storage size values unless they are not consumed by virt-install

### DIFF
--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -750,7 +750,7 @@ class CreateVmModal extends React.Component {
             unattendedInstallation: false,
             source: '',
             os: undefined,
-            memorySize: props.nodeMaxMemory ? Math.min(1, Math.floor(convertToUnit(props.nodeMaxMemory, units.KiB, units.GiB))) : 1,
+            memorySize: props.nodeMaxMemory ? Math.min(1, convertToUnit(props.nodeMaxMemory, units.KiB, units.GiB)) : 1,
             memorySizeUnit: units.GiB.name,
             storageSize: convertToUnit(10 * 1024, units.MiB, units.GiB), // tied to Unit
             storageSizeUnit: units.GiB.name,
@@ -833,13 +833,13 @@ class CreateVmModal extends React.Component {
         case 'memorySizeUnit':
             this.setState({ [key]: value });
             key = 'memorySize';
-            value = Math.round(convertToUnit(this.state.memorySize, this.state.memorySizeUnit, value));
+            value = convertToUnit(this.state.memorySize, this.state.memorySizeUnit, value);
             this.setState({ [key]: value });
             break;
         case 'storageSizeUnit':
             this.setState({ [key]: value });
             key = 'storageSize';
-            value = Math.round(convertToUnit(this.state.storageSize, this.state.storageSizeUnit, value));
+            value = convertToUnit(this.state.storageSize, this.state.storageSizeUnit, value);
             this.setState({ [key]: value });
             break;
         case 'startVm': {
@@ -870,7 +870,7 @@ class CreateVmModal extends React.Component {
 
                 const converted = convertToUnit(stateDelta.minimumMemory, units.B, units.GiB);
                 if (converted == 0 || converted % 1 !== 0) // If minimum memory is not a whole number in GiB, set value in MiB
-                    this.setState({ memorySizeUnit: units.MiB.name }, () => this.onValueChanged("memorySize", Math.floor(convertToUnit(stateDelta.minimumMemory, units.B, units.MiB))));
+                    this.setState({ memorySizeUnit: units.MiB.name }, () => this.onValueChanged("memorySize", convertToUnit(stateDelta.minimumMemory, units.B, units.MiB)));
                 else
                     this.setState({ memorySizeUnit: units.GiB.name }, () => this.onValueChanged("memorySize", converted));
             }
@@ -880,7 +880,7 @@ class CreateVmModal extends React.Component {
 
                 const converted = convertToUnit(stateDelta.minimumStorage, units.B, this.state.storageSizeUnit);
                 if (converted == 0 || converted % 1 !== 0) // If minimum storage is not a whole number in GiB, set value in MiB
-                    this.setState({ storageSizeUnit: units.MiB.name }, () => this.onValueChanged("storageSize", Math.floor(convertToUnit(stateDelta.minimumStorage, units.B, units.MiB))));
+                    this.setState({ storageSizeUnit: units.MiB.name }, () => this.onValueChanged("storageSize", convertToUnit(stateDelta.minimumStorage, units.B, units.MiB)));
                 else
                     this.setState({ storageSizeUnit: units.GiB.name }, () => this.onValueChanged("storageSize", converted));
             }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -32,7 +32,7 @@ export function toReadableNumber(number) {
     if (number < 1) {
         return Math.floor(number * 100) / 100;
     } else {
-        const fixed1 = Math.floor((number * 10) / 10);
+        const fixed1 = Math.floor(number * 10) / 10;
         return (number - fixed1 === 0) ? Math.floor(number) : fixed1;
     }
 }

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -92,6 +92,9 @@ class TestMachinesCreate(VirtualMachinesCase):
         # check that newer oses are present and searchable with substring match
         runner.checkFilteredOsTest(TestMachinesCreate.VmDialog(self, os_name=config.WINDOWS_SERVER_10, os_search_name=config.WINDOWS_SERVER_10_SHORT))
 
+        # Memory unit conversion
+        runner.memoryUnitConversionTest(TestMachinesCreate.VmDialog(self, sourceType='disk-image'))
+
         # try to CREATE WITH DIALOG ERROR
         # name
         runner.checkDialogFormValidationTest(TestMachinesCreate.VmDialog(self, "", storage_size=1), {"vm-name": "Name must not be empty"})
@@ -719,6 +722,16 @@ class TestMachinesCreate(VirtualMachinesCase):
 
             return self
 
+        def checkMemoryUnitConversion(self):
+            b = self.browser
+
+            b.select_from_dropdown("#memory-size-unit-select", "MiB")
+            b.set_input_text("#memory-size", "128")
+            b.select_from_dropdown("#memory-size-unit-select", "GiB")
+            b.wait_val("#memory-size", "0.125")
+
+            return self
+
         def checkOsInput(self):
             b = self.browser
 
@@ -1313,6 +1326,11 @@ class TestMachinesCreate(VirtualMachinesCase):
                 .cancel(True)
             self._assertScriptFinished() \
                 .checkEnvIsEmpty()
+
+        def memoryUnitConversionTest(self, dialog):
+            dialog.open() \
+                .checkMemoryUnitConversion() \
+                .cancel(True)
 
         def checkFilteredOsTest(self, dialog):
             dialog.open() \


### PR DESCRIPTION
Let's use toReadableNumber function only when the number is presented
in a helper text, and not consumed by our scripts.

Relevant to https://bugzilla.redhat.com/show_bug.cgi?id=1979152