### PR TITLE
packaging: Move Debian watch and packit to tar.xz

### DIFF
--- a/packaging/debian/watch
+++ b/packaging/debian/watch
@@ -1,2 +1,2 @@
 version=4
-https://github.com/cockpit-project/cockpit-machines/releases/ .*/cockpit-machines-([\d\.]+)\.tar\.gz
+https://github.com/cockpit-project/cockpit-machines/releases/ .*/cockpit-machines-([\d\.]+)\.tar\.xz

--- a/packit.yaml
+++ b/packit.yaml
@@ -7,7 +7,7 @@ actions:
   post-upstream-clone: make cockpit-machines.spec
   create-archive:
     - make dist DOWNLOAD_DIST_OPTIONS=--wait FORCE_DOWNLOAD_DIST=1
-    - find -name 'cockpit-machines-*.tar.gz'
+    - find -name 'cockpit-machines-*.tar.xz'
 jobs:
   - job: tests
     trigger: pull_request


### PR DESCRIPTION
These two places were forgotten in commit 544cb90b70.