### PR TITLE
Build node cache on release, move to xz release tarballs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 *.pyc
+*.rpm
+*.tar.xz
 bots/
 dist/
 lib/
 test/common/
-cockpit-machines-*.rpm
 cockpit-machines.spec
 node_modules/
 package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ $(TARFILE): $(WEBPACK_TEST) $(RPM_NAME).spec
 	tar czf $(TARFILE) --transform 's,^,cockpit-$(PACKAGE_NAME)/,' \
 		--exclude $(RPM_NAME).spec.in \
 		--exclude test/reference \
-		$$(git ls-files) $(LIB_TEST) src/lib/patternfly/*.scss package-lock.json $(RPM_NAME).spec dist/; \
+		$$(git ls-files) $(LIB_TEST) src/lib/ package-lock.json $(RPM_NAME).spec dist/; \
 
 srpm: $(TARFILE) $(RPM_NAME).spec
 	rpmbuild -bs \

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ TEST_OS = fedora-34
 endif
 export TEST_OS
 TARFILE=cockpit-$(PACKAGE_NAME)-$(VERSION).tar.gz
+NODE_CACHE=cockpit-$(PACKAGE_NAME)-node-$(VERSION).tar.xz
 RPMFILE=$(shell rpmspec -D"VERSION $(VERSION)" -q `ls cockpit-machines.spec.in cockpit-machines.spec 2>/dev/null | head -n1`).rpm
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check if/when npm install ran
@@ -115,6 +116,11 @@ $(TARFILE): $(WEBPACK_TEST) $(RPM_NAME).spec
 		--exclude test/reference \
 		$$(git ls-files) $(LIB_TEST) src/lib/ package-lock.json $(RPM_NAME).spec dist/; \
 
+$(NODE_CACHE): $(NODE_MODULES_TEST)
+	tar --xz -cf $@ node_modules
+
+node-cache: $(NODE_CACHE)
+
 srpm: $(TARFILE) $(RPM_NAME).spec
 	rpmbuild -bs \
 	  --define "_sourcedir `pwd`" \
@@ -201,4 +207,4 @@ $(NODE_MODULES_TEST): package.json
 	env -u NODE_ENV npm install
 	env -u NODE_ENV npm prune
 
-.PHONY: all clean install devel-install dist-gzip srpm rpm check vm update-po
+.PHONY: all clean install devel-install dist-gzip node-cache srpm rpm check vm update-po

--- a/Makefile
+++ b/Makefile
@@ -78,13 +78,13 @@ download-po: $(WEBLATE_REPO)
 $(WEBPACK_TEST): $(LIB_TEST) $(shell find src/ -type f) package.json webpack.config.js
 	test/download-dist $${DOWNLOAD_DIST_OPTIONS:-} || \
 	    if [ -z "$$FORCE_DOWNLOAD_DIST" ]; then \
-		($(MAKE) $(NODE_MODULES_TEST) && NODE_ENV=$(NODE_ENV) npm run build); \
+		($(MAKE) $(NODE_MODULES_TEST) && NODE_ENV=$(NODE_ENV) node_modules/.bin/webpack); \
 	    else \
 		exit 1; \
 	    fi
 
 watch:
-	NODE_ENV=$(NODE_ENV) npm run watch
+	NODE_ENV=$(NODE_ENV) node_modules/.bin/webpack --watch
 
 clean:
 	rm -rf dist/

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ifeq ($(TEST_OS),)
 TEST_OS = fedora-34
 endif
 export TEST_OS
-TARFILE=cockpit-$(PACKAGE_NAME)-$(VERSION).tar.gz
+TARFILE=cockpit-$(PACKAGE_NAME)-$(VERSION).tar.xz
 NODE_CACHE=cockpit-$(PACKAGE_NAME)-node-$(VERSION).tar.xz
 RPMFILE=$(shell rpmspec -D"VERSION $(VERSION)" -q `ls cockpit-machines.spec.in cockpit-machines.spec 2>/dev/null | head -n1`).rpm
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
@@ -102,7 +102,7 @@ devel-install: $(WEBPACK_TEST)
 	mkdir -p ~/.local/share/cockpit
 	ln -s `pwd`/dist ~/.local/share/cockpit/$(PACKAGE_NAME)
 
-dist-gzip: $(TARFILE)
+dist: $(TARFILE)
 	@ls -1 $(TARFILE)
 
 # when building a distribution tarball, call webpack with a 'production' environment
@@ -111,7 +111,7 @@ dist-gzip: $(TARFILE)
 # node_modules/ can be reconstructed if necessary)
 $(TARFILE): export NODE_ENV=production
 $(TARFILE): $(WEBPACK_TEST) $(RPM_NAME).spec
-	tar czf $(TARFILE) --transform 's,^,cockpit-$(PACKAGE_NAME)/,' \
+	tar --xz -cf $(TARFILE) --transform 's,^,cockpit-$(PACKAGE_NAME)/,' \
 		--exclude $(RPM_NAME).spec.in \
 		--exclude test/reference \
 		$$(git ls-files) $(LIB_TEST) src/lib/ package-lock.json $(RPM_NAME).spec dist/; \
@@ -207,4 +207,4 @@ $(NODE_MODULES_TEST): package.json
 	env -u NODE_ENV npm install
 	env -u NODE_ENV npm prune
 
-.PHONY: all clean install devel-install dist-gzip node-cache srpm rpm check vm update-po
+.PHONY: all clean install devel-install dist node-cache srpm rpm check vm update-po

--- a/cockpit-machines.spec.in
+++ b/cockpit-machines.spec.in
@@ -22,7 +22,7 @@ Summary:        Cockpit user interface for virtual machines
 License:        LGPLv2+ and MIT
 URL:            https://github.com/cockpit-project/cockpit-machines
 
-Source0:        https://github.com/cockpit-project/cockpit-machines/releases/download/%{version}/cockpit-machines-%{version}.tar.gz
+Source0:        https://github.com/cockpit-project/cockpit-machines/releases/download/%{version}/cockpit-machines-%{version}.tar.xz
 BuildArch:      noarch
 BuildRequires:  libappstream-glib
 BuildRequires:  make

--- a/packit.yaml
+++ b/packit.yaml
@@ -6,7 +6,7 @@ downstream_package_name: cockpit-machines
 actions:
   post-upstream-clone: make cockpit-machines.spec
   create-archive:
-    - make dist-gzip DOWNLOAD_DIST_OPTIONS=--wait FORCE_DOWNLOAD_DIST=1
+    - make dist DOWNLOAD_DIST_OPTIONS=--wait FORCE_DOWNLOAD_DIST=1
     - find -name 'cockpit-machines-*.tar.gz'
 jobs:
   - job: tests

--- a/test/vm.install
+++ b/test/vm.install
@@ -21,10 +21,10 @@ if [ -d /var/tmp/debian ]; then
 
     # build source package
     cd /var/tmp
-    TAR=$(ls cockpit-machines-*.tar.gz)
+    TAR=$(ls cockpit-machines-*.tar.xz)
     VERSION="${TAR#cockpit-machines-}"
-    VERSION="${VERSION%.tar.gz}"
-    ln -s $TAR cockpit-machines_${VERSION}.orig.tar.gz
+    VERSION="${VERSION%.tar.xz}"
+    ln -s $TAR cockpit-machines_${VERSION}.orig.tar.xz
     tar xf "$TAR"
     cd cockpit-machines
     cp -r ../debian .


### PR DESCRIPTION
Ported most commits from https://github.com/cockpit-project/starter-kit/pull/488 , except for the one that actually rebuilds the webpack during RPM. We don't currently have pressure to do this for existing projects, and with the commits from these PRs (and thus having node cache tarballs available for releases), we could enable this quickly if/when needed.