### PR TITLE
Parse supported disk bus types from domcapabities and filter the displayed select options

### DIFF
--- a/src/components/vm/disks/diskAdd.jsx
+++ b/src/components/vm/disks/diskAdd.jsx
@@ -141,7 +141,9 @@ class AdditionalOptions extends React.Component {
     }
 
     render() {
-        const displayBusTypes = diskBusTypes[this.props.device].map(type => ({ value: type }));
+        const displayBusTypes = diskBusTypes[this.props.device]
+                .filter(bus => this.props.supportedDiskBusTypes.includes(bus))
+                .map(type => ({ value: type }));
         if (displayBusTypes.find(busType => busType.value == this.props.busType) == undefined)
             displayBusTypes.push({ value: this.props.busType, disabled: true });
 
@@ -642,7 +644,8 @@ export class AddDiskModalBody extends React.Component {
                                        device={this.state.device}
                                        idPrefix={idPrefix}
                                        onValueChanged={this.onValueChanged}
-                                       busType={this.state.busType} />
+                                       busType={this.state.busType}
+                                       supportedDiskBusTypes={this.props.supportedDiskBusTypes} />
                 </Form>
             );
         }

--- a/src/components/vm/disks/diskEdit.jsx
+++ b/src/components/vm/disks/diskEdit.jsx
@@ -78,8 +78,10 @@ const CacheRow = ({ onValueChanged, dialogValues, idPrefix, shutoff }) => {
     );
 };
 
