### PR TITLE
Fix error messages not showing

### DIFF
--- a/src/components/storagePools/storageVolumeCreate.jsx
+++ b/src/components/storagePools/storageVolumeCreate.jsx
@@ -78,11 +78,11 @@ class CreateStorageVolumeModal extends React.Component {
             const size = convertToUnit(this.state.size, this.state.unit, 'MiB');
 
             storageVolumeCreate(connectionName, name, volumeName, size, format)
+                    .then(() => this.props.close())
                     .catch(exc => {
                         this.setState({ createInProgress: false });
                         this.dialogErrorSet(_("Volume failed to be created"), exc.message);
-                    })
-                    .then(() => this.props.close());
+                    });
         }
     }
 

--- a/src/components/storagePools/storageVolumeDelete.jsx
+++ b/src/components/storagePools/storageVolumeDelete.jsx
@@ -40,11 +40,11 @@ export class StorageVolumeDelete extends React.Component {
         Promise.all(volumes.map(volume =>
             storageVolumeDelete(storagePool.connectionName, storagePool.name, volume.name)
         ))
-                .catch(exc => {
-                    this.props.deleteErrorHandler(_("Storage volumes could not be deleted"), exc.message);
-                })
                 .then(() => {
                     storagePoolRefresh(storagePool.connectionName, storagePool.id);
+                })
+                .catch(exc => {
+                    this.props.deleteErrorHandler(_("Storage volumes could not be deleted"), exc.message);
                 });
     }
 

--- a/src/components/vm/disks/diskAdd.jsx
+++ b/src/components/vm/disks/diskAdd.jsx
@@ -354,8 +354,8 @@ export class AddDiskModalBody extends React.Component {
         // There are recently no Libvirt events for storage volumes and polling is ugly.
         // https://bugzilla.redhat.com/show_bug.cgi?id=1578836
         getAllStoragePools({ connectionName: this.props.vm.connectionName })
-                .catch(exc => this.dialogErrorSet(_("Storage pools could not be fetched"), exc.message))
-                .then(() => this.setState({ dialogLoading: false, ...this.initialState }));
+                .then(() => this.setState({ dialogLoading: false, ...this.initialState }))
+                .catch(exc => this.dialogErrorSet(_("Storage pools could not be fetched"), exc.message));
     }
 
     validateParams() {
@@ -520,13 +520,13 @@ export class AddDiskModalBody extends React.Component {
                 cacheMode: this.state.cacheMode,
                 busType: this.state.busType
             })
-                    .catch(exc => {
-                        this.setState({ addDiskInProgress: false });
-                        this.dialogErrorSet(_("Disk failed to be created"), exc.message);
-                    })
                     .then(() => { // force reload of VM data, events are not reliable (i.e. for a down VM)
                         close();
                         return getVm({ connectionName: vm.connectionName, name: vm.name, id: vm.id });
+                    })
+                    .catch(exc => {
+                        this.setState({ addDiskInProgress: false });
+                        this.dialogErrorSet(_("Disk failed to be created"), exc.message);
                     });
         }
 
@@ -552,10 +552,6 @@ export class AddDiskModalBody extends React.Component {
             shareable: volume && volume.format === "raw" && isVolumeUsed[this.state.existingVolumeName],
             busType: this.state.busType
         })
-                .catch(exc => {
-                    this.setState({ addDiskInProgress: false });
-                    this.dialogErrorSet(_("Disk failed to be attached"), exc.message);
-                })
                 .then(() => { // force reload of VM data, events are not reliable (i.e. for a down VM)
                     const promises = [];
                     if (this.state.mode !== CUSTOM_PATH && volume.format === "raw" && isVolumeUsed[this.state.existingVolumeName]) {
@@ -576,6 +572,10 @@ export class AddDiskModalBody extends React.Component {
                     }
 
                     return getVm({ connectionName: vm.connectionName, name: vm.name, id: vm.id });
+                })
+                .catch(exc => {
+                    this.setState({ addDiskInProgress: false });
+                    this.dialogErrorSet(_("Disk failed to be attached"), exc.message);
                 });
     }
 

