### PR TITLE
Fix incorrect warning about volume being in use during VM creation

### DIFF
--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -635,7 +635,7 @@ const MemoryRow = ({ memorySize, memorySizeUnit, nodeMaxMemory, minimumMemory, o
     );
 };
 
-const StorageRow = ({ connectionName, allowNoDisk, storageSize, storageSizeUnit, onValueChanged, minimumStorage, storagePoolName, storagePools, storageVolume, vms, validationFailed }) => {
+const StorageRow = ({ connectionName, allowNoDisk, storageSize, storageSizeUnit, onValueChanged, minimumStorage, storagePoolName, storagePools, storageVolume, vms, validationFailed, inProgress }) => {
     let validationStateStorage = validationFailed.storage ? 'error' : 'default';
     const poolSpaceAvailable = getSpaceAvailable(storagePools, connectionName);
     let helperTextNewVolume = (
@@ -693,11 +693,11 @@ const StorageRow = ({ connectionName, allowNoDisk, storageSize, storageSizeUnit,
             storagePoolName !== "NoStorage" &&
             <FormGroup label={_("Volume")}
                        fieldId="storage-volume-select"
-                       helperText={(isVolumeUsed[storageVolume] && isVolumeUsed[storageVolume].length > 0) && _("This volume is already used by another VM.")}
-                       validated={(isVolumeUsed[storageVolume] && isVolumeUsed[storageVolume].length > 0) ? "warning" : "default"}>
+                       helperText={!inProgress && (isVolumeUsed[storageVolume] && isVolumeUsed[storageVolume].length > 0) && _("This volume is already used by another VM.")}
+                       validated={!inProgress && (isVolumeUsed[storageVolume] && isVolumeUsed[storageVolume].length > 0) ? "warning" : "default"}>
                 <FormSelect id="storage-volume-select"
                             value={storageVolume}
-                            validated={(isVolumeUsed[storageVolume] && isVolumeUsed[storageVolume].length > 0) ? "warning" : "default"}
+                            validated={!inProgress && (isVolumeUsed[storageVolume] && isVolumeUsed[storageVolume].length > 0) ? "warning" : "default"}
                             onChange={value => onValueChanged('storageVolume', value)}>
                     {volumeEntries}
                 </FormSelect>
@@ -1036,6 +1036,7 @@ class CreateVmModal extends React.Component {
                     vms={vms}
                     minimumStorage={this.state.minimumStorage}
                     validationFailed={validationFailed}
+                    inProgress={this.state.inProgress}
                 />}
 
                 <MemoryRow


### PR DESCRIPTION
This fixes a race condition which was visible only for few moments
during VM creation.
How to reproduce:
1. Have some available storage volume
2. In VM creation dialog, choose that available volume as storage
3. Clicking button "Create"

There will be few moments when VM creation dialog is still open,
but the volume is already in use (by the VM which is being created)
and dialog shows "This volume is already used by another VM."

This is confusing and can lead user to think that something went
wrong during VM creation. Therefore ideally do not show this warning
during VM creation.

![Screenshot from 2022-01-21 14-57-07](https://user-images.githubusercontent.com/42733240/150539814-634e7e29-2558-4dda-8b41-354627883c4f.png)