-const BusRow = ({ onValueChanged, dialogValues, diskDevice, idPrefix, shutoff }) => {
-    const busTypes = diskBusTypes[diskDevice].map(type => ({ value: type }));
+const BusRow = ({ onValueChanged, dialogValues, diskDevice, idPrefix, shutoff, supportedDiskBusTypes }) => {
+    const busTypes = diskBusTypes[diskDevice]
+            .filter(bus => supportedDiskBusTypes.includes(bus))
+            .map(type => ({ value: type }));
     if (busTypes.find(busType => busType.value == dialogValues.busType) == undefined)
         busTypes.push({ value: dialogValues.busType, disabled: true });
 
@@ -141,13 +143,13 @@ const AccessRow = ({ onValueChanged, dialogValues, diskDevice, driverType, idPre
     );
 };
 
-export const EditDiskAction = ({ idPrefix, disk, onAddErrorNotification, vm }) => {
+export const EditDiskAction = ({ idPrefix, disk, onAddErrorNotification, vm, supportedDiskBusTypes }) => {
     const [isOpen, setIsOpen] = useState(false);
 
     return (
         <>
             <Button id={idPrefix}
-                    isDisabled={!Object.keys(diskBusTypes).includes(disk.device)}
+                    isDisabled={!Object.keys(diskBusTypes).includes(disk.device) || !supportedDiskBusTypes}
                     variant='secondary'
                     onClick={() => setIsOpen(true)}>
                 {_("Edit")}
@@ -156,6 +158,7 @@ export const EditDiskAction = ({ idPrefix, disk, onAddErrorNotification, vm }) =
                                       disk={disk}
                                       onAddErrorNotification={onAddErrorNotification}
                                       setIsOpen={setIsOpen}
+                                      supportedDiskBusTypes={supportedDiskBusTypes}
                                       vm={vm} />}
         </>
     );
@@ -208,7 +211,7 @@ export class EditDiskModal extends React.Component {
     }
 
     render() {
-        const { vm, disk, idPrefix, setIsOpen } = this.props;
+        const { vm, disk, idPrefix, setIsOpen, supportedDiskBusTypes } = this.props;
 
         const defaultBody = (
             <Form isHorizontal>
@@ -226,7 +229,8 @@ export class EditDiskModal extends React.Component {
                         diskDevice={disk.device}
                         idPrefix={idPrefix}
                         onValueChanged={this.onValueChanged}
-                        shutoff={vm.state == 'shut off'} />
+                        shutoff={vm.state == 'shut off'}
+                        supportedDiskBusTypes={supportedDiskBusTypes} />
 
                 <CacheRow dialogValues={this.state}
                         idPrefix={idPrefix}

--- a/src/components/vm/disks/vmDisksCard.jsx
+++ b/src/components/vm/disks/vmDisksCard.jsx
@@ -86,10 +86,15 @@ export class VmDisksActions extends React.Component {
 
         return (
             <>
-                <Button id={`${idPrefix}-adddisk`} variant='secondary' onClick={this.open}>
+                <Button id={`${idPrefix}-adddisk`} variant='secondary' onClick={this.open} isDisabled={!this.props.supportedDiskBusTypes}>
                     {_("Add disk")}
                 </Button>
-                {this.state.showAddDiskModal && <AddDiskModalBody close={this.close} idPrefix={idPrefix} vm={vm} vms={vms} storagePools={storagePools.filter(pool => pool && pool.active)} />}
+                {this.state.showAddDiskModal &&
+                <AddDiskModalBody close={this.close}
+                                  idPrefix={idPrefix}
+                                  vm={vm} vms={vms}
+                                  storagePools={storagePools.filter(pool => pool && pool.active)}
+                                  supportedDiskBusTypes={this.props.supportedDiskBusTypes} />}
             </>
         );
     }
@@ -172,7 +177,7 @@ export class VmDisksCardLibvirt extends React.Component {
     }
 
     render() {
-        const { vm, storagePools } = this.props;
+        const { vm, storagePools, supportedDiskBusTypes } = this.props;
 
         const idPrefix = `${vmId(vm.name)}-disks`;
         const areDiskStatsSupported = this.getDiskStatsSupport(vm);
@@ -188,12 +193,14 @@ export class VmDisksCardLibvirt extends React.Component {
                 vm={vm}
                 disks={disks}
                 renderCapacity={areDiskStatsSupported}
+                supportedDiskBusTypes={supportedDiskBusTypes}
                 onAddErrorNotification={this.props.onAddErrorNotification} />
         );
     }
 }
 
 VmDisksCardLibvirt.propTypes = {
+    supportedDiskBusTypes: PropTypes.array,
     vm: PropTypes.object.isRequired,
 };
 
@@ -204,7 +211,7 @@ export class VmDisksCard extends React.Component {
     }
 
     render() {
-        const { vm, disks, renderCapacity, onAddErrorNotification } = this.props;
+        const { vm, disks, renderCapacity, onAddErrorNotification, supportedDiskBusTypes } = this.props;
         let renderCapacityUsed, renderAccess, renderAdditional;
         const columnTitles = [_("Device")];
         const idPrefix = `${vmId(vm.name)}-disks`;
@@ -293,7 +300,8 @@ export class VmDisksCard extends React.Component {
                     <EditDiskAction disk={disk}
                                     vm={vm}
                                     idPrefix={`${idPrefixRow}-edit`}
-                                    onAddErrorNotification={onAddErrorNotification} /> }
+                                    onAddErrorNotification={onAddErrorNotification}
+                                    supportedDiskBusTypes={supportedDiskBusTypes} />}
                 </div>
             );
             columns.push({ title: diskActions });
@@ -317,4 +325,5 @@ VmDisksCard.propTypes = {
     disks: PropTypes.array.isRequired,
     renderCapacity: PropTypes.bool,
     onAddErrorNotification: PropTypes.func.isRequired,
+    supportedDiskBusTypes: PropTypes.array,
 };

--- a/src/libvirt-xml-parse.js
+++ b/src/libvirt-xml-parse.js
@@ -111,6 +111,15 @@ export function getDomainCapCPUHostModel(capsXML) {
     return hostModelModeElem && Array.prototype.map.call(hostModelModeElem.getElementsByTagName("model"), modelElem => modelElem.textContent)[0];
 }
 
+export function getDomainCapDiskBusTypes(capsXML) {
+    const domainCapsElem = getElem(capsXML);
+    const devicesCapsElem = domainCapsElem.getElementsByTagName("devices") && domainCapsElem.getElementsByTagName("devices")[0];
+    const diskCapsElem = devicesCapsElem.getElementsByTagName("disk") && devicesCapsElem.getElementsByTagName("disk")[0];
+    const enumElems = diskCapsElem && diskCapsElem.getElementsByTagName("enum");
+    const busElem = enumElems && Array.prototype.find.call(enumElems, enumElem => enumElem.getAttribute("name") == "bus");
+    return busElem && Array.prototype.map.call(busElem.getElementsByTagName("value"), valueElem => valueElem.textContent);
+}
+
 export function getSingleOptionalElem(parent, name) {
     const subElems = parent.getElementsByTagName(name);
     return subElems.length > 0 ? subElems[0] : undefined; // optional


### PR DESCRIPTION
* [ ] tested against a ppc machine

Move fetching of the domain domcapabities one component up so as to avoid
doing the API call twice, as it's now needed in two places.

This affects the Add and Edit disk dialogs.

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1862779