### PR TITLE
Fix validation check for the source field in 'Add shared directory' dialog

### DIFF
--- a/src/components/vm/filesystems/vmFilesystemsCard.jsx
+++ b/src/components/vm/filesystems/vmFilesystemsCard.jsx
@@ -211,7 +211,7 @@ const VmFilesystemAddModal = ({ connectionName, memory, memoryBacking, objPath, 
                                </Popover>
                            }
                            helperTextInvalid={validationFailed.source}
-                           validated={validationFailed.mountTag ? "error" : "default"}>
+                           validated={validationFailed.source ? "error" : "default"}>
                     <FileAutoComplete id={`${idPrefix}-modal-source`}
                                       onChange={value => setSource(value)}
                                       placeholder="/export/to/guest"


### PR DESCRIPTION
The test already exists, but since the 'tag' was also invalid, both
fields got invalidated.

Fixes #348