### PR TITLE
workflows: Run npm-update with deploy key

### DIFF
--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   npm-update:
     runs-on: ubuntu-20.04
+    environment: self
+    permissions:
+      pull-requests: write
     steps:
       - name: Set up dependencies
         run: |
@@ -16,13 +19,12 @@ jobs:
       - name: Set up configuration and secrets
         run: |
           printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
-          echo '${{ secrets.COCKPITUOUS_TOKEN }}' > ~/.config/github-token
+          echo '${{ github.token }}' > ~/.config/github-token
 
       - name: Clone repository
         uses: actions/checkout@v2
         with:
-          # the default GITHUB_TOKEN would override our ~/.git-credentials from above
-          token: '${{ secrets.COCKPITUOUS_TOKEN }}'
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Run npm-update bot
         run: |


### PR DESCRIPTION
Drop the final use of COCKPITUOUS_TOKEN from this repo and use the
`DEPLOY_KEY` in the `self` environment instead.  The PR opening gets
done with the scope-constrained GitHub Actions token.