### PR TITLE
Fix race condition on deleting a domain (alternative to #516)

### DIFF
--- a/src/libvirtApi/common.js
+++ b/src/libvirtApi/common.js
@@ -154,7 +154,7 @@ function domainEventUndefined(connectionName, domPath) {
                 if (!objPaths[0].includes(domPath))
                     store.dispatch(undefineVm({ connectionName, id: domPath }));
                 else
-                    domainGet({ connectionName, id:domPath, updateOnly: true });
+                    domainGet({ connectionName, id: domPath, updateOnly: true });
             })
             .catch(ex => console.warn("ListDomains action failed:", ex.toString()));
 }
@@ -164,7 +164,7 @@ function domainEventStopped(connectionName, domPath) {
     call(connectionName, "/org/libvirt/QEMU", "org.libvirt.Connect", "ListDomains", [0], { timeout, type: "u" })
             .then(objPaths => {
                 if (objPaths[0].includes(domPath))
-                    domainGet({ connectionName, id:domPath, updateOnly: true });
+                    domainGet({ connectionName, id: domPath, updateOnly: true });
                 else // Transient vm will get undefined when stopped
                     store.dispatch(undefineVm({ connectionName, id:domPath, transientOnly: true }));
             })

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -498,11 +498,12 @@ export function domainGet({
     id: objPath,
     connectionName,
     updateOnly,
+    reportErrors,
 }) {
     let props = {};
     let domainXML;
 
-    return call(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_SECURE], { timeout, type: 'u' })
+    const p = call(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_SECURE], { timeout, type: 'u' })
             .then(domXml => {
                 domainXML = domXml[0];
                 return call(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_SECURE | Enum.VIR_DOMAIN_XML_INACTIVE], { timeout, type: 'u' });
@@ -546,8 +547,12 @@ export function domainGet({
                     store.dispatch(updateOrAddVm(Object.assign({}, props, dumpxmlParams)));
 
                 snapshotGetAll({ connectionName, domainPath: objPath });
-            })
-            .catch(ex => console.warn("GET_VM action failed for path", objPath, ex.toString()));
+            });
+
+    if (reportErrors)
+        return p;
+
+    return p.catch(ex => console.warn("GET_VM action failed for path", objPath, ex.toString()));
 }
 
 export function domainGetAll({ connectionName }) {

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -558,7 +558,6 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                       memory_size=128, memory_size_unit='MiB',
                                                       start_vm=True))
 
-    @no_retry_when_changed
     def testCreateUrlSource(self):
         runner = TestMachinesCreate.CreateVmRunner(self)
         config = TestMachinesCreate.TestCreateConfig


### PR DESCRIPTION
When deleting a domain in the UI, it gets both destroyed and undefined at
the same time. The async handling in domainEventUndefined() and
domainEventStopped() can run in dozens of combinations, but there is one
common case which fails:

 - domainEvent.Undefined signal gets received first, and the handler
   starts
 - domainEvent.Undefined finishes its ListDomains call in the meantime,
   and as the domain is not destroyed yet, it is still in the result; so
   the handler issues a domainGet() to update properties
 - the domain gets destroyed now, so the domainGet() fails and logs the
   `GET_VM action failed` warning; as a result, properties in redux do
   not get updated -- in particular, `persistent` remains `true` (it
   would have been updated to `false` if the domainGet() call succeeded)
 - the corresponding domainEvent.Stopped signal arrives and
   domainEventStopped() gets called; as the domain does not exist any
   more, it is not in the ListDomains() result, and thus it calls
   undefineVm() with `transientOnly: true`. However, as the redux model
   still thinks the domain is persistent, this is a no-op.

In *general*, the logic in domainEvent{Stopped,Undefine}() is correct
for the cases where the handlers don't run in parallel. The bug is that
it entirely ignores the `GET_VM` action -- if that fails, the domain is
gone, and we should always update our redux model accordingly.

To fix that, add a flag to domainGet() to actually return promise
rejections instead of ignoring them, and dispatch an undefineVm() in
the Undefined/Stopped handlers() if it fails -- then the domain went
away while the handler was running, and we should forget about it.

Fixes #488
https://bugzilla.redhat.com/show_bug.cgi?id=2033367

----

This is an alternative implementation to #516 which is more targeted, but also more complicated.