### PR TITLE
Fix node device attachment and detachment for usb devices without bus/device numbers

### DIFF
--- a/src/components/vm/hostdevs/hostDevAdd.jsx
+++ b/src/components/vm/hostdevs/hostDevAdd.jsx
@@ -35,7 +35,7 @@ import {
 
 import { ModalError } from "cockpit-components-inline-notification.jsx";
 import { domainAttachHostDevices, domainGet } from "../../../libvirtApi/domain.js";
-import { findHostNodeDevice } from "../../../helpers.js";
+import { findMatchingNodeDevices } from "../../../helpers.js";
 import { getOptionalValue } from "./hostDevCard.jsx";
 import "./hostDevAdd.scss";
 
@@ -151,9 +151,9 @@ function getSelectableDevices(nodeDevices, vm, type) {
         let deviceIsAlreadyAttached = false;
 
         vm.hostDevices.forEach(hostDev => {
-            const foundNodeDevice = findHostNodeDevice(hostDev, nodeDevices);
+            const foundNodeDevices = findMatchingNodeDevices(hostDev, nodeDevices);
 
-            if (foundNodeDevice && nodeDev.path === foundNodeDevice.path)
+            if (foundNodeDevices.length === 1 && nodeDev.path === foundNodeDevices[0].path)
                 deviceIsAlreadyAttached = true;
         });
 

--- a/src/components/vm/hostdevs/hostDevCard.jsx
+++ b/src/components/vm/hostdevs/hostDevCard.jsx
@@ -219,7 +219,7 @@ export const VmHostDevCard = ({ vm, nodeDevices, config }) => {
                     <DeleteResourceButton objectId={`${id}-hostdev-${hostdevId}`}
                                           actionName={_("Remove")}
                                           showDialog={() => setDeleteDialogProps({
-                                              objectType: hostdev.type + " host device",
+                                              objectType: cockpit.format(_("$1 host device"), hostdev.type),
                                               objectName: "",
                                               onClose: () => setDeleteDialogProps(undefined),
                                               deleteHandler: () => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -399,8 +399,8 @@ export function findHostNodeDevice(hostdev, nodeDevices) {
     case "usb": {
         const vendorId = hostdev.source.vendor.id;
         const productId = hostdev.source.product.id;
-        const device = parseInt(hostdev.source.device, 16).toString();
-        const bus = parseInt(hostdev.source.bus, 16).toString();
+        const device = hostdev.source.device;
+        const bus = hostdev.source.bus;
 
         nodeDev = nodeDevices.find(d => {
             // vendor and product are properties used to identify correct device. But vendor and product
@@ -870,6 +870,32 @@ export function getNodeDevSource(dev) {
         const bus = dev.busnum;
 
         source = `${bus}.${device}`;
+    } else {
+        throw new Error(`getNodeDevSource: unsupport device type '${dev.type}'`);
+    }
+
+    return source;
+}
+
+export function getHostDevSourceObject(dev) {
+    let source;
+
+    if (dev.type === "pci") {
+        const domain = dev.source.address.domain;
+        const bus = dev.source.address.bus;
+        const slot = dev.source.address.slot;
+        const func = dev.source.address.func;
+
+        source = { domain, bus, slot, func };
+    } else if (dev.type === "usb") {
+        const device = dev.source.device;
+        const bus = dev.source.bus;
+        const vendor = dev.source.vendor.id;
+        const product = dev.source.product.id;
+
+        source = { vendor, product, bus, device };
+    } else {
+        throw new Error(`getHostDevSourceObject: unsupport device type '${dev.type}'`);
     }
 
     return source;

--- a/src/libvirt-xml-parse.js
+++ b/src/libvirt-xml-parse.js
@@ -522,6 +522,7 @@ export function parseDumpxmlForHostDevices(devicesElem) {
             case "usb": {
                 const addressElem = getSingleOptionalElem(hostdevElem, 'address');
                 const sourceElem = getSingleOptionalElem(hostdevElem, 'source');
+                const sourceAddressElem = getSingleOptionalElem(sourceElem, 'address');
 
                 let vendorElem, productElem;
                 if (sourceElem) {
@@ -542,8 +543,8 @@ export function parseDumpxmlForHostDevices(devicesElem) {
                         product: {
                             id: productElem ? productElem.getAttribute('id') : undefined,
                         },
-                        device: addressElem.getAttribute('device'),
-                        bus: addressElem.getAttribute('bus'),
+                        device: sourceAddressElem ? sourceAddressElem.getAttribute('device') : undefined,
+                        bus: sourceAddressElem ? sourceAddressElem.getAttribute('bus') : undefined,
                     },
                 };
                 hostdevs.push(dev);

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -136,14 +136,16 @@ export function domainAttachDisk({
     return domainAttachDevice({ connectionName, vmId, permanent, hotplug, xmlDesc });
 }
 
-export function domainAttachHostDevice({ connectionName, vmName, live, dev }) {
+export function domainAttachHostDevices({ connectionName, vmName, live, devices }) {
     const options = { err: "message" };
-    const source = getNodeDevSource(dev);
-    const args = ["virt-xml", "-c", `qemu:///${connectionName}`, vmName, "--add-device", "--hostdev", source];
+    const args = ["virt-xml", "-c", `qemu:///${connectionName}`, vmName];
+
+    devices.forEach(dev => {
+        args.push("--add-device", "--hostdev", getNodeDevSource(dev));
+    });
 
     if (connectionName === "system")
         options.superuser = "try";
-
     if (live)
         args.push("--update");
 

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -48,9 +48,6 @@ if [ "$TEST_OS" = "centos-8-stream" ]; then
     EXCLUDES="$EXCLUDES TestMachinesConsoles.testExternalConsole"
 fi
 
-# depends on available host devices, TF machines not predictable enough
-EXCLUDES="$EXCLUDES TestMachinesHostDevs.testHostDevAdd"
-
 # FIXME: https://github.com/cockpit-project/cockpit-machines/issues/581
 EXCLUDES="$EXCLUDES TestMachinesCreate.testCreateThenInstall"
 

--- a/test/check-machines-hostdevs
+++ b/test/check-machines-hostdevs
@@ -177,7 +177,9 @@ class TestMachinesHostDevs(VirtualMachinesCase):
 
             def verify(self):
                 b.wait_visible(f"#vm-subVmTest1-hostdev-{self.vm_dev_id}-product")
-                b.wait_in_text(f"#vm-subVmTest1-hostdev-{self.vm_dev_id}-product", self._model)
+                if (self._model != "(Undefined)"):
+                    b.wait_in_text(f"#vm-subVmTest1-hostdev-{self.vm_dev_id}-product", self._model)
+
                 b.wait_in_text(f"#vm-subVmTest1-hostdev-{self.vm_dev_id}-vendor", self._vendor)
 
             def verify_backend(self):

--- a/test/check-machines-hostdevs
+++ b/test/check-machines-hostdevs
@@ -30,7 +30,7 @@ sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
 
 from machineslib import VirtualMachinesCase  # noqa
 from testlib import skipImage, nondestructive, test_main  # noqa
-from machinesxmls import USB_HOSTDEV, PCI_HOSTDEV  # noqa
+from machinesxmls import USB_HOSTDEV, USB_HOSTDEV_NONEXISTENT, PCI_HOSTDEV  # noqa
 
 virt_xml_mock = """#!/usr/bin/python
 
@@ -71,10 +71,24 @@ class TestMachinesHostDevs(VirtualMachinesCase):
                 b.wait_in_text("#vm-subVmTest1-hostdev-1-source #1-device", "1")
                 b.wait_in_text("#vm-subVmTest1-hostdev-1-source #1-bus", "1")
 
-        # Test offline attachment of PCI host device
-        # A pci device should always be present
         m.execute("virsh destroy subVmTest1")
         b.wait_in_text("#vm-subVmTest1-state", "Shut off")
+
+        # Test attachment of non-existent host device
+        m.execute(f"echo \"{USB_HOSTDEV_NONEXISTENT}\" > /tmp/usbnonexistenthostedxml")
+        m.execute("virsh attach-device --domain subVmTest1 --file /tmp/usbnonexistenthostedxml --config")
+        b.reload()
+        b.enter_page('/machines')
+
+        b.wait_in_text("#vm-subVmTest1-hostdev-1-vendor", "0xffff")
+        b.wait_in_text("#vm-subVmTest1-hostdev-1-product", "0xffff")
+        b.wait_in_text("#vm-subVmTest1-hostdev-1-source #1-device", "Unspecified")
+        b.wait_in_text("#vm-subVmTest1-hostdev-1-source #1-bus", "Unspecified")
+
+        m.execute("virsh detach-device --domain subVmTest1 --file /tmp/usbnonexistenthostedxml --config")
+
+        # Test offline attachment of PCI host device
+        # A pci device should always be present
         m.execute(f"echo \"{PCI_HOSTDEV}\" > /tmp/pcihostedxml")
         m.execute("virsh attach-device --domain subVmTest1 --file /tmp/pcihostedxml --persistent")
         b.reload()

--- a/test/check-machines-hostdevs
+++ b/test/check-machines-hostdevs
@@ -21,6 +21,7 @@ import os
 import sys
 import subprocess
 import re
+import xml.etree.ElementTree as ET
 
 # import Cockpit's machinery for test VMs and its browser test API
 TEST_DIR = os.path.dirname(__file__)
@@ -92,9 +93,9 @@ class TestMachinesHostDevs(VirtualMachinesCase):
 
     @skipImage("exporting devices to qemu:///session not supported yet", "ubuntu-2004")
     def testHostDevAddSessionConnection(self):
-        self.testHostDevAdd('session')
+        self.testHostDevAddSingleDevice('session')
 
-    def testHostDevAdd(self, connectionName='system'):
+    def testHostDevAddSingleDevice(self, connectionName='system'):
         b = self.browser
         m = self.machine
 
@@ -193,7 +194,7 @@ class TestMachinesHostDevs(VirtualMachinesCase):
 
                     slot_parts = re.split(r":|\.", self._slot)
 
-                    if int(slot_parts[0]) == domain and int(slot_parts[1]) == bus and int(slot_parts[2]) == slot and int(slot_parts[3]) == func:
+                    if int(slot_parts[0], 16) == domain and int(slot_parts[1], 16) == bus and int(slot_parts[2], 16) == slot and int(slot_parts[3], 16) == func:
                         return
 
                 raise Exception("Verification failed. No matching node device was found in VM's xml.")
@@ -226,6 +227,87 @@ class TestMachinesHostDevs(VirtualMachinesCase):
             dev_type="pci",
             fail_message="Host device could not be attached",
         ).execute()
+
+    def testHostDevAddMultipleDevices(self, connectionName='system'):
+        b = self.browser
+        m = self.machine
+
+        self.run_admin("mkdir /tmp/vmdir", connectionName)
+        self.addCleanup(self.run_admin, "rm -rf /tmp/vmdir/", connectionName)
+
+        self.login_and_go("/machines")
+        b.wait_in_text("body", "Virtual machines")
+        self.createVm("subVmTest1", running=False, connection=connectionName)
+        self.goToVmPage("subVmTest1", connectionName)
+
+        b.wait_visible("#vm-subVmTest1-hostdevs")
+        b.wait_not_present("#vm-subVmTest1-hostdev-1-product")
+
+        b.click("button#vm-subVmTest1-hostdevs-add")
+        b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Add host device")
+        b.click("input#pci")
+
+        b.set_checked(".pf-c-table input[name='checkrow0']", True)
+        slot1 = b.text("#vm-subVmTest1-hostdevs-dialog table tbody tr:nth-child(1) td:nth-child(4) dd")
+
+        b.set_checked(".pf-c-table input[name='checkrow1']", True)
+        slot2 = b.text("#vm-subVmTest1-hostdevs-dialog table tbody tr:nth-child(2) td:nth-child(4) dd")
+
+        # PCI devies will be sorted in the UI by slot
+        if slot1 > slot2:
+            (slot1, slot2) = (slot2, slot1)
+
+        self.run_admin(f"virsh -c qemu:///{connectionName} dumpxml subVmTest1 > /tmp/vmdir/vmxml1", connectionName)
+        b.click(".pf-c-modal-box__footer button:contains(Add)")
+        b.wait_not_present("#vm-subVmTest1-hostdevs-dialog")
+
+        b.wait_visible("#vm-subVmTest1-hostdev-1-product")
+        b.wait_in_text("#1-slot", slot1)
+
+        b.wait_visible("#vm-subVmTest1-hostdev-2-product")
+        b.wait_in_text("#2-slot", slot2)
+
+        self.run_admin(f"virsh -c qemu:///{connectionName} dumpxml subVmTest1 > /tmp/vmdir/vmxml2", connectionName)
+        vm_diff = m.execute("diff /tmp/vmdir/vmxml1 /tmp/vmdir/vmxml2 | sed -e 's/^>//;1d'")  # Print difference between XMLs before and after adding host devices
+        vm_diff = f'<root>{vm_diff}</root>'  # Diff contains 2 <hostdevice> elements. Add root to ease xml parsing
+
+        root = ET.fromstring(vm_diff)
+
+        hostdev1_address_elem = root[0].find('source').find('address')
+        hostdev2_address_elem = root[1].find('source').find('address')
+
+        hostdev1_domain = hostdev1_address_elem.get('domain')[2:]  # Remove '0x' prefix from hex number
+        hostdev1_bus = hostdev1_address_elem.get('bus')[2:]
+        hostdev1_slot = hostdev1_address_elem.get('slot')[2:]
+        hostdev1_function = hostdev1_address_elem.get('function')[2:]
+        hostdev2_domain = hostdev2_address_elem.get('domain')[2:]
+        hostdev2_bus = hostdev2_address_elem.get('bus')[2:]
+        hostdev2_slot = hostdev2_address_elem.get('slot')[2:]
+        hostdev2_function = hostdev2_address_elem.get('function')[2:]
+
+        slot_parts1 = re.split(r":|\.", slot1)
+        slot_parts2 = re.split(r":|\.", slot2)
+        # Cannot guarantee order of host devices in VM's XML, try in different order in case of failure
+        try:
+            self.assertEqual(slot_parts1[0], hostdev1_domain)
+            self.assertEqual(slot_parts1[1], hostdev1_bus)
+            self.assertEqual(slot_parts1[2], hostdev1_slot)
+            self.assertEqual(slot_parts1[3], hostdev1_function)
+
+            self.assertEqual(slot_parts2[0], hostdev2_domain)
+            self.assertEqual(slot_parts2[1], hostdev2_bus)
+            self.assertEqual(slot_parts2[2], hostdev2_slot)
+            self.assertEqual(slot_parts2[3], hostdev2_function)
+        except AssertionError:
+            self.assertEqual(slot_parts1[0], hostdev2_domain)
+            self.assertEqual(slot_parts1[1], hostdev2_bus)
+            self.assertEqual(slot_parts1[2], hostdev2_slot)
+            self.assertEqual(slot_parts1[3], hostdev2_function)
+
+            self.assertEqual(slot_parts2[0], hostdev1_domain)
+            self.assertEqual(slot_parts2[1], hostdev1_bus)
+            self.assertEqual(slot_parts2[2], hostdev1_slot)
+            self.assertEqual(slot_parts2[3], hostdev1_function)
 
 
 if __name__ == '__main__':

--- a/test/machinesxmls.py
+++ b/test/machinesxmls.py
@@ -110,6 +110,13 @@ USB_HOSTDEV = """<hostdev mode='subsystem' type='usb'>
   </source>
 </hostdev>"""
 
+USB_HOSTDEV_NONEXISTENT = """<hostdev mode='subsystem' type='usb'>
+  <source>
+    <vendor id='0xffff'/>
+    <product id='0xffff'/>
+  </source>
+</hostdev>"""
+
 PCI_HOSTDEV = """<hostdev mode='subsystem' type='pci'>
   <source>
     <address domain='0x0000' bus='0x00' slot='0xF' function='0x0'/>


### PR DESCRIPTION
We also used to identify usb device by only 'vendor ID' and 'product ID'. But that will identify a wrong usb device when it has the same 'vendor ID' and 'product ID' with another usb device
And, in 'https://libvirt.org/formatnode.html', it seems that usb_device should always has bus and device numbere as there is no 'optional' label beside these two properties. So, it seems that we
won't miss anything

Relevant to https://bugzilla.redhat.com/show_bug.cgi?id=2018448

 - Land PR #601 to fix packit tests