### PR TITLE
Fix creation of cloud-init user-data file

### DIFF
--- a/src/scripts/install_machine.py
+++ b/src/scripts/install_machine.py
@@ -129,16 +129,16 @@ def prepare_cloud_init(args):
             mode='w+'
         )
         user_data_file.write("#cloud-config\n")
-        if 'userLogin' in args:
+        if args['userLogin']:
             user_data_file.write("users:\n")
             user_data_file.write(f"  - name: {args['userLogin']}\n")
 
-        if 'rootPassword' in args or 'userPassword' in args:
+        if args['rootPassword'] or args['userPassword']:
             user_data_file.write("chpasswd:\n")
             user_data_file.write("  list: |\n")
-            if 'rootPassword' in args:
+            if args['rootPassword']:
                 user_data_file.write(f"    root:{args['rootPassword']}\n")
-            if 'userPassword' in args:
+            if args['userPassword']:
                 user_data_file.write(f"    {args['userLogin']}:{args['userPassword']}\n")
             user_data_file.write("  expire: False\n")
 


### PR DESCRIPTION
Now if only root passwd was set, and the user field were left empty we
would get:

users:
  - name:
chpasswd:
  list: |
    root:strongpassword
    :
  expire: False

Which is obviously wrong. We don't need to check if the keys exist, they
always exist if we reach that part of the code, we need to check that
they are not empty.

Note: we do it correctly for other parameters, like unattended installs

This broke in commit 1c286554f3b7f05441588822aefcdc0a92bed0e3