### PR TITLE
test: Avoid text cursor in "Add disk" dialog pixel tests

### DIFF
--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -297,6 +297,8 @@ class TestMachinesDisks(VirtualMachinesCase):
             self.fill()
 
             if self.pixel_test_tag:
+                # focus away from any input field, to avoid the text cursor in screenshots
+                self.test_obj.browser.focus("#vm-subVmTest1-disks-adddisk-dialog-cancel")
                 self.test_obj.browser.assert_pixels("#vm-subVmTest1-disks-adddisk-dialog-modal-window", self.pixel_test_tag,
                                                     ignore=[".pf-c-expandable-section__toggle-icon"])
 


### PR DESCRIPTION
These are a bit unstable, sometimes the blinking cursor is not visible
and causes failed tests. To avoid that, focus the cancel button, which
is know to be stable.