### PR TITLE
test: Drop obsolete vm.install hacks

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -6,18 +6,7 @@ set -eu
 # for Debian based images, build and install debs
 if [ -d /var/tmp/debian ]; then
     apt-get update
-    if grep -q 'VERSION_ID="21.04"' /etc/os-release; then
-        # HACK: nftables backend does not currently work with libvirt: https://launchpad.net/bugs/1799095
-        sed -i 's/FirewallBackend=nftables/FirewallBackend=iptables/' /etc/firewalld/firewalld.conf
-    elif grep -q 'VERSION_ID="20.10"' /etc/os-release; then
-        # HACK: nftables backend does not currently work with libvirt: https://launchpad.net/bugs/1799095
-        sed -i 's/FirewallBackend=nftables/FirewallBackend=iptables/' /etc/firewalld/firewalld.conf
-
-        BACKPORTS="-t groovy-backports"
-    elif grep -q 'VERSION_ID="10"' /etc/os-release; then
-        BACKPORTS="-t buster-backports"
-    fi
-    eatmydata apt-get install ${BACKPORTS:-} ${APT_INSTALL_OPTIONS:-} -y cockpit-ws cockpit-system
+    eatmydata apt-get install ${APT_INSTALL_OPTIONS:-} -y cockpit-ws cockpit-system
 
     # build source package
     cd /var/tmp


### PR DESCRIPTION
Our ubuntu-stable image is 21.04 now, and debian-stable is Debian 11,
so drop the now unused backports installation.

The virsh network works fine with the default configuration now, so drop
the firewalld config hack.