### PR TITLE
test: Stop using the internet for Debian/Ubuntu tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ $(RPMFILE): $(TARFILE) $(RPM_NAME).spec
 # determine what to depend on and do for Fedora/RHEL/Debian VM preparation
 ifneq ($(filter debian-% ubuntu-%,$(TEST_OS)),)
 VM_DEP=$(TARFILE) packaging/debian/rules packaging/debian/control
-VM_PACKAGE=--upload `pwd`/$(TARFILE):/var/tmp/ --upload `pwd`/packaging/debian:/var/tmp/
+VM_PACKAGE=--no-network --upload `pwd`/$(TARFILE):/var/tmp/ --upload `pwd`/packaging/debian:/var/tmp/
 else
 ifneq ($(filter arch,$(TEST_OS)),)
 VM_DEP=$(TARFILE) packaging/arch/PKGBUILD

--- a/test/vm.install
+++ b/test/vm.install
@@ -5,9 +5,6 @@ set -eu
 
 # for Debian based images, build and install debs
 if [ -d /var/tmp/debian ]; then
-    apt-get update
-    eatmydata apt-get install ${APT_INSTALL_OPTIONS:-} -y cockpit-ws cockpit-system
-
     # build source package
     cd /var/tmp
     TAR=$(ls cockpit-machines-*.tar.xz)


### PR DESCRIPTION
Since https://github.com/cockpit-project/bots/commit/b06bd37b0ad our
Debian/Ubuntu test VMs have the basic cockpit packages pre-installed.
Drop the apt calls to install them, so that we stop getting surprise
breakages due to new cockpit versions. These will now properly appear on
image refreshes.

That was the last thing using the internet for these tests, so switch
them to run offline.