### PR TITLE
Fix VM deletion race condition with domainGet() harder

### DIFF
--- a/src/libvirtApi/common.js
+++ b/src/libvirtApi/common.js
@@ -239,7 +239,7 @@ function getNodeMaxMemory({ connectionName }) {
     return call(connectionName, "/org/libvirt/QEMU", "org.libvirt.Connect", "NodeGetMemoryStats", [-1, 0], { timeout, type: "iu" })
             .then(stats => store.dispatch(setNodeMaxMemory({ memory: stats[0].total })))
             .catch(ex => {
-                console.warn("NodeGetMemoryStats failed: %s", ex);
+                console.warn("NodeGetMemoryStats failed:", ex.toString());
                 return Promise.reject(ex);
             });
 }

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -557,7 +557,7 @@ export function domainGet({
                 else
                     store.dispatch(updateOrAddVm(Object.assign({}, props, dumpxmlParams)));
 
-                snapshotGetAll({ connectionName, domainPath: objPath });
+                return snapshotGetAll({ connectionName, domainPath: objPath });
             })
             .catch(ex => console.warn("GET_VM action failed for path", objPath, ex.toString()));
 }

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -537,7 +537,7 @@ export function domainGet({
 
                 return call(connectionName, objPath, "org.freedesktop.DBus.Properties", "GetAll", ["org.libvirt.Domain"], { timeout, type: 's' });
             })