--- a/src/components/vm/disks/vmDisksCard.jsx
+++ b/src/components/vm/disks/vmDisksCard.jsx
@@ -265,14 +265,14 @@ export class VmDisksCard extends React.Component {
 
             const onRemoveDisk = () => {
                 return detachDisk({ connectionName: vm.connectionName, id: vm.id, name: vm.name, target: disk.target, live: vm.state === 'running', persistent: vm.persistent })
+                        .then(() => {
+                            getVm({ connectionName: vm.connectionName, id:vm.id });
+                        })
                         .catch(ex => {
                             onAddErrorNotification({
                                 text: cockpit.format(_("Disk $0 fail to get detached from VM $1"), disk.target, vm.name),
                                 detail: ex.message, resourceId: vm.id,
                             });
-                        })
-                        .then(() => {
-                            getVm({ connectionName: vm.connectionName, id:vm.id });
                         });
             };
             const deleteDialogProps = {

--- a/src/components/vm/nics/nicAdd.jsx
+++ b/src/components/vm/nics/nicAdd.jsx
@@ -118,11 +118,11 @@ export class AddNIC extends React.Component {
             permanent: this.state.permanent,
             hotplug: vm.state === "running",
         })
-                .catch(exc => this.dialogErrorSet(_("Network interface settings could not be saved"), exc.message))
                 .then(() => {
                     getVm({ connectionName: vm.connectionName, id: vm.id });
                     this.props.close();
-                });
+                })
+                .catch(exc => this.dialogErrorSet(_("Network interface settings could not be saved"), exc.message));
     }
 
     render() {

--- a/src/components/vm/nics/vmNicsCard.jsx
+++ b/src/components/vm/nics/vmNicsCard.jsx
@@ -209,13 +209,13 @@ export class VmNetworkTab extends React.Component {
                 e.stopPropagation();
                 if (network.mac) {
                     changeNetworkState({ name: vm.name, id: vm.id, connectionName: vm.connectionName, networkMac: network.mac, state: network.state === 'up' ? 'down' : 'up' })
+                            .then(() => getVm({ connectionName: vm.connectionName, id:vm.id, name: vm.name }))
                             .catch(ex => {
                                 onAddErrorNotification({
                                     text: cockpit.format(_("NIC $0 of VM $1 failed to change state"), network.mac, vm.name),
                                     detail: ex.message, resourceId: vm.id,
                                 });
-                            })
-                            .then(() => getVm({ connectionName: vm.connectionName, id:vm.id, name: vm.name }));
+                            });
                 }
             };
         };

--- a/src/components/vm/overview/bootOrder.jsx
+++ b/src/components/vm/overview/bootOrder.jsx
@@ -210,11 +210,11 @@ class BootOrderModal extends React.Component {
             connectionName: vm.connectionName,
             devices,
         })
-                .catch(exc => this.dialogErrorSet(_("Boot order settings could not be saved"), exc.message))
                 .then(() => {
                     getVm({ connectionName: vm.connectionName, id: vm.id });
                     this.close();
-                });
+                })
+                .catch(exc => this.dialogErrorSet(_("Boot order settings could not be saved"), exc.message));
     }
 
     onToggleDevice(device) {

--- a/src/components/vm/overview/memoryModal.jsx
+++ b/src/components/vm/overview/memoryModal.jsx
@@ -79,7 +79,6 @@ export class MemoryModal extends React.Component {
                 connectionName: vm.connectionName,
                 maxMemory: this.state.maxMemory
             })
