### PR TITLE
 Fix labels for block/character device source

### DIFF
--- a/src/components/vm/hostdevs/hostDevCard.jsx
+++ b/src/components/vm/hostdevs/hostDevCard.jsx
@@ -126,11 +126,11 @@ export const VmHostDevCard = ({ vm, nodeDevices, config }) => {
         } else if (hostDev.type === "storage") {
             const block = hostDev.source.block;
 
-            addOptionalToCell(cell, block, `${hostdevId}-block`, _("Block"));
+            addOptionalToCell(cell, block, `${hostdevId}-block`, _("Path"));
         } else if (hostDev.type === "misc") {
             const ch = hostDev.source.char;
 
-            addOptionalToCell(cell, ch, `${hostdevId}-char`, _("Char"));
+            addOptionalToCell(cell, ch, `${hostdevId}-char`, _("Path"));
         } else if (hostDev.type === "net") {
             const iface = hostDev.source.interface;
 


### PR DESCRIPTION
 These describe the path to the block/character device in the host OS.
 Let's use that wording instead as for "Char" can't even be translated.