### PR TITLE
Update serial console when its alias changes

### DIFF
--- a/src/components/vm/consoles/consoles.jsx
+++ b/src/components/vm/consoles/consoles.jsx
@@ -48,10 +48,21 @@ class Consoles extends React.Component {
 
         this.state = {
             consoleDetail: undefined,
+            serial: props.vm.displays && props.vm.displays.filter(display => display.type == 'pty'),
         };
 
         this.getDefaultConsole = this.getDefaultConsole.bind(this);
         this.onDesktopConsoleDownload = this.onDesktopConsoleDownload.bind(this);
+    }
+
+    static getDerivedStateFromProps(nextProps, prevState) {
+        const oldSerial = prevState.serial;
+        const newSerial = nextProps.vm.displays && nextProps.vm.displays.filter(display => display.type == 'pty');
+
+        if (newSerial.length !== oldSerial.length || oldSerial.some((pty, index) => pty.alias !== newSerial[index].alias))
+            return { serial: newSerial };
+
+        return null;
     }
 
     getDefaultConsole () {
@@ -83,8 +94,8 @@ class Consoles extends React.Component {
 
     render () {
         const { vm, onAddErrorNotification } = this.props;
+        const { serial } = this.state;
         const spice = vm.displays && vm.displays.find(display => display.type == 'spice');
-        const serial = vm.displays && vm.displays.filter(display => display.type == 'pty');
         const vnc = vm.displays && vm.displays.find(display => display.type == 'vnc');
 
         if (!domainCanConsole || !domainCanConsole(vm.state)) {

--- a/src/components/vm/consoles/serialConsole.jsx
+++ b/src/components/vm/consoles/serialConsole.jsx
@@ -38,13 +38,21 @@ class SerialConsoleCockpit extends React.Component {
     }
 
     componentDidMount() {
-        this.createChannel();
+        this.createChannel(this.props.spawnArgs);
     }
 
-    createChannel () {
+    componentDidUpdate(prevProps) {
+        const oldSpawnArgs = prevProps.spawnArgs;
+        const newSpawnArgs = this.props.spawnArgs;
+
+        if (newSpawnArgs.length !== oldSpawnArgs.length || oldSpawnArgs.some((arg, index) => arg !== newSpawnArgs[index]))
+            this.createChannel(this.props.spawnArgs);
+    }
+
+    createChannel (spawnArgs) {
         const opts = {
             payload: "stream",
-            spawn: this.props.spawnArgs,
+            spawn: spawnArgs,
             pty: true,
         };
         if (this.props.connectionName == "system")
@@ -82,7 +90,7 @@ class SerialConsoleCockpit extends React.Component {
                 <div className="pf-c-console__actions-serial">
                     {this.state.channel
                         ? <Button id={this.props.vmName + "-serialconsole-disconnect"} variant="secondary" onClick={this.onDisconnect}>{_("Disconnect")}</Button>
-                        : <Button id={this.props.vmName + "-serialconsole-connect"} variant="secondary" onClick={this.createChannel}>{_("Connect")}</Button>
+                        : <Button id={this.props.vmName + "-serialconsole-connect"} variant="secondary" onClick={() => this.createChannel(this.props.spawnArgs)}>{_("Connect")}</Button>
                     }
                 </div>
                 <div id={pid} className="vm-terminal pf-c-console__serial">


### PR DESCRIPTION
In order to create a serial console, we call 'virsh console [domain]
--devname [alias]' command. Sometimes however, alias might be undefined.
In that case, don't pass any devname parameter at all, instead of
passing empty string as parameter.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2032099