### PR TITLE
Bring back scrollbars in dialogs

### DIFF
--- a/src/components/vm/vmMigrateDialog.scss
+++ b/src/components/vm/vmMigrateDialog.scss
@@ -7,6 +7,7 @@
     margin-bottom: var(--pf-global--spacer--xs);
 }
 
-.pf-c-modal-box__body {
-    overflow-y: hidden !important;
+// Add some padding to avoid scrollbar being shown
+#migrate-modal form {
+    padding-bottom: var(--pf-global--spacer--xs);
 }


### PR DESCRIPTION
Commit 55bb9393106042dd9ce44eeb48293c013f7feeea removed scrollbars from
the dialog bodies unconditionally.
This broke mobile mode for most of machines dialogs.

Adjust the hack which the CSS snippet is trying to do and make sure it
applies only to the Migrate dialog.