### PR TITLE
Add script to (re-)generate GitHub deploy keys

### DIFF
--- a/.github/deploy-keys.sh
+++ b/.github/deploy-keys.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# (Re-)generate all deploy keys on https://github.com/cockpit-project/cockpit-machines/settings/environments
+
+set -eux
+
+ORG=cockpit-project
+THIS=cockpit-machines
+
+[ -e bots ] || make bots
+
+# for workflows pushing to our own repo: npm-update.yml and weblate-sync-po.yml
+bots/github-upload-secrets --receiver "${ORG}/${THIS}" --env self --ssh-keygen DEPLOY_KEY --deploy-to "${ORG}/${THIS}"
+
+# for weblate-sync-pot.yml: push to https://github.com/cockpit-project/cockpit-machines-weblate/settings/keys
+bots/github-upload-secrets --receiver "${ORG}/${THIS}" --env "${THIS}-weblate" --ssh-keygen DEPLOY_KEY --deploy-to "${ORG}/${THIS}-weblate"
+
+# for {publish,prune}-dist.yml: push to https://github.com/cockpit-project/cockpit-machines-dist/settings/keys
+bots/github-upload-secrets --receiver "${ORG}/${THIS}" --env "${THIS}-dist" --ssh-keygen DEPLOY_KEY --deploy-to "${ORG}/${THIS}-dist"


### PR DESCRIPTION
These deploy keys were created manually so far. Let's keep them in a
shell script so that we don't need to remember which ones we need, and
how to re-generate them en masse if/when we need to.

Adapted from https://github.com/cockpit-project/cockpit-podman/commit/1616cf96b24

----

I ran the script locally, so https://github.com/cockpit-project/cockpit-machines/settings/environments has fresh keys. build/publish-dist will already use these.