### PR TITLE
Add support for multiple pty consoles

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint-config-standard-react": "^9.2.0",
     "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jsx-a11y": "^6.3.1",
+    "eslint-plugin-jsx-a11y": "~6.4.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.21.0",

--- a/src/components/vm/consoles/desktopConsole.jsx
+++ b/src/components/vm/consoles/desktopConsole.jsx
@@ -36,10 +36,10 @@ function fmt_to_fragments(fmt) {
     return React.createElement.apply(null, [React.Fragment, { }].concat(fmt.split(/(\$[0-9]+)/g).map(replace)));
 }
 
-const DesktopConsoleDownload = ({ displays, onDesktopConsole }) => {
+const DesktopConsoleDownload = ({ vnc, spice, onDesktopConsole }) => {
     return (
-        <DesktopViewer spice={displays.spice}
-                       vnc={displays.vnc}
+        <DesktopViewer spice={spice}
+                       vnc={vnc}
                        onDownload={onDesktopConsole}
                        textManualConnection={_("Manual connection")}
                        textNoProtocol={_("No connection available")}

--- a/src/libvirt-xml-parse.js
+++ b/src/libvirt-xml-parse.js
@@ -274,7 +274,7 @@ export function parseDumpxmlForCpu(cpuElem) {
 }
 
 export function parseDumpxmlForConsoles(devicesElem) {
-    const displays = {};
+    const displays = [];
     const graphicsElems = devicesElem.getElementsByTagName("graphics");
     if (graphicsElems) {
         for (let i = 0; i < graphicsElems.length; i++) {
@@ -290,7 +290,7 @@ export function parseDumpxmlForConsoles(devicesElem) {
             if (display.type &&
                 (display.autoport ||
                 (display.address && (display.port || display.tlsPort)))) {
-                displays[display.type] = display;
+                displays.push(display);
                 logDebug(`parseDumpxmlForConsoles(): graphics device found: ${JSON.stringify(display)}`);
             } else {
                 console.warn(`parseDumpxmlForConsoles(): mandatory properties are missing in dumpxml, found: ${JSON.stringify(display)}`);
@@ -304,9 +304,8 @@ export function parseDumpxmlForConsoles(devicesElem) {
         for (let i = 0; i < consoleElems.length; i++) {
             const consoleElem = consoleElems[i];
             if (consoleElem.getAttribute('type') === 'pty') {
-                // Definition of serial console is detected.
-                // So far no additional details needs to be parsed since the console is accessed via 'virsh console'.
-                displays.pty = {};
+                const aliasElem = getSingleOptionalElem(consoleElem, 'alias');
+                displays.push({ type: 'pty', alias: aliasElem ? aliasElem.getAttribute('name') : undefined });
             }
         }
     }

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -83,7 +83,12 @@ export const domainCanPause = (vmState) => vmState == 'running';
 export const domainCanRename = (vmState) => vmState == 'shut off';
 export const domainCanResume = (vmState) => vmState == 'paused';
 export const domainIsRunning = (vmState) => domainCanReset(vmState);
-export const domainSerialConsoleCommand = ({ vm }) => vm.displays.pty ? ['virsh', ...VMS_CONFIG.Virsh.connections[vm.connectionName].params, 'console', vm.name] : false;
+export const domainSerialConsoleCommand = ({ vm, alias }) => {
+    if (vm.displays.find(display => display.type == 'pty'))
+        return ['virsh', ...VMS_CONFIG.Virsh.connections[vm.connectionName].params, 'console', vm.name, alias || ''];
+    else
+        return false;
+};
 
 let pythonPath;
 

--- a/src/libvirtUtils.js
+++ b/src/libvirtUtils.js
@@ -52,12 +52,13 @@ function prepareParamsFromObjOfObjs(objectData, valueTransformer) {
 }
 
 export function prepareDisplaysParam(displays) {
-    return prepareParamsFromObjOfObjs(displays, display => {
+    return prepareParamsFromArrOfObjs(displays.filter(display => ["vnc", "spice"].includes(display.type)), display => {
         return {
             type: display.type,
             listen: display.address,
             port: display.port,
             tlsport: display.tlsPort,
+            alias: display.alias,
         };
     });
 }

--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -103,6 +103,7 @@ class TestMachinesConsoles(VirtualMachinesCase):
     @no_retry_when_changed
     def testSerialConsole(self):
         b = self.browser
+        m = self.machine
         name = "vmWithSerialConsole"
 
         self.createVm(name, graphics='vnc', ptyconsole=True)
@@ -130,10 +131,21 @@ class TestMachinesConsoles(VirtualMachinesCase):
         b.click("button:contains(Expand)")
         b.assert_pixels("#vm-vmWithSerialConsole-consoles-page", "vm-details-console-serial")
 
+        # Add a second serial console
+        m.execute("virsh destroy vmWithSerialConsole && virt-xml --add-device vmWithSerialConsole --console pty,target_type=virtio && virsh start vmWithSerialConsole")
+        b.click("#pf-c-console__type-selector")
+        b.wait_visible("#pf-c-console__type-selector + .pf-c-select__menu")
+        b.click("li:contains('Serial console (console0)') button")
+        b.wait(lambda: m.execute("ps aux | grep 'virsh -c qemu:///system console vmWithSerialConsole console0'"))
+        b.click("#pf-c-console__type-selector")
+        b.click("li:contains('Serial console (console1)') button")
+        b.wait(lambda: m.execute("ps aux | grep 'virsh -c qemu:///system console vmWithSerialConsole console1'"))
+
         # disconnecting the serial console closes the pty channel
         self.allow_journal_messages("connection unexpectedly closed by peer",
                                     ".*Connection reset by peer")
         self.allow_browser_errors("Disconnection timed out.")
+        self.allow_journal_messages(".* couldn't shutdown fd: Transport endpoint is not connected")
 
     def testSwitchConsoleFromSerialToGraphical(self):
         b = self.browser


### PR DESCRIPTION
### Machines: Support selecting between consoles of the same type

VM configurations can specify multiple pty consoles. For example: a VM can have an emulated serial console and a virtio serial console. The console menu now shows alias identifiers in the console menu, making it possible to choose between consoles of the same type.

![140937551-4e7bb79d-54da-4bf7-9c67-b1ac85f1f074](https://user-images.githubusercontent.com/10246/141093360-44074da0-828a-4e3a-bdac-94106064b92a.png)



