### PR TITLE
fmf: Disable TestMachinesCreate.testCreateThenInstall

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -55,6 +55,8 @@ fi
 
 if [ "$TEST_OS" = "fedora-35" ] || [ "$TEST_OS" = "fedora-36" ] || [ "$TEST_OS" = "centos-9-stream" ]; then
     EXCLUDES="$EXCLUDES TestMachinesHostDevs.testHostDevAdd"
+    # https://github.com/cockpit-project/cockpit-machines/issues/526
+    EXCLUDES="$EXCLUDES TestMachinesCreate.testCreateThenInstall"
 fi
 
 if [ "$TEST_OS" = "fedora-36" ]; then


### PR DESCRIPTION
It fails way too often (three times in a row), and is too hard to debug
without artifacts.

See issue #526