### PR TITLE
test: Fix race condition in TestMachinesFilesystems.testBasicSystemConnection

### DIFF
--- a/test/check-machines-filesystems
+++ b/test/check-machines-filesystems
@@ -58,7 +58,7 @@ class TestMachinesFilesystems(VirtualMachinesCase):
         # wait until page initialized
         b.wait_visible("#vm-subVmTest1-hostdevs")
 
-        if m.image in ["rhel-8-5", "centos-8-stream", "ubuntu-2004", "fedora-33"] or connection == "session":
+        if m.image in ["rhel-8-5", "ubuntu-2004", "fedora-33"] or connection == "session":
             b.wait_not_present("#vm-subVmTest1-filesystems-add")
             return
 

--- a/test/check-machines-filesystems
+++ b/test/check-machines-filesystems
@@ -55,6 +55,8 @@ class TestMachinesFilesystems(VirtualMachinesCase):
         self.login_and_go("/machines")
         self.createVm("subVmTest1", running=False, connection=connection)
         self.goToVmPage("subVmTest1", connectionName=connection)
+        # wait until page initialized
+        b.wait_visible("#vm-subVmTest1-hostdevs")
 
         if m.image in ["rhel-8-5", "centos-8-stream", "ubuntu-2004", "fedora-33"] or connection == "session":
             b.wait_not_present("#vm-subVmTest1-filesystems-add")


### PR DESCRIPTION
The negative test for "Shared Directories card not present" is also able
to pass on OSes which do support it, but where detection takes longer
than reaching the check. This particularly affects centos-8-stream.

Wait until the page sufficiently initialized, i.e. when the "host
devices" is visible.

Update the test for current CentOS 8 stream. This fixes [this failure](http://artifacts.dev.testing-farm.io/4c9d5e09-adc0-4eed-bde0-875d8ba05d51/) in packit.

 - [ ] Requires https://github.com/cockpit-project/bots/issues/2639 so that our bots c8s image picks up the latest libvirt