### PR TITLE
npm: Update to latest eslint-plugin-jsx-a11y

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint-config-standard-react": "^9.2.0",
     "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jsx-a11y": "~6.4.1",
+    "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.21.0",

--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -146,6 +146,7 @@ class TestMachinesConsoles(VirtualMachinesCase):
                                     ".*Connection reset by peer")
         self.allow_browser_errors("Disconnection timed out.")
         self.allow_journal_messages(".* couldn't shutdown fd: Transport endpoint is not connected")
+        self.allow_journal_messages("127.0.0.1:5900: couldn't read: Connection refused")
 
     def testSwitchConsoleFromSerialToGraphical(self):
         b = self.browser


### PR DESCRIPTION
Version 6.5.1 got released which works with ESLint 7 again and fixes
[1]. Bump the dependency. This essentially reverts the hack from
commit c08230873bd59.
   
[1] https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/824

---

The second commit fixes [this flake](https://logs.cockpit-project.org/logs/pull-447-20211111-061104-f0949c5d-ubuntu-2004/log.html#4)