### PR TITLE
Enable dynamic logging

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -36,8 +36,6 @@ const VMS_CONFIG = {
             }
         }
     },
-    // TODO: make it configurable via config file
-    isDev: false, // Never commit with 'true'
 };
 
 export default VMS_CONFIG;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -21,7 +21,6 @@ import * as dfnlocales from 'date-fns/locale';
 import { formatRelative } from 'date-fns';
 
 import cockpit from 'cockpit';
-import VMS_CONFIG from './config.js';
 
 const _ = cockpit.gettext;
 
@@ -175,14 +174,9 @@ export function arrayEquals(arr1, arr2) {
     return diff.length === 0;
 }
 
-export function logDebug(msg, ...params) {
-    if (VMS_CONFIG.isDev) {
-        console.log(msg, ...params);
-    }
-}
-
-export function logError(msg, ...params) {
-    console.error(msg, ...params);
+export function logDebug() {
+    if (window.debugging === "all" || window.debugging === "machines")
+        console.debug.apply(console, arguments);
 }
 
 export function digitFilter(event, allowDots = false) {


### PR DESCRIPTION
Drop the static `isDev` configuration flag and move to Cockpit's
standard way [1] of enabling debugging at runtime through setting
`window.debugging`.

Also drop the unused `logError()` helper, our code uses
`console.error()` directly and there is little reason to do otherwise.

[1] https://github.com/cockpit-project/cockpit/blob/main/HACKING.md#debug-logging-in-javascript-console

----

This would have helped me a lot to debug issue #488 on the downstream RHEL infra, where it's difficult to rebuild the webpack. Thus marking release-blocker.