### PR TITLE
test: Robustify TestMachinesCreate.testCreateCloudBaseImage

### DIFF
--- a/src/libvirtApi/common.js
+++ b/src/libvirtApi/common.js
@@ -147,7 +147,7 @@ function delayPolling(action, timeout) {
     }
 }
 
-// Undefined the VM from Redux store only if it"s not transient
+// Undefined the VM from Redux store only if it's not transient
 function domainEventUndefined(connectionName, domPath) {
     call(connectionName, "/org/libvirt/QEMU", "org.libvirt.Connect", "ListDomains", [Enum.VIR_CONNECT_LIST_DOMAINS_TRANSIENT], { timeout, type: "u" })
             .then(objPaths => {
@@ -159,7 +159,7 @@ function domainEventUndefined(connectionName, domPath) {
             .catch(ex => console.warn("ListDomains action failed:", ex.toString()));
 }
 
-function domainUpdateOrDelete(connectionName, domPath) {
+function domainEventStopped(connectionName, domPath) {
     // Transient VMs cease to exists once they are stopped. Check if VM was transient and update or undefined it
     call(connectionName, "/org/libvirt/QEMU", "org.libvirt.Connect", "ListDomains", [0], { timeout, type: "u" })
             .then(objPaths => {
@@ -168,7 +168,7 @@ function domainUpdateOrDelete(connectionName, domPath) {
                 else // Transient vm will get undefined when stopped
                     store.dispatch(undefineVm({ connectionName, id:domPath, transientOnly: true }));
             })
-            .catch(ex => console.warn("domainUpdateOrDelete action failed:", ex.toString()));
+            .catch(ex => console.warn("domainEventStopped action failed:", ex.toString()));
 }
 
 /**
@@ -342,7 +342,7 @@ function startEventMonitorDomains(connectionName) {
                 break;
 
             case domainEvent.Stopped:
-                domainUpdateOrDelete(connectionName, objPath);
+                domainEventStopped(connectionName, objPath);
                 break;
 
             default:

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -853,6 +853,7 @@ class TestMachinesCreate(VirtualMachinesCase):
 
             self.machine.execute(f"virsh destroy {self.name}")
             self.assertIn(f"backing file: {self.location}", self.machine.execute(f"qemu-img info /var/lib/libvirt/images/{self.name}.qcow2"))
+            self.browser.wait_text(f"#vm-{self.name}-state", "Shut off")
 
         def createRespectQemuConfConsoleConfig(self, vnc_listen, spice_listen, vnc_passwd, spice_passwd):
             self.browser.click(".pf-c-modal-box__footer button:contains(Create)")


### PR DESCRIPTION
After destroying the VM, wait until the UI caught up before clicking
"Delete".

----

This fixes [this failure](https://logs.cockpit-project.org/logs/pull-2729-20211216-133824-fd3dfae8-rhel-8-6-cockpit-project-cockpit-machines/log.html#9), which also happens quite often in downstream gating.

See  #488 for debugging details.