### PR TITLE
Fix "current snapshot" icon

### DIFF
--- a/src/components/vm/snapshots/vmSnapshotsCard.jsx
+++ b/src/components/vm/snapshots/vmSnapshotsCard.jsx
@@ -22,8 +22,8 @@ import cockpit from 'cockpit';
 import { vmId, localize_datetime } from "../../../helpers.js";
 import { CreateSnapshotModal } from "./vmSnapshotsCreateModal.jsx";
 import { ListingTable } from "cockpit-components-table.jsx";
-import { Button, Tooltip } from '@patternfly/react-core';
-import { InfoAltIcon } from '@patternfly/react-icons';
+import { Button, Tooltip, Flex, FlexItem } from '@patternfly/react-core';
+import { CheckIcon, InfoAltIcon } from '@patternfly/react-icons';
 import { DeleteResourceButton, DeleteResourceModal } from '../../common/deleteResource.jsx';
 import { RevertSnapshotModal } from './vmSnapshotsRevertModal.jsx';
 import { deleteSnapshot, getVmSnapshots } from '../../../libvirt-dbus.js';
@@ -84,14 +84,14 @@ export class VmSnapshotsCard extends React.Component {
             {
                 name: _("Creation time"), value: (snap, snapId) => {
                     const date = localize_datetime(snap.creationTime * 1000);
-                    return (<div className="snap-creation-time">
-                        <div id={`${id}-snapshot-${snapId}-date`}>
+                    return (<Flex className="snap-creation-time">
+                        <FlexItem id={`${id}-snapshot-${snapId}-date`} spacer={{ default: 'spacerSm' }}>
                             {date}
-                        </div>
-                        { snap.isCurrent && <Tooltip content={_("Current")}>
-                            <i id={`${id}-snapshot-${snapId}-current`} className="pficon pficon-ok" />
-                        </Tooltip> }
-                    </div>);
+                        </FlexItem>
+                        { snap.isCurrent && <FlexItem><Tooltip content={_("Current")}>
+                            <CheckIcon id={`${id}-snapshot-${snapId}-current`} />
+                        </Tooltip></FlexItem> }
+                    </Flex>);
                 }
             },
             {

--- a/src/components/vm/snapshots/vmSnapshotsCard.scss
+++ b/src/components/vm/snapshots/vmSnapshotsCard.scss
@@ -6,6 +6,7 @@
     padding: .5rem
 }
 
-.snap-creation-time {
-    display: flex;
+// CheckIcon is black by default
+.snap-creation-time svg {
+    color: var(--pf-global--palette--green-300);
 }


### PR DESCRIPTION
The icon was broken at least in some cases. Replace it with CheckIcon,
and wrap it in Flex to get a reasonable spacing.

----

 - [x] Rebase after #257 (collision due to code proximity)

On main it looks like that for me:

![main-list-snapshot](https://user-images.githubusercontent.com/200109/125915538-1857bd89-fcb1-45ac-b924-74596b045ab4.png)

With this fix:

![current-snapshot-pr](https://user-images.githubusercontent.com/200109/125915571-a07a06be-2278-4680-acdc-5f2dc0aa0387.png)

(ignore the "today at", that is the change from #257 -- the PRs will collide, but it's a separate change)