### PR TITLE
Revert "fmf: Only run a subset of tests on RHEL 9"

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -25,10 +25,17 @@ export TEST_AUDIT_NO_SELINUX=1
 
 EXCLUDES=""
 
+if [ "$ID" = "rhel" ]; then
+    EXCLUDES="TestMachinesDisks.testDetachDisk
+              TestMachinesDisks.testDiskEdit
+              TestMachinesDisks.testAddDiskDirPool
+              TestMachinesNetworks.testNetworkSettings
+    "
+fi
+
 # Fedora gating tests are running on infra without /dev/kvm; Machines tests are too darn slow there
-# too many tests also fail on RHEL 9 (also on testing farm); so just pick a representative sample on these
-# Only RHEL 8 gating env can run all tests
-if ! [ "$ID" = "rhel" -a "${VERSION_ID#8}" != "$VERSION_ID" ]; then
+# so just pick a representative sample
+if [ "$ID" = "fedora" ]; then
     # Testing Farm machines are really slow in European evenings
     export TEST_TIMEOUT_FACTOR=3
     TESTS="TestMachinesConsoles.testInlineConsole

--- a/test/check-machines-hostdevs
+++ b/test/check-machines-hostdevs
@@ -19,6 +19,7 @@
 
 import os
 import sys
+import subprocess
 
 # import Cockpit's machinery for test VMs and its browser test API
 TEST_DIR = os.path.dirname(__file__)
@@ -74,9 +75,14 @@ class TestMachinesHostDevs(VirtualMachinesCase):
         b.enter_page('/machines')
 
         b.wait_in_text("#vm-subVmTest1-hostdev-1-type", "pci")
-        if 'virtio' in m.execute("cut -f18 /proc/bus/pci/devices"):
+        try:
+            m.execute("test -d /sys/devices/pci0000\\:00/0000\\:00\\:0f.0/")
             b.wait_in_text("#vm-subVmTest1-hostdev-1-vendor", "Red Hat, Inc")
             b.wait_in_text("#vm-subVmTest1-hostdev-1-product", "Virtio network device")
+            b.assert_pixels("#vm-subVmTest1-hostdevs", "vm-details-hostdevs-card")
+        except subprocess.CalledProcessError:
+            pass
+
         b.wait_in_text("#vm-subVmTest1-hostdev-1-source #1-slot", "0000:00:0f.0")
 
 


### PR DESCRIPTION
This reverts commit 4bcb3ec32fb3bb16c4dc78c5d0090e1b1782e8cd.