-                    .catch(exc => this.dialogErrorSet(_("Maximum memory could not be saved"), exc.message))
                     .then(() => {
                         if (vm.currentMemory !== this.state.maxMemory) {
                             setMemory({
@@ -88,14 +87,15 @@ export class MemoryModal extends React.Component {
                                 memory: this.state.memory,
                                 isRunning: vm.state == 'running'
                             })
-                                    .catch(exc => this.dialogErrorSet(_("Memory could not be saved"), exc.message))
                                     .then(() => {
                                         if (vm.state !== 'running')
                                             getVm({ connectionName: vm.connectionName, id: vm.id });
                                         this.close();
-                                    });
+                                    })
+                                    .catch(exc => this.dialogErrorSet(_("Memory could not be saved"), exc.message));
                         }
-                    });
+                    })
+                    .catch(exc => this.dialogErrorSet(_("Maximum memory could not be saved"), exc.message));
         } else if (vm.currentMemory !== this.state.memory) {
             setMemory({
                 id: vm.id,
@@ -103,12 +103,12 @@ export class MemoryModal extends React.Component {
                 memory: this.state.memory,
                 isRunning: vm.state == 'running'
             })
-                    .catch(exc => this.dialogErrorSet(_("Memory could not be saved"), exc.message))
                     .then(() => {
                         if (vm.state !== 'running')
                             getVm({ connectionName: vm.connectionName, id: vm.id });
                         this.close();
-                    });
+                    })
+                    .catch(exc => this.dialogErrorSet(_("Memory could not be saved"), exc.message));
         } else {
             this.close();
         }

--- a/src/components/vm/overview/vcpuModal.jsx
+++ b/src/components/vm/overview/vcpuModal.jsx
@@ -166,8 +166,8 @@ export class VCPUModal extends React.Component {
             cores: this.state.cores,
             isRunning: vm.state == 'running'
         })
-                .catch(exc => this.dialogErrorSet(_("VCPU settings could not be saved"), exc.message))
-                .then(close);
+                .then(close)
+                .catch(exc => this.dialogErrorSet(_("VCPU settings could not be saved"), exc.message));
     }
 
     render() {

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -262,7 +262,8 @@ class TestMachinesDisks(VirtualMachinesCase):
             volume_format=None,
             persistent_vm=True,
             pixel_test_tag=None,
-            xfail=False, xfail_object=None, xfail_error=None,
+            xfail=False, xfail_object=None,
+            xfail_error_message=None, xfail_error_title=None,
             pixel_test_ignore=None
         ):
             self.test_obj = test_obj
@@ -287,7 +288,8 @@ class TestMachinesDisks(VirtualMachinesCase):
 
             self.xfail = xfail
             self.xfail_object = xfail_object
-            self.xfail_error = xfail_error
+            self.xfail_error_message = xfail_error_message
+            self.xfail_error_title = xfail_error_title
 
         def getExpectedFormat(selfi, pool_type):
             # Guess by the name of the pool it's format to avoid passing more parameters
@@ -316,7 +318,11 @@ class TestMachinesDisks(VirtualMachinesCase):
             if not self.xfail:
                 self.verify_disk_added()
             else:
-                self.test_obj.browser.wait_in_text(f"#vm-subVmTest1-disks-adddisk-{self.xfail_object}-helper.pf-m-error", self.xfail_error)
+                if self.xfail_object:
+                    self.test_obj.browser.wait_in_text(f"#vm-subVmTest1-disks-adddisk-{self.xfail_object}-helper.pf-m-error", self.xfail_error_message)
+                else:
+                    self.test_obj.browser.wait_in_text(".pf-c-modal-box__footer .pf-c-alert__title", self.xfail_error_title)
+                    self.test_obj.browser.click(".pf-c-modal-box__footer button:contains(Cancel)")
 
         def open(self):
             b = self.test_obj.browser
@@ -487,7 +493,7 @@ class TestMachinesDisks(VirtualMachinesCase):
                 self,
                 pool_name='iscsi-pool',
                 pool_type='iscsi',
