### PR TITLE
Fix building with npm 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ip": "^1.1.5",
     "jed": "^1.1.1",
     "mini-css-extract-plugin": "^0.11.0",
-    "null-loader": "^3.0.0",
+    "null-loader": "^4.0.0",
     "po2json": "^1.0.0-alpha",
     "raw-loader": "^4.0.0",
     "sass": "^1.35.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@patternfly/patternfly": "4.135.2",
     "@patternfly/react-console": "4.13.8",
     "@patternfly/react-core": "4.157.3",
+    "@patternfly/react-icons": "4.13.0",
     "@patternfly/react-styles": "4.11.16",
     "@patternfly/react-table": "4.31.3",
     "date-fns": "2.24.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,8 @@ const CockpitPoPlugin = require("./src/lib/cockpit-po-plugin");
 
 const webpack = require("webpack");
 
-const nodedir = path.resolve((process.env.SRCDIR || __dirname), "node_modules");
+// absolute path disables recursive module resolution, so build a relative one
+const nodedir = path.relative(process.cwd(), path.resolve((process.env.SRCDIR || __dirname), "node_modules"));
 
 /* A standard nodejs and webpack pattern */
 const production = process.env.NODE_ENV === 'production';


### PR DESCRIPTION
Tested in a Fedora 35 toolbox. Similar to https://github.com/cockpit-project/starter-kit/pull/501, but requires a little more work.

There are still two warnings:
```
pm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: react-ellipsis-with-tooltip@1.1.1
npm WARN Found: react-bootstrap@0.33.1
npm WARN node_modules/react-bootstrap
npm WARN   react-bootstrap@"^0.33.0" from patternfly-react@2.39.17
npm WARN   node_modules/patternfly-react
npm WARN     patternfly-react@"2.39.17" from the root project
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer react-bootstrap@"0.31.x || 0.32.x" from react-ellipsis-with-tooltip@1.1.1
npm WARN node_modules/react-ellipsis-with-tooltip
npm WARN   react-ellipsis-with-tooltip@"^1.0.8" from patternfly-react@2.39.17
npm WARN   node_modules/patternfly-react
npm WARN 
npm WARN Conflicting peer dependency: react-bootstrap@0.32.4
npm WARN node_modules/react-bootstrap
npm WARN   peer react-bootstrap@"0.31.x || 0.32.x" from react-ellipsis-with-tooltip@1.1.1
npm WARN   node_modules/react-ellipsis-with-tooltip
npm WARN     react-ellipsis-with-tooltip@"^1.0.8" from patternfly-react@2.39.17
npm WARN     node_modules/patternfly-react
```

There is not that much that we can do about them, PF3 is dead. At some point we need to port our boot order dialog to PF4.