### PR TITLE
Do not change "startVm" value when selecting Unattended installation

### DIFF
--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -888,13 +888,15 @@ class CreateVmModal extends React.Component {
                 const converted = convertToUnit(stateDelta.minimumStorage, units.B, bestUnit);
                 this.setState({ storageSizeUnit: bestUnit.name }, () => this.onValueChanged("storageSize", converted));
             }
+
             if (!value || !value.unattendedInstallable)
                 this.onValueChanged('unattendedInstallation', false);
+
             this.setState(stateDelta);
             break;
         }
         case 'unattendedInstallation':
-            this.setState({ unattendedInstallation: value, startVm: true });
+            this.setState({ unattendedInstallation: value });
             break;
         default:
             this.setState({ [key]: value });
@@ -925,7 +927,7 @@ class CreateVmModal extends React.Component {
                 storageSize: convertToUnit(this.state.storageSize, this.state.storageSizeUnit, units.GiB),
                 storagePool: this.state.storagePool,
                 storageVolume: this.state.storageVolume,
-                startVm: this.state.startVm,
+                startVm: this.state.unattendedInstallation || this.state.startVm,
                 unattended: this.state.unattendedInstallation,
                 userPassword: this.state.userPassword,
                 rootPassword: this.state.rootPassword,
@@ -960,7 +962,7 @@ class CreateVmModal extends React.Component {
         let startVmCheckbox = (
             <FormGroup fieldId="start-vm" label={_("Immediately start VM")} hasNoPaddingTop>
                 <Checkbox id="start-vm"
-                    isChecked={this.state.startVm}
+                    isChecked={this.state.unattendedInstallation || this.state.startVm}
                     isDisabled={this.state.unattendedInstallation}
                     onChange={checked => this.onValueChanged('startVm', checked)} />
             </FormGroup>

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -696,6 +696,7 @@ class TestMachinesCreate(VirtualMachinesCase):
             self.browser = test_obj.browser
             self.machine = test_obj.machine
             self.assertTrue = test_obj.assertTrue
+            self.assertFalse = test_obj.assertFalse
             self.assertIn = test_obj.assertIn
             self.assertEqual = test_obj.assertEqual
             self.goToVmPage = test_obj.goToVmPage
@@ -798,9 +799,12 @@ class TestMachinesCreate(VirtualMachinesCase):
             b.wait_not_present("#navbar-oops")
 
             # click the 'X' button to clear the OS input and check there is no Ooops
+            # Also check start VM checkbox was not changed (https://bugzilla.redhat.com/show_bug.cgi?id=2033603)
+            b.set_checked("#start-vm", False)
             b.click("#os-select-group button[aria-label=\"Clear all\"]")
             b.wait_attr("#os-select-group input", "value", "")
             b.wait_not_present("#navbar-oops")
+            self.assertFalse(b.get_checked("#start-vm"))
 
             return self
 


### PR DESCRIPTION
This was causing several in several bugs in Create VM dialog:
1. uncheck "Start VM" checkbox, select OS with aunattended installation,
   click "X" button, "Start VM" button is checked.
2. uncheck "Start VM" checkbox, check "Unattended installation", uncheck
   "Unattended installation", "Start VM" checkbox is checked.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2033603