### PR TITLE
Disable non-shared storage migration for some distros

### DIFF
--- a/src/components/vm/vmMigrateDialog.scss
+++ b/src/components/vm/vmMigrateDialog.scss
@@ -6,3 +6,7 @@
 .popover-headline {
     margin-bottom: var(--pf-global--spacer--xs);
 }
+
+.pf-c-modal-box__body {
+    overflow-y: hidden !important;
+}

--- a/test/check-machines-migrate
+++ b/test/check-machines-migrate
@@ -95,12 +95,14 @@ class TestMachinesMigration(VirtualMachinesCase):
     def testSharedStorageMigration(self):
         self._testMigrationGeneric(False, False, None)
 
+    @skipImage('RHEL doesnt provide support for copy-storage migration', "rhel-8-4", "rhel-8-5", "rhel-9-0")
     def testCopyStorageMigration(self):
         self._testMigrationGeneric(True, False, None)
 
     def testMoveTemporarilyMigration(self):
         self._testMigrationGeneric(False, True, None)
 
+    @skipImage('RHEL doesnt provide support for copy-storage migration', "rhel-8-4", "rhel-8-5", "rhel-9-0")
     def testFailMigrationPoolNotFound(self):
         # Equivalent storage pool is not present on the destination
         self._testMigrationGeneric(True, False, "pool")
@@ -108,26 +110,32 @@ class TestMachinesMigration(VirtualMachinesCase):
     # Only qemu 5.1.0 and above does checking for volumes compatibility during migration
     # See https://mail.gnu.org/archive/html/qemu-devel/2020-04/msg05559.html
     @skipImage('Fails validation because ubuntu-2004 with qemu version below 5.1.0 doesnt compare volume sizes', "ubuntu-2004")
+    @skipImage('RHEL doesnt provide support for copy-storage migration', "rhel-8-4", "rhel-8-5", "rhel-9-0")
     def testFailMigrationVolumesNotCompatible(self):
         # Different sized volume already exists on destination
         self._testMigrationGeneric(True, False, "volume")
 
+    @skipImage('RHEL doesnt provide support for copy-storage migration', "rhel-8-4", "rhel-8-5", "rhel-9-0")
     def testFailMigrationTCPPortClosed(self):
         # Ports for TCP tranfer are closed
         self._testMigrationGeneric(True, False, "port_closed")
 
+    @skipImage('RHEL doesnt provide support for copy-storage migration', "rhel-8-4", "rhel-8-5", "rhel-9-0")
     def testFailMigrationAuthentication(self):
         # No key authentication is set up
         self._testMigrationGeneric(True, False, "authentication")
 
+    @skipImage('RHEL doesnt provide support for copy-storage migration', "rhel-8-4", "rhel-8-5", "rhel-9-0")
     def testFailMigrationUriIncorrect(self):
         # Incorrect uri inputted
         self._testMigrationGeneric(True, False, "uri")
 
+    @skipImage('RHEL doesnt provide support for copy-storage migration', "rhel-8-4", "rhel-8-5", "rhel-9-0")
     def testFailMigrationDomainUnknown(self):
         # Destination domain name is not defined in /etc/hosts and is not resolvable
         self._testMigrationGeneric(True, False, "domain")
 
+    @skipImage('RHEL doesnt provide support for copy-storage migration', "rhel-8-4", "rhel-8-5", "rhel-9-0")
     def testFailMigrationStopLibvirtd(self):
         # Libvirtd.service is not working on the destination
         self._testMigrationGeneric(True, False, "libvirtd")
@@ -164,10 +172,13 @@ class TestMachinesMigration(VirtualMachinesCase):
 
         b.set_checked("#temporary", temporary)
 
-        if copy_storage:
-            b.click("#copy")
+        if self.machine.image in ["rhel-8-4", "rhel-8-5", "rhel-9-0"]:
+            b.wait_not_present("#copy")
         else:
-            b.click("#shared")
+            if copy_storage:
+                b.click("#copy")
+            else:
+                b.click("#shared")
 
         if temporary and copy_storage:
             b.wait_visible(".footer-warning")


### PR DESCRIPTION
When copy-storage option is disabled for certain distro, storage row is hidden and shared-storage is assumed. This is not perfect, as user might not realize they need to have shared storage set up, so perhaps some warning or change of design could be done.

![Screenshot from 2021-07-23 18-10-21](https://user-images.githubusercontent.com/42733240/126810890-b744e951-9651-444b-860b-6ff856200769.png)


Fixes #247