### PR TITLE
fmf: Run tests with firefox

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -12,17 +12,12 @@ LOGS="$(pwd)/logs"
 mkdir -p "$LOGS"
 chmod a+w "$LOGS"
 
-# install browser; on RHEL/CentOS, use firefox
-if grep -Eq 'ID=.*(rhel|centos)' /etc/os-release; then
-    # Install firefox to pull in all the deps
-    dnf install -y firefox
-    curl --location 'https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US' | tar -C /usr/local/lib/ -xj
-    ln -s /usr/local/lib/firefox/firefox /usr/local/bin/
-    TEST_BROWSER=firefox
-else
-    dnf install -y chromium
-    TEST_BROWSER=chromium
-fi
+# install firefox (available everywhere in Fedora and RHEL); install the package to pull in all the dependencies
+# we don't need the H.264 codec, and it is sometimes not available (rhbz#2005760)
+dnf install --disablerepo=fedora-cisco-openh264 -y firefox
+# install nightly for Chrome DevTools Protocol support
+curl --location 'https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US' | tar -C /usr/local/lib/ -xj
+ln -s /usr/local/lib/firefox/firefox /usr/local/bin/
 
 #HACK: unbreak rhel-9-0's default choice of 999999999 rounds, see https://bugzilla.redhat.com/show_bug.cgi?id=1993919
 sed -ie 's/#SHA_CRYPT_MAX_ROUNDS 5000/SHA_CRYPT_MAX_ROUNDS 5000/' /etc/login.defs
@@ -75,7 +70,7 @@ if grep -Eq 'PLATFORM_ID=.*(f35)' /etc/os-release; then
 fi
 
 # Run tests as unprivileged user
-su - -c "env TEST_BROWSER=$TEST_BROWSER SOURCE=$SOURCE LOGS=$LOGS $TESTS/run-test.sh" runtest
+su - -c "env TEST_BROWSER=firefox SOURCE=$SOURCE LOGS=$LOGS $TESTS/run-test.sh" runtest
 
 RC=$(cat $LOGS/exitcode)
 exit ${RC:-1}

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -6,6 +6,7 @@ require:
   - cockpit-ws
   # build/test infra dependencies
   - virt-install
+  - bzip2
   - git-core
   - libvirt-python3
   - make


### PR DESCRIPTION
Chromium has started to crash in current Fedora, and is not easily
available in RHEL.

Install bzip2 to unpack the nightly tarball.

Cherry-picked from starter-kit commit 0bc01714ee7d2

---

This should fix our current [persistent failures in packit](http://artifacts.dev.testing-farm.io/df63686e-deca-49ae-8218-551f8aa8e3bd/) on F34/rawhide.