### PR TITLE
Fix cloning of VMs on session connection

### DIFF
--- a/src/components/vm/vmCloneDialog.jsx
+++ b/src/components/vm/vmCloneDialog.jsx
@@ -49,7 +49,10 @@ export const CloneDialog = ({ name, connectionName, toggleModal }) => {
         }
 
         setInProgress(true);
-        return cockpit.spawn(["virt-clone", "--connect", "qemu:///" + connectionName, "--original", name, "--name", newVmName, "--auto-clone"], { superuser: "try", pty: true })
+        const options = { pty: true };
+        if (connectionName === "system")
+            options.superuser = "try";
+        return cockpit.spawn(["virt-clone", "--connect", "qemu:///" + connectionName, "--original", name, "--name", newVmName, "--auto-clone"], options)
                 .stream(setVirtCloneOutput)
                 .then(toggleModal, exc => {
                     setInProgress(false);

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -159,14 +159,6 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         b.wait_in_text("#virtual-machines-listing .pf-c-empty-state", "No VM is running")
         m.execute("virsh define --file /tmp/subVmTest1.xml")
 
-        # clone
-        self.performAction("subVmTest1", "clone")
-
-        b.wait_text(".pf-c-modal-box__title-text", "Create a clone VM based on subVmTest1")
-        b.click("footer button.pf-m-primary")
-        b.wait_not_present(".pf-c-modal-box")
-        self.waitVmRow("subVmTest1-clone")
-
         # start another one, should appear automatically
         self.createVm("subVmTest2")
         b.wait_in_text("#vm-subVmTest2-state", "Running")
@@ -224,6 +216,29 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         b.click('#vm-subVmTest2-state button:contains("view more")')
         b.wait_in_text(".pf-c-popover", "VM subVmTest2 failed to start")
         b.click('#vm-subVmTest2-state button[aria-label=label-close-button]')
+
+    def testCloneSessionConnection(self):
+        self.testClone(connectionName='session')
+
+    def testClone(self, connectionName='system'):
+        b = self.browser
+
+        self.run_admin("mkdir /tmp/vmdir", connectionName)
+        self.addCleanup(self.run_admin, "rm -rf /tmp/vmdir/", connectionName)
+
+        self.login_and_go("/machines")
+        b.wait_in_text("body", "Virtual machines")
+
+        self.createVm("subVmTest1", running=False, connection=connectionName)
+
+        self.waitVmRow("subVmTest1", connectionName=connectionName)
+
+        self.performAction("subVmTest1", "clone")
+
+        b.wait_text(".pf-c-modal-box__title-text", "Create a clone VM based on subVmTest1")
+        b.click("footer button.pf-m-primary")
+        b.wait_not_present(".pf-c-modal-box")
+        self.waitVmRow("subVmTest1-clone", connectionName=connectionName)
 
     def testRename(self):
         b = self.browser


### PR DESCRIPTION
If a user has administrative access, then setting "superuser: 'try'" would
cause that a VM which is supposed to be cloned would be looked up in
session connection of root, not the session connection of the user,
resulting in virt-clone not being able to find the correct VM.

Screenshot of the bug:
![Screenshot from 2021-10-27 16-10-26](https://user-images.githubusercontent.com/42733240/139098312-0f7942cf-e1a4-48ea-8dca-d3a0a1ba6511.png)
