### PR TITLE
nic: Show full of models

### DIFF
--- a/src/components/vm/nics/nicBody.jsx
+++ b/src/components/vm/nics/nicBody.jsx
@@ -56,7 +56,7 @@ export const NetworkModelRow = ({ idPrefix, onValueChanged, dialogValues, osType
                         .map(networkModel => {
                             return (
                                 <FormSelectOption value={networkModel.name} key={networkModel.name}
-                                                  label={networkModel.name && '(' + networkModel.desc + ')'} />
+                                                  label={networkModel.name + ' (' + networkModel.desc + ')'} />
                             );
                         })}
             </FormSelect>


### PR DESCRIPTION
`&&` is logical operator saying - if `name` is defined, show `(desc)`,
but we want to show `name (desc)`.

Fixes #506