### PR TITLE
Introduce rename operation

### DIFF
--- a/src/components/vm/vmActions.jsx
+++ b/src/components/vm/vmActions.jsx
@@ -33,10 +33,12 @@ import {
 import { CloneDialog } from './vmCloneDialog.jsx';
 import { DeleteDialog } from "./deleteDialog.jsx";
 import { MigrateDialog } from './vmMigrateDialog.jsx';
+import { RenameDialog } from './vmRenameDialog.jsx';
 import {
     domainCanDelete,
     domainCanInstall,
     domainCanReset,
+    domainCanRename,
     domainCanResume,
     domainCanRun,
     domainCanPause,
@@ -59,6 +61,7 @@ const VmActions = ({ vm, storagePools, onAddErrorNotification, isDetailsPage }) 
     const [isActionOpen, setIsActionOpen] = useState(false);
     const [showDeleteDialog, toggleDeleteModal] = useState(false);
     const [showMigrateDialog, toggleMigrateDialog] = useState(false);
+    const [showRenameDialog, toggleRenameDialog] = useState(false);
     const [showCloneDialog, toggleCloneModal] = useState(false);
     const [operationInProgress, setOperationInProgress] = useState(false);
     const [prevVmState, setPrevVmState] = useState(vm.state);
@@ -343,6 +346,28 @@ const VmActions = ({ vm, storagePools, onAddErrorNotification, isDetailsPage }) 
         );
     }
 
+    if (domainCanRename(state)) {
+        dropdownItems.push(
+            <DropdownItem key={`${id}-rename`}
+                          id={`${id}-rename`}
+                          onClick={() => toggleRenameDialog(true)}>
+                {_("Rename")}
+            </DropdownItem>
+        );
+        dropdownItems.push(<DropdownSeparator key="separator-rename" />);
+    }
+
+    let renameAction;
+    if (showRenameDialog) {
+        renameAction = (
+            <RenameDialog key='action-rename'
+                          vmName={vm.name}
+                          vmId={vm.id}
+                          connectionName={vm.connectionName}
+                          toggleModal={() => toggleRenameDialog(!showRenameDialog)} />
+        );
+    }
+
     let deleteAction = null;
     if (state !== undefined && domainCanDelete(state, vm.id)) {
         if (!vm.persistent) {
@@ -377,6 +402,7 @@ const VmActions = ({ vm, storagePools, onAddErrorNotification, isDetailsPage }) 
             {deleteAction}
             {cloneAction}
             {migrateAction}
+            {renameAction}
             <Dropdown onSelect={() => setIsActionOpen(!isActionOpen)}
                       id={`${id}-action-kebab`}
                       toggle={<KebabToggle isDisabled={vm.isUi} onToggle={isOpen => setIsActionOpen(isOpen)} />}

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -85,6 +85,7 @@ export const domainCanRun = (vmState, hasInstallPhase) => !hasInstallPhase && vm
 export const domainCanSendNMI = (vmState) => domainCanReset(vmState);
 export const domainCanShutdown = (vmState) => domainCanReset(vmState);
 export const domainCanPause = (vmState) => vmState == 'running';
+export const domainCanRename = (vmState) => vmState == 'shut off';
 export const domainCanResume = (vmState) => vmState == 'paused';
 export const domainIsRunning = (vmState) => domainCanReset(vmState);
 export const domainSerialConsoleCommand = ({ vm }) => vm.displays.pty ? ['virsh', ...VMS_CONFIG.Virsh.connections[vm.connectionName].params, 'console', vm.name] : false;
@@ -627,6 +628,14 @@ export function domainReboot({
     id: objPath
 }) {
     return call(connectionName, objPath, 'org.libvirt.Domain', 'Reboot', [0], { timeout, type: 'u' });
+}
+
+export function domainRename({
+    connectionName,
+    id: objPath,
+    newName,
+}) {
+    return call(connectionName, objPath, 'org.libvirt.Domain', 'Rename', [newName, 0], { timeout, type: 'su' });
 }
 
 export function domainResume({

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -237,6 +237,29 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         b.wait_in_text(".pf-c-popover", "VM subVmTest2 failed to start")
         b.click('#vm-subVmTest2-state button[aria-label=label-close-button]')
 
+    def testRename(self):
+        b = self.browser
+
+        self.createVm("old", running=False)
+
+        self.login_and_go("/machines")
+
+        b.wait_in_text("body", "Virtual machines")
+
+        self.performAction("old", "rename")
+
+        b.set_input_text("#rename-dialog-new-name", "new")
+        b.click("#rename-dialog-confirm")
+        self.waitVmRow("new")
+        self.waitVmRow("old-name", "system", False)
+
+        # Rename to itself and expect error
+        self.performAction("new", "rename")
+
+        b.set_input_text("#rename-dialog-new-name", "new")
+        b.click("#rename-dialog-confirm")
+        b.wait_in_text(".pf-c-modal-box__footer .pf-c-alert.pf-m-danger", "Can't rename domain to itself")
+
     def testLibvirt(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Fixes #50

## Machines: Add support for renaming VMs

The Machines page can rename virtual machines.

![Screen Shot 2021-09-08 at 18 45 02](https://user-images.githubusercontent.com/14921356/132550664-feb32873-bf76-4a03-88ba-c0ae6890ed80.png)
![Screen Shot 2021-09-08 at 18 43 17](https://user-images.githubusercontent.com/14921356/132550749-f185580c-8d87-4c3d-a4eb-b07b6da11b13.png)

