### PR TITLE
Show install_machine.py invocation in debug logs

### DIFF
--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -254,7 +254,6 @@ export function domainCreate({
     userPassword,
     vmName,
 }) {
-    logDebug(`CREATE_VM(${vmName}):`);
     // shows dummy vm  until we get vm from virsh (cleans up inProgress)
     setVmCreateInProgress(vmName, connectionName, { openConsoleTab: startVm });
 
@@ -284,6 +283,8 @@ export function domainCreate({
         userPassword,
         vmName,
     });
+
+    logDebug(`CREATE_VM(${vmName}): install_machine.py '${args}'`);
 
     return cockpit
             .spawn([pythonPath, "--", "-", args], opts)


### PR DESCRIPTION
That makes it possible to reproduce and investigate creation failures on
the command line, by calling install_machine.py with the logged JSON
string.

---

This helped me with investigating https://bugzilla.redhat.com/show_bug.cgi?id=2032462 . Originally I thought this was our bug, but it's not, so only that little change remained..