### PR TITLE
Bump cockpit test lib to fix Browser.logout() for cockpit 258

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 253; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 8b00034ff0aa0dc8014aef32067559ccfb88afb2; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -472,7 +472,10 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                       start_vm=True))
 
         self.browser.switch_to_top()
-        self.browser.wait_not_visible("#navbar-oops")
+        if self.system_before(258):
+            self.browser.wait_not_visible("#navbar-oops")
+        else:
+            self.browser.wait_not_present("#navbar-oops")
 
         # define again the default storage pool for system connection
         # we need so that the UI will know the remaining available space when we use that pool's path

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1554,11 +1554,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         # HACK: Capabilities are not updated dynamically
         # https://bugzilla.redhat.com/show_bug.cgi?id=1807198
         def hack_broken_caps():
-            if m.image in [
-                "fedora-33", "fedora-34", "fedora-testing",
-                "centos-8-stream", "centos-9-stream", "rhel-8-4", "rhel-8-5", "rhel-8-6", "rhel-9-0",
-                "ubuntu-2004", "ubuntu-stable", "debian-stable", "debian-testing"
-            ]:
+            if m.image in ["rhel-8-5", "ubuntu-2004"]:
                 m.execute("systemctl restart libvirtd")
                 # We don't get events for shut off VMs so reload the page
                 b.reload()


### PR DESCRIPTION
The shell DOM changed in Cockpit 258. Pick up the Browser.logout()
change which can deal with both old and new shell versions.

The new test API blurs inputs for pixel tests, adjust the reference
images accordingly.

 - https://github.com/cockpit-project/cockpit/pull/16662