### PR TITLE
jQuery → Promise handler API

### DIFF
--- a/src/components/libvirtSlate.jsx
+++ b/src/components/libvirtSlate.jsx
@@ -50,7 +50,7 @@ const LibvirtSlate = ({ loadingResources, libvirtService }) => {
                         serviceName: libvirtService.unit.Id
                     }).catch(ex => { setError(_("Failed to start virtualization service")); setErrorDetail(ex.message) });
                 }, ex => { setError(_("Failed to enable virtualization service")); setErrorDetail(ex.message) })
-                .always(() => setActionInProgress(false));
+                .finally(() => setActionInProgress(false));
     };
 
     const goToServicePage = () => {

--- a/src/components/networks/network.jsx
+++ b/src/components/networks/network.jsx
@@ -109,8 +109,8 @@ class NetworkActions extends React.Component {
         const network = this.props.network;
 
         networkActivate(network.connectionName, network.id)
-                .always(() => this.setState({ operationInProgress: false }))
-                .fail(exc => {
+                .finally(() => this.setState({ operationInProgress: false }))
+                .catch(exc => {
                     store.dispatch(
                         updateOrAddNetwork({
                             connectionName: network.connectionName,
@@ -128,8 +128,8 @@ class NetworkActions extends React.Component {
         const network = this.props.network;
 
         networkDeactivate(this.props.network.connectionName, this.props.network.id)
-                .always(() => this.setState({ operationInProgress: false }))
-                .fail(exc => {
+                .finally(() => this.setState({ operationInProgress: false }))
+                .catch(exc => {
                     store.dispatch(
                         updateOrAddNetwork({
                             connectionName: network.connectionName,

--- a/src/components/storagePools/createStoragePoolDialog.jsx
+++ b/src/components/storagePools/createStoragePoolDialog.jsx
@@ -394,9 +394,7 @@ class CreateStoragePoolModal extends React.Component {
                         this.setState({ createInProgress: false });
                         this.dialogErrorSet(_("Storage pool failed to be created"), exc.message);
                     })
-                    .then(() => {
-                        this.props.close();
-                    });
+                    .then(() => this.props.close());
         }
     }
 
@@ -463,7 +461,7 @@ export class CreateStoragePoolAction extends React.Component {
     componentDidMount() {
         getPoolCapabilities({ connectionName: "session" })
                 .then(poolCapabilities => this.setState({ poolCapabilities }))
-                .always(() => this.setState({ poolCapabilities: {} }));
+                .finally(() => this.setState({ poolCapabilities: {} }));
     }
 
     close() {

--- a/src/components/storagePools/storagePool.jsx
+++ b/src/components/storagePools/storagePool.jsx
@@ -110,7 +110,7 @@ class StoragePoolActions extends React.Component {
 
         this.setState({ operationInProgress: true });
         storagePoolActivate(storagePool.connectionName, storagePool.id)
-                .fail(exc => {
+                .catch(exc => {
                     store.dispatch(
                         updateOrAddStoragePool({
                             connectionName: storagePool.connectionName,
@@ -122,7 +122,7 @@ class StoragePoolActions extends React.Component {
                         }, true)
                     );
                 })
-                .always(() => this.setState({ operationInProgress: false }));
+                .finally(() => this.setState({ operationInProgress: false }));
     }
 
     onDeactivate() {
@@ -130,7 +130,7 @@ class StoragePoolActions extends React.Component {
 
         this.setState({ operationInProgress: true });
         storagePoolDeactivate(storagePool.connectionName, storagePool.id)
-                .fail(exc => {
+                .catch(exc => {
                     store.dispatch(
                         updateOrAddStoragePool({
                             connectionName: storagePool.connectionName,
@@ -142,7 +142,7 @@ class StoragePoolActions extends React.Component {
                         }, true)
                     );
                 })
-                .always(() => this.setState({ operationInProgress: false }));
+                .finally(() => this.setState({ operationInProgress: false }));
     }
 
     render() {

--- a/src/components/storagePools/storageVolumeCreate.jsx
+++ b/src/components/storagePools/storageVolumeCreate.jsx
@@ -78,13 +78,11 @@ class CreateStorageVolumeModal extends React.Component {
             const size = convertToUnit(this.state.size, this.state.unit, 'MiB');
 
             storageVolumeCreate(connectionName, name, volumeName, size, format)
-                    .fail(exc => {
+                    .catch(exc => {
                         this.setState({ createInProgress: false });
                         this.dialogErrorSet(_("Volume failed to be created"), exc.message);
                     })
-                    .then(() => {
-                        this.props.close();
-                    });
+                    .then(() => this.props.close());
         }
     }
 

--- a/src/components/vm/consoles/vnc.jsx
+++ b/src/components/vm/consoles/vnc.jsx
@@ -126,7 +126,7 @@ class Vnc extends React.Component {
                     key={cockpit.format("ctrl-alt-$0", keyName)}
                     onClick={() => {
                         return domainSendKey(connectionName, vmId, [Enum.KEY_LEFTCTRL, Enum.KEY_LEFTALT, Enum[cockpit.format("KEY_$0", keyName.toUpperCase())]])
-                                .fail(ex => onAddErrorNotification({
+                                .catch(ex => onAddErrorNotification({
                                     text: cockpit.format(_("Failed to send key Ctrl+Alt+$0 to VM $1"), keyName, vmName),
                                     detail: ex.message
                                 }));

--- a/src/components/vm/disks/diskAdd.jsx
+++ b/src/components/vm/disks/diskAdd.jsx
@@ -341,7 +341,7 @@ export class AddDiskModalBody extends React.Component {
         // There are recently no Libvirt events for storage volumes and polling is ugly.
         // https://bugzilla.redhat.com/show_bug.cgi?id=1578836
         getAllStoragePools({ connectionName: this.props.vm.connectionName })
-                .fail(exc => this.dialogErrorSet(_("Storage pools could not be fetched"), exc.message))
+                .catch(exc => this.dialogErrorSet(_("Storage pools could not be fetched"), exc.message))
                 .then(() => this.setState({ dialogLoading: false }));
     }
 
@@ -503,7 +503,7 @@ export class AddDiskModalBody extends React.Component {
                 cacheMode: this.state.cacheMode,
                 busType: this.state.busType
             })
-                    .fail(exc => {
+                    .catch(exc => {
                         this.setState({ addDiskInProgress: false });
                         this.dialogErrorSet(_("Disk failed to be created"), exc.message);
                     })
@@ -535,7 +535,7 @@ export class AddDiskModalBody extends React.Component {
             shareable: volume && volume.format === "raw" && isVolumeUsed[this.state.existingVolumeName],
             busType: this.state.busType
         })
-                .fail(exc => {
+                .catch(exc => {
                     this.setState({ addDiskInProgress: false });
                     this.dialogErrorSet(_("Disk failed to be attached"), exc.message);
                 })
@@ -548,7 +548,7 @@ export class AddDiskModalBody extends React.Component {
 
                             promises.push(
                                 updateDiskAttributes({ connectionName: vm.connectionName, objPath: vm.id, readonly: false, shareable: true, target: diskTarget })
-                                        .fail(exc => this.dialogErrorSet(_("Disk settings could not be saved"), exc.message))
+                                        .catch(exc => this.dialogErrorSet(_("Disk settings could not be saved"), exc.message))
                             );
                         });
 

--- a/src/components/vm/disks/diskEdit.jsx
+++ b/src/components/vm/disks/diskEdit.jsx
@@ -199,9 +199,7 @@ export class EditDiskModal extends React.Component {
             existingTargets
         })
                 .then(() => setIsOpen(false))
-                .fail((exc) => {
-                    this.dialogErrorSet(_("Disk settings could not be saved"), exc.message);
-                });
+                .catch(exc => this.dialogErrorSet(_("Disk settings could not be saved"), exc.message));
     }
 
     render() {

--- a/src/components/vm/nics/nicAdd.jsx
+++ b/src/components/vm/nics/nicAdd.jsx
@@ -118,9 +118,7 @@ export class AddNIC extends React.Component {
             permanent: this.state.permanent,
             hotplug: vm.state === "running",
         })
-                .fail((exc) => {
-                    this.dialogErrorSet(_("Network interface settings could not be saved"), exc.message);
-                })
+                .catch(exc => this.dialogErrorSet(_("Network interface settings could not be saved"), exc.message))
                 .then(() => {
                     getVm({ connectionName: vm.connectionName, id: vm.id });
                     this.props.close();

--- a/src/components/vm/overview/bootOrder.jsx
+++ b/src/components/vm/overview/bootOrder.jsx
@@ -210,7 +210,7 @@ class BootOrderModal extends React.Component {
             connectionName: vm.connectionName,
             devices,
         })
-                .fail(exc => this.dialogErrorSet(_("Boot order settings could not be saved"), exc.message))
+                .catch(exc => this.dialogErrorSet(_("Boot order settings could not be saved"), exc.message))
                 .then(() => {
                     getVm({ connectionName: vm.connectionName, id: vm.id });
                     this.close();

--- a/src/components/vm/overview/memoryModal.jsx
+++ b/src/components/vm/overview/memoryModal.jsx
@@ -79,7 +79,7 @@ export class MemoryModal extends React.Component {
                 connectionName: vm.connectionName,
                 maxMemory: this.state.maxMemory
             })
-                    .fail(exc => this.dialogErrorSet(_("Maximum memory could not be saved"), exc.message))
+                    .catch(exc => this.dialogErrorSet(_("Maximum memory could not be saved"), exc.message))
                     .then(() => {
                         if (vm.currentMemory !== this.state.maxMemory) {
                             setMemory({
@@ -88,7 +88,7 @@ export class MemoryModal extends React.Component {
                                 memory: this.state.memory,
                                 isRunning: vm.state == 'running'
                             })
-                                    .fail(exc => this.dialogErrorSet(_("Memory could not be saved"), exc.message))
+                                    .catch(exc => this.dialogErrorSet(_("Memory could not be saved"), exc.message))
                                     .then(() => {
                                         if (vm.state !== 'running')
                                             getVm({ connectionName: vm.connectionName, id: vm.id });
@@ -103,7 +103,7 @@ export class MemoryModal extends React.Component {
                 memory: this.state.memory,
                 isRunning: vm.state == 'running'
             })
-                    .fail(exc => this.dialogErrorSet(_("Memory could not be saved"), exc.message))
+                    .catch(exc => this.dialogErrorSet(_("Memory could not be saved"), exc.message))
                     .then(() => {
                         if (vm.state !== 'running')
                             getVm({ connectionName: vm.connectionName, id: vm.id });

--- a/src/components/vm/overview/vcpuModal.jsx
+++ b/src/components/vm/overview/vcpuModal.jsx
@@ -166,9 +166,7 @@ export class VCPUModal extends React.Component {
             cores: this.state.cores,
             isRunning: vm.state == 'running'
         })
-                .fail((exc) => {
-                    this.dialogErrorSet(_("VCPU settings could not be saved"), exc.message);
-                })
+                .catch(exc => this.dialogErrorSet(_("VCPU settings could not be saved"), exc.message))
                 .then(close);
     }
 

--- a/src/components/vm/overview/vmOverviewCard.jsx
+++ b/src/components/vm/overview/vmOverviewCard.jsx
@@ -76,7 +76,7 @@ class VmOverviewCard extends React.Component {
     componentDidMount() {
         this._isMounted = true;
         getDomainCapabilities(this.props.vm.connectionName, this.props.vm.arch, this.props.vm.emulatedMachine)
-                .done(domCaps => {
+                .then(domCaps => {
                     const loaderElems = getDomainCapLoader(domCaps);
                     const maxVcpu = getDomainCapMaxVCPU(domCaps);
                     const cpuModels = getDomainCapCPUCustomModels(domCaps);
@@ -85,7 +85,7 @@ class VmOverviewCard extends React.Component {
                     if (this._isMounted)
                         this.setState({ loaderElems, maxVcpu: Number(maxVcpu), cpuModels, cpuHostModel });
                 })
-                .fail(() => console.warn("getDomainCapabilities failed"));
+                .catch(() => console.warn("getDomainCapabilities failed"));
 
         cockpit.spawn(['which', 'virt-xml'], { err: 'ignore' })
                 .then(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -48,9 +48,7 @@ function renderApp() {
                     render(name);
                 }
             })
-            .fail((exception, data) => {
-                console.error(`initialize failed: getting libvirt service name returned error: "${JSON.stringify(exception)}", data: "${JSON.stringify(data)}"`);
-            });
+            .catch(ex => console.error(`initialize failed: getting libvirt service name returned error: "${JSON.stringify(ex)}"`));
 }
 
 /**

--- a/src/libvirt-common.js
+++ b/src/libvirt-common.js
@@ -1120,13 +1120,13 @@ export function createVm({
         profile,
         useCloudInit,
     ], opts)
-            .done(() => {
+            .then(() => {
                 finishVmCreateInProgress(vmName, connectionName);
                 clearVmUiState(vmName, connectionName);
             })
-            .fail((exception, data) => {
+            .fail(ex => {
                 clearVmUiState(vmName, connectionName); // inProgress cleanup
-                console.info(`spawn 'vm creation' returned error: "${JSON.stringify(exception)}", data: "${JSON.stringify(data)}"`);
+                console.info(`spawn 'vm creation' returned error: "${JSON.stringify(ex)}"`);
             });
 }
 
@@ -1149,8 +1149,8 @@ export function getOsInfoList () {
             .then(osList => {
                 parseOsInfoList(osList);
             })
-            .fail((exception, data) => {
-                console.error(`get os list returned error: "${JSON.stringify(exception)}", data: "${JSON.stringify(data)}"`);
+            .catch(ex => {
+                console.error(`get os list returned error: "${JSON.stringify(ex)}"`);
                 parseOsInfoList('[]');
             });
 }
@@ -1184,7 +1184,7 @@ export function installVm({ onAddErrorNotification, vm }) {
         firmware == "efi" ? 'uefi' : '',
         autostart,
     ], opts)
-            .always(() => clearVmUiState(name, connectionName));
+            .finally(() => clearVmUiState(name, connectionName));
 }
 
 export function startLibvirt({ serviceName }) {

--- a/src/libvirt-dbus.js
+++ b/src/libvirt-dbus.js
@@ -997,7 +997,7 @@ function doUsagePolling(name, connectionName, objPath) {
     const flags = Enum.VIR_DOMAIN_STATS_BALLOON | Enum.VIR_DOMAIN_STATS_VCPU | Enum.VIR_DOMAIN_STATS_BLOCK | Enum.VIR_DOMAIN_STATS_STATE;
 
     return call(connectionName, objPath, 'org.libvirt.Domain', 'GetStats', [flags, 0], { timeout: 5000, type: 'uu' })
-            .done(info => {
+            .then(info => {
                 if (Object.getOwnPropertyNames(info[0]).length > 0) {
                     info = info[0];
                     const props = { name, connectionName, id: objPath };
@@ -1027,7 +1027,7 @@ function doUsagePolling(name, connectionName, objPath) {
                 }
             })
             .catch(ex => console.warn(`GetStats(${name}, ${connectionName}) failed: ${ex.toString()}`))
-            .always(() => delayPolling(() => doUsagePolling(name, connectionName, objPath), null, name, connectionName));
+            .finally(() => delayPolling(() => doUsagePolling(name, connectionName, objPath), null, name, connectionName));
 }
 
 /**


### PR DESCRIPTION
Replace the old jQuery .done/.fail/.always aliases with their standard
Promise .then/.catch/.finally names. Just keep three .fail() handlers
which rely on some cockpit.defer() specific behaviour; these are more
tricky, and will be ported separately.

Drop the second `data` argument from some exception handlers. This is
not a thing on either the old cockpit.defer nor the Promise API.

 - [x] builds on top of PR #279 