### PR TITLE
Forbid configurations where users would attempt to use cdroms in virtio bus

### DIFF
--- a/src/components/vm/disks/diskAdd.jsx
+++ b/src/components/vm/disks/diskAdd.jsx
@@ -28,7 +28,7 @@ import cockpit from 'cockpit';
 
 import { FileAutoComplete } from 'cockpit-components-file-autocomplete.jsx';
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
-import { diskCacheModes, units, convertToUnit, getDefaultVolumeFormat, getNextAvailableTarget, getStorageVolumesUsage, getStorageVolumeDiskTarget } from '../../../helpers.js';
+import { diskBusTypes, diskCacheModes, units, convertToUnit, getDefaultVolumeFormat, getNextAvailableTarget, getStorageVolumesUsage, getStorageVolumeDiskTarget } from '../../../helpers.js';
 import { VolumeCreateBody } from '../../storagePools/storageVolumeCreateBody.jsx';
 import { domainAttachDisk, domainGet, domainIsRunning, domainUpdateDiskAttributes } from '../../../libvirtApi/domain.js';
 import { storagePoolGetAll } from '../../../libvirtApi/storagePool.js';
@@ -40,10 +40,6 @@ const CREATE_NEW = 'create-new';
 const USE_EXISTING = 'use-existing';
 const CUSTOM_PATH = 'custom-path';
 
-const busTypes = {
-    disk: ['sata', 'scsi', 'usb', 'virtio'],
-    cdrom: ['sata', 'scsi', 'usb']
-};
 const poolTypesNotSupportingVolumeCreation = ['iscsi', 'iscsi-direct', 'gluster', 'mpath'];
 
 function getFilteredVolumes(vmStoragePool, disks) {
@@ -145,7 +141,7 @@ class AdditionalOptions extends React.Component {
     }
 
     render() {
-        const displayBusTypes = busTypes[this.props.device].map(type => ({ value: type }));
+        const displayBusTypes = diskBusTypes[this.props.device].map(type => ({ value: type }));
         if (displayBusTypes.find(busType => busType.value == this.props.busType) == undefined)
             displayBusTypes.push({ value: this.props.busType, disabled: true });
 

--- a/src/components/vm/disks/diskEdit.jsx
+++ b/src/components/vm/disks/diskEdit.jsx
@@ -29,7 +29,7 @@ import { InfoAltIcon } from '@patternfly/react-icons';
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
 
 import { domainUpdateDiskAttributes } from '../../../libvirtApi/domain.js';
-import { diskCacheModes, getDiskPrettyName, getDiskFullName } from '../../../helpers.js';
+import { diskBusTypes, diskCacheModes, getDiskPrettyName, getDiskFullName } from '../../../helpers.js';
 
 import 'form-layout.scss';
 
@@ -78,8 +78,8 @@ const CacheRow = ({ onValueChanged, dialogValues, idPrefix, shutoff }) => {
     );
 };
 
-const BusRow = ({ onValueChanged, dialogValues, idPrefix, shutoff }) => {
-    const busTypes = ['sata', 'scsi', 'usb', 'virtio'].map(type => ({ value: type }));
+const BusRow = ({ onValueChanged, dialogValues, diskDevice, idPrefix, shutoff }) => {
+    const busTypes = diskBusTypes[diskDevice].map(type => ({ value: type }));
     if (busTypes.find(busType => busType.value == dialogValues.busType) == undefined)
         busTypes.push({ value: dialogValues.busType, disabled: true });
 
@@ -144,7 +144,10 @@ export const EditDiskAction = ({ idPrefix, disk, onAddErrorNotification, vm }) =
 
     return (
         <>
-            <Button id={idPrefix} variant='secondary' onClick={() => setIsOpen(true)}>
+            <Button id={idPrefix}
+                    isDisabled={!Object.keys(diskBusTypes).includes(disk.device)}
+                    variant='secondary'
+                    onClick={() => setIsOpen(true)}>
                 {_("Edit")}
             </Button>
             {isOpen && <EditDiskModal idPrefix={idPrefix}
@@ -217,6 +220,7 @@ export class EditDiskModal extends React.Component {
                            onValueChanged={this.onValueChanged} />
 
                 <BusRow dialogValues={this.state}
+                        diskDevice={disk.device}
                         idPrefix={idPrefix}
                         onValueChanged={this.onValueChanged}
                         shutoff={vm.state == 'shut off'} />

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -46,6 +46,13 @@ export function localize_datetime(time) {
     return formatRelative(time, Date.now(), { locale });
 }
 
+export const diskBusTypes = {
+    cdrom: ['sata', 'scsi', 'usb'],
+    disk: ['sata', 'scsi', 'usb', 'virtio'],
+    floppy: ['sata', 'scsi', 'usb', 'virtio'],
+    lun: ['sata', 'scsi', 'usb', 'virtio'],
+};
+
 export const diskCacheModes = ['default', 'none', 'writethrough', 'writeback', 'directsync', 'unsafe'];
 
 export const units = {

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -173,6 +173,16 @@ class TestMachinesDisks(VirtualMachinesCase):
             b.wait_not_present("#vm-subVmTest1-disks-sdb-edit-dialog .pf-c-alert")
             cancel("sdb")
 
+        # Virtio bus type should not be shown for CDROM devices
+        m.execute("touch /var/lib/libvirt/novell.iso")
+        m.execute("virsh attach-disk --domain subVmTest1 --source /var/lib/libvirt/novell.iso --target hda --type cdrom --mode readonly --persistent")
+        # virsh attach-disk want send an event for offline VM changes
+        b.reload()
+        b.enter_page('/machines')
+        open("hda")
+        b._wait_present("#vm-subVmTest1-disks-hda-edit-bus-type option[value=sata]")
+        self.assertFalse(b.is_present("#vm-subVmTest1-disks-hda-edit-bus-type option[value=virtio]"))
+
         # Start Vm
         b.click("#vm-subVmTest1-run")
         b.wait_in_text("#vm-subVmTest1-state", "Running")


### PR DESCRIPTION
Libvirt would generate an error for that anyway, but let's hide this
combination from the UI.

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1993434