### PR TITLE
packit: Force dist download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,12 @@ download-po: $(WEBLATE_REPO)
 	sed -e 's/%{VERSION}/$(VERSION)/g' $< > $@
 
 $(WEBPACK_TEST): $(LIB_TEST) $(shell find src/ -type f) package.json webpack.config.js
-	test/download-dist $${DOWNLOAD_DIST_OPTIONS:-} || ($(MAKE) $(NODE_MODULES_TEST) && NODE_ENV=$(NODE_ENV) npm run build)
+	test/download-dist $${DOWNLOAD_DIST_OPTIONS:-} || \
+	    if [ -z "$$FORCE_DOWNLOAD_DIST" ]; then \
+		($(MAKE) $(NODE_MODULES_TEST) && NODE_ENV=$(NODE_ENV) npm run build); \
+	    else \
+		exit 1; \
+	    fi
 
 watch:
 	NODE_ENV=$(NODE_ENV) npm run watch

--- a/packit.yaml
+++ b/packit.yaml
@@ -6,7 +6,7 @@ downstream_package_name: cockpit-machines
 actions:
   post-upstream-clone: make cockpit-machines.spec
   create-archive:
-    - make dist-gzip DOWNLOAD_DIST_OPTIONS=--wait
+    - make dist-gzip DOWNLOAD_DIST_OPTIONS=--wait FORCE_DOWNLOAD_DIST=1
     - find -name 'cockpit-machines-*.tar.gz'
 jobs:
   - job: tests


### PR DESCRIPTION
The sandcastle env has too little RAM to do a webpack build, so it
inevitably fails. Let's fail in a faster and more obvious way instead.