### PR TITLE
Enable SSH password authentication when setting root/user password

### DIFF
--- a/src/scripts/install_machine.py
+++ b/src/scripts/install_machine.py
@@ -134,6 +134,8 @@ def prepare_cloud_init(args):
             user_data_file.write(f"  - name: {args['userLogin']}\n")
 
         if args['rootPassword'] or args['userPassword']:
+            # enable SSH password login if any password is set
+            user_data_file.write("ssh_pwauth: true\n")
             user_data_file.write("chpasswd:\n")
             user_data_file.write("  list: |\n")
             if args['rootPassword']:

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -834,6 +834,11 @@ class TestMachinesCreate(VirtualMachinesCase):
             virt_install_cmd_out = self.machine.execute(virt_install_cmd)
             if self.user_login or self.user_password:
                 self.assertIn("--cloud-init user-data=", virt_install_cmd_out)
+                # parse the file
+                user_data_path = virt_install_cmd_out.split("user-data=", 1)[1].split()[0]
+                user_data = self.machine.execute("cat " + user_data_path)
+
+                self.assertIn("\nssh_pwauth: true", user_data)
 
             self.machine.execute(f"virsh destroy {self.name}")
             self.assertIn(f"backing file: {self.location}", self.machine.execute(f"qemu-img info /var/lib/libvirt/images/{self.name}.qcow2"))


### PR DESCRIPTION
When setting a user password through cloud-init parameters, also enable
SSH password authentication through the `ssh_pwauth` cloud-init flag [1].
SSH is the primary way to actually access these instances in most cases.

Note that this does not enable SSH password login for root
(`PermitRootLogin`). This is too dangerous to do implicitly, and
cloud-init also does not have a declarative API for that anyway.

Our integration tests don't actually communicate with the OS inside the
VM, so just add a shallow check to make sure that the flag appears in
the cloud-init user-data file.

https://bugzilla.redhat.com/show_bug.cgi?id=1990003

[1] https://cloudinit.readthedocs.io/en/latest/topics/modules.html#set-passwords

---

I tested that manually (after some trouble, see #309), and it works as expected.