### PR TITLE
Convert from moment to date-fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@patternfly/react-core": "4.135.15",
     "@patternfly/react-styles": "4.11.0",
     "@patternfly/react-table": "4.29.0",
-    "moment": "2.29.1",
+    "date-fns": "2.22.1",
     "patternfly": "3.59.5",
     "patternfly-react": "2.39.17",
     "prop-types": "15.7.2",

--- a/src/components/vm/snapshots/vmSnapshotsCard.jsx
+++ b/src/components/vm/snapshots/vmSnapshotsCard.jsx
@@ -17,10 +17,9 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 import React from 'react';
-import moment from "moment";
 
 import cockpit from 'cockpit';
-import { vmId } from "../../../helpers.js";
+import { vmId, localize_datetime } from "../../../helpers.js";
 import { CreateSnapshotModal } from "./vmSnapshotsCreateModal.jsx";
 import { ListingTable } from "cockpit-components-table.jsx";
 import { Button, Tooltip } from '@patternfly/react-core';
@@ -32,20 +31,6 @@ import { deleteSnapshot, getVmSnapshots } from '../../../libvirt-dbus.js';
 import './vmSnapshotsCard.scss';
 
 const _ = cockpit.gettext;
-
-function prettyTime(unixTime) {
-    const yesterday = _("Yesterday");
-    const today = _("Today");
-    moment.locale(cockpit.language, {
-        calendar : {
-            lastDay : `[${yesterday}] LT`,
-            sameDay : `[${today}] LT`,
-            sameElse : "L LT"
-        }
-    });
-
-    return moment(Number(unixTime) * 1000).calendar();
-}
 
 export class VmSnapshotsActions extends React.Component {
     constructor(props) {
@@ -98,7 +83,7 @@ export class VmSnapshotsCard extends React.Component {
         let detailMap = [
             {
                 name: _("Creation time"), value: (snap, snapId) => {
-                    const date = prettyTime(snap.creationTime);
+                    const date = localize_datetime(snap.creationTime * 1000);
                     return (<div className="snap-creation-time">
                         <div id={`${id}-snapshot-${snapId}-date`}>
                             {date}

--- a/src/components/vm/snapshots/vmSnapshotsCreateModal.jsx
+++ b/src/components/vm/snapshots/vmSnapshotsCreateModal.jsx
@@ -62,8 +62,11 @@ const DescriptionRow = ({ onValueChanged, description }) => {
 export class CreateSnapshotModal extends React.Component {
     constructor(props) {
         super(props);
+        // cut off seconds, subseconds, and timezone
+        const now = new Date().toISOString()
+                .replace(/:[^:]*$/, '');
         this.state = {
-            name: props.vm.name + '_' + moment().format("YYYY-MM-DD_hh:mma"),
+            name: props.vm.name + '_' + now,
             description: "",
             validationError: {},
             inProgress: false,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -16,6 +16,10 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
+
+import * as dfnlocales from 'date-fns/locale';
+import { formatRelative } from 'date-fns';
+
 import cockpit from 'cockpit';
 import VMS_CONFIG from './config.js';
 
@@ -35,6 +39,11 @@ export function toReadableNumber(number) {
         const fixed1 = Math.floor((number * 10) / 10);
         return (number - fixed1 === 0) ? Math.floor(number) : fixed1;
     }
+}
+
+export function localize_datetime(time) {
+    const locale = (cockpit.language == "en") ? dfnlocales.enUS : dfnlocales[cockpit.language.replace('_', '')];
+    return formatRelative(time, Date.now(), { locale });
 }
 
 export const diskCacheModes = ['default', 'none', 'writethrough', 'writeback', 'directsync', 'unsafe'];

--- a/test/check-machines-snapshots
+++ b/test/check-machines-snapshots
@@ -39,8 +39,8 @@ class TestMachinesSnapshots(VirtualMachinesCase):
     def testSnapshots(self):
         # Checks if difference of @time1 and @time2 is not greater than @difference (in seconds)
         def checkTimeDiff(time1, time2, difference):
-            tmp = time2.split(' ')  # split "Today 13:13:13" into day and time
-            if not tmp[1].startswith('00:') and not tmp[0] == "Today":
+            tmp = time2.split(' ')  # split "today at 13:13:13" into day and time
+            if not tmp[2].startswith('00:') and not tmp[0] == "today":
                 return False
 
             diff = datetime.strptime(time1, '%H:%M:%S') - datetime.strptime("".join(tmp[-2:]), '%I:%M%p')


### PR DESCRIPTION
Steal and slightly adjust localize_datetime() from c-podman, and replace
the custom prettyTime() that used the deprecated moment. This fixes
translated times, and avoids our project specific translations of
"Today" and "Yesterday".

Change snapshot creation default name from moment to Date.toISOFormat()
(with stripping off seconds). This is reasonably similar.

-----

Create snapshot dialog and list on main (note the wrong time format -- it's in English, but locale is German):
![main-create-snapshot](https://user-images.githubusercontent.com/200109/125910376-a8f0b469-2f40-4602-8d1f-ab46fb9116fc.png)
![main-list-snapshot](https://user-images.githubusercontent.com/200109/125910384-37f3cdae-97f8-4484-bef7-02707c586bd4.png)

The same with this PR:
![pr-create-snapshot](https://user-images.githubusercontent.com/200109/125910408-b9d52d58-293e-4c22-8184-204e5244fa46.png)
![pr-list-snapshot-de](https://user-images.githubusercontent.com/200109/125910413-243a52b1-b56c-45b9-bcfb-8db65a53ddef.png)

Also looks correct in English:
![pr-list-snapshot-en](https://user-images.githubusercontent.com/200109/125910432-4a44ff1a-1e26-4165-974f-d42ea71a59d6.png)
