### PR TITLE
tests: Change libvirt version checking which is just wrong to image check

### DIFF
--- a/test/check-machines-filesystems
+++ b/test/check-machines-filesystems
@@ -111,7 +111,7 @@ class TestMachinesFilesystems(VirtualMachinesCase):
         b.set_file_autocomplete_val("#vm-subVmTest1-filesystems-modal-source-group", "/tmp/dir1/")
         b.set_input_text("#vm-subVmTest1-filesystems-modal-mountTag", "dir1")
         b.click("#vm-subVmTest1-filesystems-modal-add")
-        if m.execute("virsh --version") >= "7.5.0":
+        if m.image not in ['rhel-8-4', 'rhel-8-5', 'ubuntu-2004', 'fedora-34', 'debian-stable']:
             b.wait_in_text(".pf-c-alert", "Failed to add shared directory")
             b.wait_in_text(".pf-c-alert", "filesystem target 'dir1' specified twice")
             b.click("#vm-subVmTest1-filesystems-modal-cancel")


### PR DESCRIPTION
In [1]: "7.10.0" >= "7.5.0"
Out[1]: False

This is just wrong check. Replace it with check of the m.image, as we do
in most other places.

This will fix TestMachinesFilesystems.testBasicSystemConnection test on
rawhide (packit run).