### PR TITLE
fmf: Skip TestMachinesHostDevs.testHostDevAdd on Fedora 36

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -53,7 +53,7 @@ if [ "$TEST_OS" = "fedora-34" ] || [ "$TEST_OS" = "centos-8-stream" ]; then
     EXCLUDES="$EXCLUDES TestMachinesCreate.testCreateFileSource"
 fi
 
-if [ "$TEST_OS" = "fedora-35" ] || [ "$TEST_OS" = "centos-9-stream" ]; then
+if [ "$TEST_OS" = "fedora-35" ] || [ "$TEST_OS" = "fedora-36" ] || [ "$TEST_OS" = "centos-9-stream" ]; then
     EXCLUDES="$EXCLUDES TestMachinesHostDevs.testHostDevAdd"
 fi
 


### PR DESCRIPTION
It does not work there for the same reason as it's broken on Fedora 35.

-----

Fixes [this rawhide packit failure](http://artifacts.dev.testing-farm.io/d5ba0629-a755-4b40-96bf-45f63f984a85/)