### PR TITLE
fmf: Go back to chromium on Fedora, enable CentOS 8 in packit

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -13,6 +13,7 @@ jobs:
     trigger: pull_request
     metadata:
       targets:
-      - fedora-33
       - fedora-34
+      - fedora-35
       - fedora-rawhide
+      - centos-stream-8

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -21,6 +21,11 @@ mv .git dot-git
 
 . /etc/os-release
 export TEST_OS="${ID}-${VERSION_ID/./-}"
+
+if [ "$TEST_OS" = "centos-8" ]; then
+    TEST_OS=centos-8-stream
+fi
+
 export TEST_AUDIT_NO_SELINUX=1
 
 EXCLUDES=""

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -38,6 +38,11 @@ if [ "$ID" = "rhel" ]; then
     "
 fi
 
+# packit centos-stream-8
+if [ "$TEST_OS" = centos-8-stream ]; then
+    EXCLUDES="TestMachinesConsoles.testExternalConsole"
+fi
+
 # Fedora gating tests are running on infra without /dev/kvm; Machines tests are too darn slow there
 # so just pick a representative sample
 if [ "$ID" = "fedora" ]; then


### PR DESCRIPTION
Firefox has not been installable in rawhide for a long time, which
breaks our tests. Go back to chromium for Fedora, but keep Firefox on
RHEL/CentOS as that's its official browser.