-                xfail=True, xfail_object='new-select-pool', xfail_error='Pool type iscsi does not support volume creation',
+                xfail=True, xfail_object='new-select-pool', xfail_error_message='Pool type iscsi does not support volume creation',
             ).execute()
 
             self.VMAddDiskDialog(
@@ -774,6 +780,15 @@ class TestMachinesDisks(VirtualMachinesCase):
 
         b.wait_in_text("#vm-subVmTest1-state", "Running")
         self.goToVmPage("subVmTest1")
+
+        # Using directory path for disk should create API failure
+        self.VMAddDiskDialog(
+            self,
+            device='disk',
+            file_path='/tmp/',
+            mode='custom-path',
+            xfail=True, xfail_error_title="Disk failed to be attached",
+        ).execute()
 
         # check disk device type
         self.VMAddDiskDialog(

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -27,7 +27,7 @@ sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
 
 from machineslib import VirtualMachinesCase  # noqa
 from testlib import no_retry_when_changed, nondestructive, test_main, wait  # noqa
-from machinesxmls import TEST_NETWORK_XML  # noqa
+from machinesxmls import TEST_NETWORK_XML, TEST_NETWORK4_XML  # noqa
 
 
 @nondestructive
@@ -106,17 +106,28 @@ class TestMachinesNICs(VirtualMachinesCase):
         m = self.machine
 
         m.execute("echo \"{0}\" > /tmp/xml && virsh net-define /tmp/xml && virsh net-start test_network".format(TEST_NETWORK_XML))
+        m.execute("echo \"{0}\" > /tmp/xml2 && virsh net-define /tmp/xml2".format(TEST_NETWORK4_XML))
 
         args = self.createVm("subVmTest1")
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual machines")
+
+        self.goToVmPage("subVmTest1")
+
+        # Test a error message handling
+        self.NICAddDialog(
+            self,
+            source_type="network",
+            source="test_network4",
+            xfail=True,
+            xfail_error="Network interface settings could not be saved",  # fail because network 'test_network4' is not active
+        ).execute()
+
         # Shut off domain
         b.click("#vm-subVmTest1-action-kebab button")
         b.click("#vm-subVmTest1-forceOff")
         b.wait_in_text("#vm-subVmTest1-state", "Shut off")
-
-        self.goToVmPage("subVmTest1")
 
         # No NICs present
         b.wait_visible("#vm-subVmTest1-add-iface-button")  # open the Network Interfaces subtab
@@ -391,7 +402,7 @@ class TestMachinesNICs(VirtualMachinesCase):
             # We have always have to specify mac and source_type to identify the device in xml and $virsh detach-interface
             self, test_obj, source_type="direct", source=None, model=None, nic_num=2,
             permanent=False, mac="52:54:00:a5:f8:c0", remove=True, persistent_vm=True,
-            pixel_test_tag=None
+            xfail=False, xfail_error=None, pixel_test_tag=None
         ):
             self.source_type = source_type
             self.source = source
@@ -407,6 +418,8 @@ class TestMachinesNICs(VirtualMachinesCase):
             self.assertEqual = test_obj.assertEqual
             self.deleteIface = test_obj.deleteIface
 
+            self.xfail = xfail
+            self.xfail_error = xfail_error
             self.pixel_test_tag = pixel_test_tag
 
         def execute(self):
@@ -414,10 +427,11 @@ class TestMachinesNICs(VirtualMachinesCase):
             self.fill()
             self.assert_pixels()
             self.create()
-            self.verify()
-            self.verify_overview()
-            if self.remove:
-                self.cleanup()
+            if not self.xfail:
+                self.verify()
+                self.verify_overview()
+                if self.remove:
+                    self.cleanup()
 
         def open(self):
             self.browser.click("#vm-subVmTest1-add-iface-button")  # open the Network Interfaces subtab
@@ -451,7 +465,11 @@ class TestMachinesNICs(VirtualMachinesCase):
         def create(self):
             self.browser.click(".pf-c-modal-box__footer button:contains(Add)")
 
-            self.browser.wait_not_present("#vm-subVmTest1-add-iface-dialog")
+            if not self.xfail:
+                self.browser.wait_not_present("#vm-subVmTest1-add-iface-dialog")
+            else:
+                self.browser.wait_in_text(".pf-c-modal-box__footer .pf-c-alert__title", self.xfail_error)
+                self.browser.click(".pf-c-modal-box__footer button:contains(Cancel)")
 
         def verify(self):
             # Verify libvirt XML

--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -686,6 +686,19 @@ class TestMachinesStoragePools(VirtualMachinesCase):
             remove=True,
         ).execute()
 