-            .then(function(returnProps) {
+            .then(returnProps => {
                 /* Sometimes not all properties are returned, for example when some domain got deleted while part
                  * of the properties got fetched from libvirt. Make sure that there is check before reading the attributes.
                  */
@@ -549,7 +549,7 @@ export function domainGet({
                     props.autostart = returnProps[0].Autostart.v.v;
                 props.ui = resolveUiState(props.name, props.connectionName);
 
-                logDebug(`${this.name}.GET_VM(${objPath}, ${connectionName}): update props ${JSON.stringify(props)}`);
+                logDebug(`${props.name}.GET_VM(${objPath}, ${connectionName}): update props ${JSON.stringify(props)}`);
 
                 const dumpxmlParams = parseDomainDumpxml(connectionName, domainXML, objPath);
                 if (updateOnly)

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -507,14 +507,7 @@ export function domainGet({
     let props = {};
     let domainXML;
 
-    const promiseGetXML = call(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_SECURE], { timeout, type: 'u' });
-
-    promiseGetXML.catch(ex => {
-        logDebug("GET_VM action GetXMLDesc failed for path", objPath, ex.toString(), "undefining VM");
-        store.dispatch(undefineVm({ connectionName, id: objPath }));
-    });
-
-    return promiseGetXML
+    return call(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_SECURE], { timeout, type: 'u' })
             .then(domXml => {
                 domainXML = domXml[0];
                 return call(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_SECURE | Enum.VIR_DOMAIN_XML_INACTIVE], { timeout, type: 'u' });
@@ -559,7 +552,10 @@ export function domainGet({
 
                 return snapshotGetAll({ connectionName, domainPath: objPath });
             })
-            .catch(ex => console.warn("GET_VM action failed for path", objPath, ex.toString()));
+            .catch(ex => {
+                console.warn("GET_VM action GetXMLDesc failed for path", objPath, ex.toString(), "undefining VM");
+                store.dispatch(undefineVm({ connectionName, id: objPath }));
+            });
 }
 
 export function domainGetAll({ connectionName }) {

--- a/src/libvirtApi/snapshot.js
+++ b/src/libvirtApi/snapshot.js
@@ -47,7 +47,7 @@ export function snapshotDelete({ connectionName, domainPath, snapshotName }) {
 }
 
 export function snapshotGetAll({ connectionName, domainPath }) {
-    call(connectionName, domainPath, 'org.libvirt.Domain', 'ListDomainSnapshots', [0], { timeout, type: 'u' })
+    return call(connectionName, domainPath, 'org.libvirt.Domain', 'ListDomainSnapshots', [0], { timeout, type: 'u' })
             .then(objPaths => {
                 const snaps = [];
                 const promises = [];

--- a/src/libvirtApi/snapshot.js
+++ b/src/libvirtApi/snapshot.js
@@ -27,6 +27,7 @@ import { updateDomainSnapshots } from '../actions/store-actions.js';
 import { getSnapshotXML } from '../libvirt-xml-create.js';
 import { parseDomainSnapshotDumpxml } from '../libvirt-xml-parse.js';
 import { call, timeout } from './helpers.js';
+import { logDebug } from '../helpers.js';
 
 export function snapshotCreate({ connectionName, vmId, name, description }) {
     const xmlDesc = getSnapshotXML(name, description);
@@ -91,7 +92,10 @@ export function snapshotGetAll({ connectionName, domainPath }) {
                         });
             })
             .catch(ex => {
-                console.warn("LIST_DOMAIN_SNAPSHOTS action failed for domain", domainPath, ":", JSON.stringify(ex));
+                if (ex.name === 'org.freedesktop.DBus.Error.UnknownMethod')
+                    logDebug("LIST_DOMAIN_SNAPSHOTS action failed for domain", domainPath, ", not supported by libvirt-dbus");
+                else
+                    console.warn("LIST_DOMAIN_SNAPSHOTS action failed for domain", domainPath, ":", JSON.stringify(ex), "name:", ex.name);
                 store.dispatch(updateDomainSnapshots({
                     connectionName,
                     domainPath,

--- a/src/libvirtApi/snapshot.js
+++ b/src/libvirtApi/snapshot.js
@@ -91,7 +91,7 @@ export function snapshotGetAll({ connectionName, domainPath }) {
                         });
             })
             .catch(ex => {
-                console.warn("LIST_DOMAIN_SNAPSHOTS action failed for domain %s: %s", domainPath, JSON.stringify(ex));
+                console.warn("LIST_DOMAIN_SNAPSHOTS action failed for domain", domainPath, ":", JSON.stringify(ex));
                 store.dispatch(updateDomainSnapshots({
                     connectionName,
                     domainPath,

--- a/src/libvirtApi/storageVolume.js
+++ b/src/libvirtApi/storageVolume.js
@@ -109,5 +109,5 @@ export function storageVolumeGetAll({ connectionName, poolName }) {
                     return Promise.resolve(volumes);
                 });
             })
-            .catch(ex => console.warn("GET_STORAGE_VOLUMES action failed for pool %s: %s", poolName, ex.toString()));
+            .catch(ex => console.warn("GET_STORAGE_VOLUMES action failed for pool", poolName, ":", ex.toString()));
 }

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -855,9 +855,13 @@ class TestMachinesCreate(VirtualMachinesCase):
 
                 self.assertIn("\nssh_pwauth: true", user_data)
 
+            self.browser.wait_text(f"#vm-{self.name}-state", "Running")
+
             self.machine.execute(f"virsh destroy {self.name}")
             self.assertIn(f"backing file: {self.location}", self.machine.execute(f"qemu-img info /var/lib/libvirt/images/{self.name}.qcow2"))
             self.browser.wait_text(f"#vm-{self.name}-state", "Shut off")
+            # wait for virt-install to finish
+            self.machine.execute(f"while {virt_install_cmd}; do sleep 1; done")
 
         def createRespectQemuConfConsoleConfig(self, vnc_listen, spice_listen, vnc_passwd, spice_passwd):
             self.browser.click(".pf-c-modal-box__footer button:contains(Create)")


### PR DESCRIPTION
The fix in commit a724e2e29c933 was incomplete -- the VM deletion can
just as well happen after the first, but before the second GetXMLDesc()
call in domainGet(), or the GetState() and property get -- all of these
mean that the VM is really gone.

The only thing we need to be concerned about is the snapshotGetAll()
call, but that does its own error handling (and ignores them).
So go back to undefining the VM whenever anything in domainGet() fails,
as in earlier versions of PR #516.

-----

I also added some small cleanups.

I am still debugging this in #489, with "loudness 11" debug level.