### PR TITLE
Stop exposing unattended installation option for ISO installation media

### DIFF
--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -1045,9 +1045,7 @@ class CreateVmModal extends React.Component {
                     minimumMemory={this.state.minimumMemory}
                 />
 
-                {this.state.sourceType != PXE_SOURCE &&
-                 this.state.sourceType != EXISTING_DISK_IMAGE_SOURCE &&
-                 this.state.sourceType != CLOUD_IMAGE &&
+                {this.state.sourceType == DOWNLOAD_AN_OS &&
                  this.props.unattendedSupported &&
                  <>
                      <UnattendedRow


### PR DESCRIPTION
* [x] update pixel tests

Unattended is not working for linux ISO media which we pass with
--cdrom. See https://bugzilla.redhat.com/show_bug.cgi?id=1868594 for
details.

Till we get a response here https://github.com/virt-manager/virt-manager/issues/296
let's disable this option that's very much broken.