+        StorageVolumeCreateDialog(
+            self,
+            pool_name="disk-pool",
+            pool_type="disk",
+            vol_name="unacceptable name",  # Partition names must follow pattern of sda1, sda2..., anything else will fail
+            size="2",
+            unit="MiB",
+            format="none",
+            xfail=True,
+            xfail_error="invalid partition name",
+            remove=True,
+        ).execute()
+
         # Try raw format
         StorageVolumeCreateDialog(
             self,

--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -69,7 +69,8 @@ class TestMachinesStoragePools(VirtualMachinesCase):
         m.execute("virsh vol-create-as myPoolTwo VolumeOne --capacity 1G --format qcow2")
         m.execute("virsh vol-create-as myPoolTwo VolumeTwo --capacity 1G --format qcow2")
         m.execute("virsh vol-create-as myPoolTwo VolumeThree --capacity 1G --format qcow2")
-        wait(lambda: all(volume in m.execute("virsh vol-list myPoolTwo") for volume in ["VolumeOne", "VolumeTwo", "VolumeThree"]))
+        m.execute("virsh vol-create-as myPoolTwo VolumeFour --capacity 1G --format qcow2")
+        wait(lambda: all(volume in m.execute("virsh vol-list myPoolTwo") for volume in ["VolumeOne", "VolumeTwo", "VolumeThree", "VolumeFour"]))
         m.execute('virsh pool-refresh myPoolOne; virsh pool-refresh myPoolTwo')
 
         connectionName = m.execute("virsh uri | head -1 | cut -d/ -f4").strip()
@@ -118,7 +119,20 @@ class TestMachinesStoragePools(VirtualMachinesCase):
         b.wait_in_text("#pool-myPoolTwo-{0}-volume-VolumeOne-name".format(connectionName), "VolumeOne")
         b.wait_in_text("#pool-myPoolTwo-{0}-volume-VolumeTwo-name".format(connectionName), "VolumeTwo")
         b.wait_in_text("#pool-myPoolTwo-{0}-volume-VolumeThree-name".format(connectionName), "VolumeThree")
+        b.wait_in_text("#pool-myPoolTwo-{0}-volume-VolumeFour-name".format(connectionName), "VolumeFour")
         b.wait_not_present("#storage-volumes-delete")
+
+        # Delete a volume from terminal and verify API error will be shown when trying to delete from UI
+        m.execute("virsh vol-delete --pool myPoolTwo --vol VolumeFour")
+        b.wait_visible("#pool-myPoolTwo-{0}-volume-VolumeFour-name".format(connectionName))
+        b.click("tbody input[aria-label='Select row 0']")
+        b.wait_in_text("#storage-volumes-delete", "Delete 1 volume")
+        b.click("#storage-volumes-delete")
+        b.wait_in_text(".pf-c-alert .pf-c-alert__title", "Storage volumes could not be deleted")
+        b.reload()
+        b.enter_page('/machines')
+        self.togglePoolRow("myPoolTwo", connectionName)
+        self.gotoVolumesTab("myPoolTwo")
 
         # Delete a volume from terminal and verify that refresh worked by reloading the browser page
         m.execute("rm -f {0}".format(os.path.join(p2, "VolumeThree")))


### PR DESCRIPTION
Weeks ago we replaced all the `.fail()` promise handlers with `.catch()`.
Handler `.fail()` returns an original promise, while `.catch()` returns a new promise or a value. This causes a problem, since `.failt().then()` was a non-problematic chain combination, since `.then()` would in case of error never be entered. However chaining `.catch().then()` causes a problem when both `.catch()` and `.then()` are entered, leading to a situation where an error is shown by `.catch()`, but modal is imediatelly closed by .then() without a chance to see the error.

Fix it by switching the two handlers.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1691662