### PR TITLE
Fix race condition on deleting a VM (alternative to #518)

### DIFF
--- a/src/libvirtApi/common.js
+++ b/src/libvirtApi/common.js
@@ -154,7 +154,7 @@ function domainEventUndefined(connectionName, domPath) {
                 if (!objPaths[0].includes(domPath))
                     store.dispatch(undefineVm({ connectionName, id: domPath }));
                 else
-                    domainGet({ connectionName, id:domPath, updateOnly: true });
+                    domainGet({ connectionName, id: domPath, updateOnly: true });
             })
             .catch(ex => console.warn("ListDomains action failed:", ex.toString()));
 }
@@ -164,7 +164,7 @@ function domainEventStopped(connectionName, domPath) {
     call(connectionName, "/org/libvirt/QEMU", "org.libvirt.Connect", "ListDomains", [0], { timeout, type: "u" })
             .then(objPaths => {
                 if (objPaths[0].includes(domPath))
-                    domainGet({ connectionName, id:domPath, updateOnly: true });
+                    domainGet({ connectionName, id: domPath, updateOnly: true });
                 else // Transient vm will get undefined when stopped
                     store.dispatch(undefineVm({ connectionName, id:domPath, transientOnly: true }));
             })


### PR DESCRIPTION
When deleting a VM in the UI, it gets both destroyed and undefined at
the same time. The async handling in domainEventUndefined() and
domainEventStopped() can run in dozens of combinations, but there is one
common case which fails:

 - domainEvent.Undefined signal gets received first, and the handler
   starts
 - domainEvent.Undefined finishes its ListDomains call in the meantime,
   and as the domain is not destroyed yet, it is still in the result; so
   the handler issues a domainGet() to update properties
 - the domain gets destroyed now, so the domainGet() fails and logs the
   `GET_VM action failed` warning; as a result, properties in redux do
   not get updated -- in particular, `persistent` remains `true` (it
   would have been updated to `false` if the domainGet() call succeeded)
 - the corresponding domainEvent.Stopped signal arrives and
   domainEventStopped() gets called; as the domain does not exist any
   more, it is not in the ListDomains() result, and thus it calls
   undefineVm() with `transientOnly: true`. However, as the redux model
   still thinks the domain is persistent, this is a no-op.

In *general*, the logic in domainEvent{Stopped,Undefine}() is correct
for the cases where the handlers don't run in parallel. The bug is that
it entirely ignores the `GET_VM` action -- if that fails, the domain is
gone, and we should always update our redux model accordingly.

To fix that, dispatch an undefineVm() in domainGet() if it fails --
ignoring bugs in libvirt, this could only have happened as a race
condition for trying to read a domain while it is being destroyed.

Fixes #488
https://bugzilla.redhat.com/show_bug.cgi?id=2033367