### PR TITLE
Fix error propagation in "Add shared directory" dialog

### DIFF
--- a/src/components/vm/filesystems/vmFilesystemsCard.jsx
+++ b/src/components/vm/filesystems/vmFilesystemsCard.jsx
@@ -125,13 +125,11 @@ const VmFilesystemAddModal = ({ connectionName, memory, memoryBacking, objPath, 
                 type: memoryBackingType,
                 memory
             })
-                    .then(() => {
-                        createFilesystem({
-                            connectionName, objPath,
-                            source, target: mountTag,
-                            xattr,
-                        });
-                    })
+                    .then(() => createFilesystem({
+                        connectionName, objPath,
+                        source, target: mountTag,
+                        xattr,
+                    }))
                     .then(
                         () => setIsOpen(false),
                         exc => setDialogError(exc.message)


### PR DESCRIPTION
Avoid a block, as that does not return anything and breaks apart the
promise chaining. This led to the dialog never picking up exceptions
from createFilesystem(). This was previously hidden by
https://bugzilla.redhat.com/show_bug.cgi?id=1972218 but this got fixed
recently.

---

With the image refresh in https://github.com/cockpit-project/bots/pull/2213 I now get a proper error message:

![shared-dir-fail](https://user-images.githubusercontent.com/200109/126044158-cf27e494-c4ed-4237-aa80-67397ec52d9b.png)

while with current main the dialog just goes away and adding a file system with an already existing mount tag fails silently (other than the journal message).