### PR TITLE
Fix crash when adding disk with custom path while no storage pools exist

### DIFF
--- a/src/components/vm/disks/diskAdd.jsx
+++ b/src/components/vm/disks/diskAdd.jsx
@@ -493,6 +493,7 @@ export class AddDiskModalBody extends React.Component {
 
     onAddClicked() {
         const { vm, vms, storagePools } = this.state;
+        let storagePool, volume, isVolumeUsed;
         const close = this.props.close;
 
         const validation = this.validateParams();
@@ -524,12 +525,12 @@ export class AddDiskModalBody extends React.Component {
                         this.setState({ addDiskInProgress: false });
                         this.dialogErrorSet(_("Disk failed to be created"), exc.message);
                     });
+        } else if (this.state.mode === USE_EXISTING) {
+            // use existing volume
+            storagePool = storagePools.find(pool => pool.name === this.state.storagePoolName);
+            volume = storagePool.volumes.find(vol => vol.name === this.state.existingVolumeName);
+            isVolumeUsed = getStorageVolumesUsage(vms, storagePool);
         }
-
-        // use existing volume
-        const storagePool = storagePools.find(pool => pool.name === this.state.storagePoolName);
-        const volume = storagePool.volumes.find(vol => vol.name === this.state.existingVolumeName);
-        const isVolumeUsed = getStorageVolumesUsage(vms, storagePool);
 
         return domainAttachDisk({
             connectionName: vm.connectionName,

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -859,6 +859,12 @@ class TestMachinesDisks(VirtualMachinesCase):
         b.click(f"{prefix}-source-group label:contains(Use existing)")
         b.wait_visible(".pf-c-modal-box__footer button:contains(Add)[aria-disabled=true]")
         b.click("#vm-subVmTest1-disks-adddisk-dialog-cancel")
+        self.VMAddDiskDialog(
+            self,
+            expected_target='sda',
+            file_path='/var/lib/libvirt/novell.iso',
+            mode='custom-path'
+        ).execute()
 
         # Ensure that the bus type autofilled value is according to the bus types of the existing disks of the guest,
         # even when these are not in the predefined value (see ide)


### PR DESCRIPTION
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1985228