### PR TITLE
test: Make testCreateUrlSource non-destructive on Debian, fix testCreateCloudBaseImage race

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -859,10 +859,12 @@ class TestMachinesCreate(VirtualMachinesCase):
             self.browser.wait_text(f"#vm-{self.name}-state", "Running")
 
             self.machine.execute(f"virsh destroy {self.name}")
-            self.assertIn(f"backing file: {self.location}", self.machine.execute(f"qemu-img info /var/lib/libvirt/images/{self.name}.qcow2"))
-            self.browser.wait_text(f"#vm-{self.name}-state", "Shut off")
             # wait for virt-install to finish
             self.machine.execute(f"while {virt_install_cmd}; do sleep 1; done")
+
+            self.browser.wait_text(f"#vm-{self.name}-state", "Shut off")
+
+            self.assertIn(f"backing file: {self.location}", self.machine.execute(f"qemu-img info /var/lib/libvirt/images/{self.name}.qcow2"))
 
         def createRespectQemuConfConsoleConfig(self, vnc_listen, spice_listen, vnc_passwd, spice_passwd):
             self.browser.click(".pf-c-modal-box__footer button:contains(Create)")

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -610,11 +610,11 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                       storage_pool="NoStorage",
                                                       start_vm=True))
 
-        # This functionality works on debian only because of extra dep.
+        # This functionality works on debian only because of extra qemu-block-extra dep.
         # Check error is returned if dependency is missing
         if self.machine.image.startswith("debian"):
-            # remove package
-            self.machine.execute("dpkg -P qemu-block-extra")
+            self.machine.execute("mount -o bind /dev/null /usr/lib/x86_64-linux-gnu/qemu/block-curl.so")
+            self.addCleanup(self.machine.execute, "umount /usr/lib/x86_64-linux-gnu/qemu/block-curl.so")
             runner.checkDialogErrorTest(TestMachinesCreate.VmDialog(self, sourceType='url',
                                                                     location=config.ISO_URL,
                                                                     memory_size=128, memory_size_unit='MiB',


### PR DESCRIPTION
Purging a package is destructive. Instead, temporarily disable QEMU's
curl block driver with a bind mount.

----

This avoids [disasters](https://logs.cockpit-project.org/logs/pull-489-20220120-074323-2e28f4df-debian-testing/log.html) when the test gets run more than once, due to being affected.

Also, `testCreateCloudBaseImage` across the board: [ubuntu-stable](https://logs.cockpit-project.org/logs/pull-489-20220120-074323-2e28f4df-ubuntu-stable/log.html), [rhel-8-6](https://logs.cockpit-project.org/logs/pull-489-20220120-074323-2e28f4df-rhel-8-6/log.html#24), [fedora-35](https://logs.cockpit-project.org/logs/pull-489-20220120-074323-2e28f4df-fedora-35-firefox/log.html), [c8s](https://logs-https-frontdoor.apps.ocp.ci.centos.org/logs/pull-489-20220120-074323-2e28f4df-centos-8-stream/log.html) and many others -- like [here](https://logs.cockpit-project.org/logs/pull-530-20220120-123907-a252fb15-centos-8-stream/log.html#65) in a "normal" PR (not the debug one in #489)

These two were the last items in the giant saga that was #488 -- so let's close that!

Fixes #488