### PR TITLE
Don't use MAC address when detaching network interface

### DIFF
--- a/src/components/vm/nics/vmNicsCard.jsx
+++ b/src/components/vm/nics/vmNicsCard.jsx
@@ -376,7 +376,7 @@ export class VmNetworkTab extends React.Component {
                         objectType: _("network interface"),
                         objectName: network.mac,
                         onClose: () => this.setState({ deleteDialogProps: undefined }),
-                        deleteHandler: () => domainDetachIface({ connectionName: vm.connectionName, mac: network.mac, vmName: vm.name, live: vm.state === 'running', persistent: nicPersistent }),
+                        deleteHandler: () => domainDetachIface({ connectionName: vm.connectionName, index: network.index, vmName: vm.name, live: vm.state === 'running', persistent: nicPersistent }),
                     };
                     const deleteNICAction = (
                         <DeleteResourceButton objectId={`${id}-iface-${networkId}`}
@@ -413,7 +413,11 @@ export class VmNetworkTab extends React.Component {
             else
                 return 0;
         };
-        const rows = vm.interfaces.sort(sortIfaces).map(target => {
+        // Normally we should identify a vNIC to detach by a number of slot, bus, function and domain.
+        // Such detachment is however broken in virt-xml, so instead let's detach it by the index of <interface> in array of VM's XML <devices>
+        // This serves as workaround for https://github.com/virt-manager/virt-manager/issues/356
+        const ifaces = vm.interfaces.map((iface, index) => ({ ...iface, index }));
+        const rows = ifaces.sort(sortIfaces).map(target => {
             const columns = detailMap.map(d => {
                 let column = null;
                 if (typeof d.value === 'string') {

--- a/src/components/vm/nics/vmNicsCard.jsx
+++ b/src/components/vm/nics/vmNicsCard.jsx
@@ -405,7 +405,15 @@ export class VmNetworkTab extends React.Component {
         detailMap = detailMap.filter(d => !d.hidden);
 
         const columnTitles = detailMap.map(target => target.name);
-        const rows = vm.interfaces.sort().map(target => {
+        const sortIfaces = (a, b) => {
+            if (a.type !== b.type)
+                return a.type > b.type ? 1 : -1;
+            else if (a.mac !== b.mac)
+                return a.mac > b.mac ? 1 : -1;
+            else
+                return 0;
+        };
+        const rows = vm.interfaces.sort(sortIfaces).map(target => {
             const columns = detailMap.map(d => {
                 let column = null;
                 if (typeof d.value === 'string') {

--- a/src/libvirt-xml-parse.js
+++ b/src/libvirt-xml-parse.js
@@ -743,6 +743,7 @@ export function parseDumpxmlForInterfaces(devicesElem) {
                     bus: addressElem ? addressElem.getAttribute('bus') : undefined,
                     function: addressElem ? addressElem.getAttribute('function') : undefined,
                     slot: addressElem ? addressElem.getAttribute('slot') : undefined,
+                    domain: addressElem ? addressElem.getAttribute('domain') : undefined,
                 },
             };
             interfaces.push(networkInterface);

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -488,9 +488,13 @@ export function domainDetachHostDevice({ connectionName, vmId, live, dev }) {
     return Promise.all(hostDevPromises);
 }
 
-export function domainDetachIface({ connectionName, mac, vmName, live, persistent }) {
+export function domainDetachIface({ connectionName, index, vmName, live, persistent }) {
     const options = { err: "message" };
-    const args = ['virt-xml', '-c', `qemu:///${connectionName}`, vmName, '--remove-device', '--network', `mac=${mac}`];
+    // Normally we should identify a vNIC to detach by a number of slot, bus, function and domain.
+    // Such detachment is however broken in virt-xml, so instead let's detach it by the index of <interface> in array of VM's XML <devices>
+    // This serves as workaround for https://github.com/virt-manager/virt-manager/issues/356
+    // virt-xml counts devices starting from 1, so we have to increase index by 1
+    const args = ['virt-xml', '-c', `qemu:///${connectionName}`, vmName, '--remove-device', '--network', `${index + 1}`];
 
     if (connectionName === "system")
         options.superuser = "try";

--- a/test/check-machines-networks
+++ b/test/check-machines-networks
@@ -508,8 +508,6 @@ class TestMachinesNetworks(VirtualMachinesCase):
         m.execute(f"echo \"{TEST_NETWORK_XML}\" > /tmp/xml && virsh net-define /tmp/xml && virsh net-start test_network")
 
         # Create a second bridge to LAN NIC, virbr0 does not make sense but let's use it for test purposes
-        m.execute("virsh attach-interface --persistent subVmTest1 bridge virbr0")
-
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual machines")
         self.waitVmRow("subVmTest1")
@@ -520,6 +518,10 @@ class TestMachinesNetworks(VirtualMachinesCase):
         b.wait_in_text("#card-pf-networks .card-pf-title-link", "2 Networks")
 
         self.goToVmPage("subVmTest1")
+
+        mac = b.text("#vm-subVmTest1-network-1-mac")
+        next_mac = self.get_next_mac(mac)
+        m.execute(f'virsh attach-interface --persistent subVmTest1 bridge virbr0 --mac {next_mac}')
 
         # Wait for the edit button
         b.click("#vm-subVmTest1-network-1-edit-dialog")
@@ -532,37 +534,37 @@ class TestMachinesNetworks(VirtualMachinesCase):
         b.wait_not_present("#vm-subVmTest1-network-1-edit-dialog-modal-window")
 
         # Fetch current NIC model type
-        current_model_type = b.text("#vm-subVmTest1-network-1-model")
+        current_model_type = b.text("#vm-subVmTest1-network-2-model")
 
         # Reopen dialog modal
-        b.click("#vm-subVmTest1-network-1-edit-dialog")
+        b.click("#vm-subVmTest1-network-2-edit-dialog")
 
         # Change network model type of a running domain
-        b.select_from_dropdown("#vm-subVmTest1-network-1-edit-dialog-model", "e1000e")
+        b.select_from_dropdown("#vm-subVmTest1-network-2-edit-dialog-model", "e1000e")
         # Wait for the footer warning to appear
-        b.wait_visible("#vm-subVmTest1-network-1-edit-dialog-idle-message")
+        b.wait_visible("#vm-subVmTest1-network-2-edit-dialog-idle-message")
         # Change network type and source of a running domain
-        b.wait_val("#vm-subVmTest1-network-1-edit-dialog-type", "network")
-        b.wait_val("#vm-subVmTest1-network-1-edit-dialog-source", "default")
-        b.select_from_dropdown("#vm-subVmTest1-network-1-edit-dialog-source", "test_network")
+        b.wait_val("#vm-subVmTest1-network-2-edit-dialog-type", "network")
+        b.wait_val("#vm-subVmTest1-network-2-edit-dialog-source", "default")
+        b.select_from_dropdown("#vm-subVmTest1-network-2-edit-dialog-source", "test_network")
         # Save the network settings
-        b.click("#vm-subVmTest1-network-1-edit-dialog-save")
-        b.wait_not_present("#vm-subVmTest1-network-1-edit-dialog-modal-window")
+        b.click("#vm-subVmTest1-network-2-edit-dialog-save")
+        b.wait_not_present("#vm-subVmTest1-network-2-edit-dialog-modal-window")
         # Wait for the tooltips to appear next to the elements we changed
-        b.wait_in_text("#vm-subVmTest1-network-1-model", current_model_type)
-        b.wait_visible("#vm-subVmTest1-network-1-model-tooltip")
-        b.wait_in_text("#vm-subVmTest1-network-1-type", 'network')
-        b.wait_in_text("#vm-subVmTest1-network-1-source", 'default')
-        b.wait_visible("#vm-subVmTest1-network-1-source-tooltip")
+        b.wait_in_text("#vm-subVmTest1-network-2-model", current_model_type)
+        b.wait_visible("#vm-subVmTest1-network-2-model-tooltip")
+        b.wait_in_text("#vm-subVmTest1-network-2-type", 'network')
+        b.wait_in_text("#vm-subVmTest1-network-2-source", 'default')
+        b.wait_visible("#vm-subVmTest1-network-2-source-tooltip")
 
         # Shut off domain and check changes are applied
         self.performAction("subVmTest1", "forceOff")
-        b.wait_in_text("#vm-subVmTest1-network-1-model", "e1000e")
-        b.wait_not_present("#vm-subVmTest1-network-1-model-tooltip")
-        b.wait_in_text("#vm-subVmTest1-network-1-type", "network")
-        b.wait_not_present("#vm-subVmTest1-network-1-type-tooltip")
-        b.wait_in_text("#vm-subVmTest1-network-1-source", "test_network")
-        b.wait_not_present("#vm-subVmTest1-network-1-source-tooltip")
+        b.wait_in_text("#vm-subVmTest1-network-2-model", "e1000e")
+        b.wait_not_present("#vm-subVmTest1-network-2-model-tooltip")
+        b.wait_in_text("#vm-subVmTest1-network-2-type", "network")
+        b.wait_not_present("#vm-subVmTest1-network-2-type-tooltip")
+        b.wait_in_text("#vm-subVmTest1-network-2-source", "test_network")
+        b.wait_not_present("#vm-subVmTest1-network-2-source-tooltip")
 
         # Remove the network interface
         m.execute("virsh detach-interface --persistent --type network --domain subVmTest1")
@@ -656,7 +658,8 @@ class TestMachinesNetworks(VirtualMachinesCase):
         self.goToVmPage("subVmTest1")
 
         # Create a second bridge to LAN NIC
-        m.execute("ip link add name br1 type bridge && virsh attach-interface --current subVmTest1 bridge br1")
+        next_mac = self.get_next_mac(next_mac)
+        m.execute(f"ip link add name br1 type bridge && virsh attach-interface --current subVmTest1 bridge br1 --mac {next_mac}")
         self.addCleanup(m.execute, "ip link delete br1")
 
         m.execute("virsh start subVmTest1")
@@ -674,7 +677,8 @@ class TestMachinesNetworks(VirtualMachinesCase):
         # Ensure that when the source of a NIC was removed we can still change it
 
         # Redefine deleted networks and attach an interface with source a deleted network
-        m.execute("virsh net-define /tmp/net-default.xml && virsh net-start default && virsh attach-interface --persistent --type network --source default --domain subVmTest1")
+        next_mac = self.get_next_mac(next_mac)
+        m.execute(f"virsh net-define /tmp/net-default.xml && virsh net-start default && virsh attach-interface --persistent --type network --source default --mac {next_mac} --domain subVmTest1")
         m.execute("virsh net-destroy default && virsh net-undefine default")
         m.execute("virsh net-define /tmp/net-test-network.xml && virsh net-start test_network")
 

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -37,13 +37,6 @@ class TestMachinesNICs(VirtualMachinesCase):
         # querying object manager often runs into that on network changes; irrelevant
         self.allow_journal_messages("org.freedesktop.NetworkManager: couldn't get managed objects at /org/freedesktop: Timeout was reached")
 
-    def deleteIface(self, iface):
-        b = self.browser
-
-        b.click(f"#delete-vm-subVmTest1-iface-{iface}")
-        b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Delete network interface")
-        b.click(".pf-c-modal-box__footer button:contains(Delete)")
-
     @no_retry_when_changed
     def testVmNICs(self):
         b = self.browser
@@ -70,22 +63,26 @@ class TestMachinesNICs(VirtualMachinesCase):
 
         b.assert_pixels("#vm-subVmTest1-networks", "vm-details-nics-card", ignore=["#vm-subVmTest1-network-1-mac", "#vm-subVmTest1-network-1-ipv4-address"])
 
+        # Remove default interface
+        self.deleteIface(1)
+
         # Test add network
         m.execute("virsh attach-interface --domain subVmTest1 --type network --source default --model virtio --mac 52:54:00:4b:73:5f --config --live")
 
-        b.wait_in_text("#vm-subVmTest1-network-2-type", "network")
-        b.wait_in_text("#vm-subVmTest1-network-2-source", "default")
-        b.wait_in_text("#vm-subVmTest1-network-2-model", "virtio")
-        b.wait_in_text("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:5f")
-        b.wait_in_text("#vm-subVmTest1-network-2-ipv4-address", "192.168.122.")
-        b.wait_in_text("#vm-subVmTest1-network-2-state", "up")
+        b.wait_in_text("#vm-subVmTest1-network-1-type", "network")
+        b.wait_in_text("#vm-subVmTest1-network-1-source", "default")
+        b.wait_in_text("#vm-subVmTest1-network-1-model", "virtio")
+        b.wait_in_text("#vm-subVmTest1-network-1-mac", "52:54:00:4b:73:5f")
+        b.wait_in_text("#vm-subVmTest1-network-1-ipv4-address", "192.168.122.")
+        b.wait_in_text("#vm-subVmTest1-network-1-state", "up")
 
         # Test bridge network
         m.execute("virsh attach-interface --domain subVmTest1 --type bridge --source virbr0 --model virtio --mac 52:54:00:4b:73:5e --config --live")
 
-        b.wait_in_text("#vm-subVmTest1-network-3-type", "bridge")
-        b.wait_in_text("#vm-subVmTest1-network-3-source", "virbr0")
-        b.wait_in_text("#vm-subVmTest1-network-3-ipv4-address", "192.168.122.")
+        # vNICs are alphabetically sorted by MAC address, so now the new vNIC is first in the list
+        b.wait_in_text("#vm-subVmTest1-network-1-type", "bridge")
+        b.wait_in_text("#vm-subVmTest1-network-1-source", "virbr0")
+        b.wait_in_text("#vm-subVmTest1-network-1-ipv4-address", "192.168.122.")
 
     def testNICPlugingAndUnpluging(self):
         b = self.browser
@@ -156,25 +153,17 @@ class TestMachinesNICs(VirtualMachinesCase):
         b.enter_page('/machines')
         b.wait_in_text("body", "Virtual machines")
         # Check NIC MAC addresses
-        b.wait_text("#vm-subVmTest1-network-1-mac", "52:54:00:4b:73:5f")
-        b.wait_text("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:6f")
-        b.wait_text("#vm-subVmTest1-network-3-mac", "52:54:00:4b:73:4f")
+        b.wait_text("#vm-subVmTest1-network-1-mac", "52:54:00:4b:73:4f")
+        b.wait_text("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:5f")
+        b.wait_text("#vm-subVmTest1-network-3-mac", "52:54:00:4b:73:6f")
         # Detach
         self.deleteIface(2)
         # Make sure popup dialog disappeared
         b.wait_not_present(".pf-c-modal-box")
-        b.wait_text_not("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:6f")
-        b.wait_text("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:4f")
+        b.wait_text_not("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:5f")
+        b.wait_text("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:6f")
 
     def testNICAdd(self):
-        def get_next_mac(last_mac):
-            parts = last_mac.split(':')
-            suffix = parts[-1]
-            new_suffix = format(int(suffix, 16) + 1, "x").zfill(2)
-            parts[-1] = new_suffix
-            new_mac = ':'.join(parts)
-            return new_mac
-
         b = self.browser
         m = self.machine
 
@@ -187,6 +176,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         b.wait_in_text("body", "Virtual machines")
 
         self.goToVmPage("subVmTest1")
+        self.deleteIface(1)  # Remove default vNIC
 
         mac_address = "52:54:00:a5:f8:00"
         # Test a error message handling
@@ -207,7 +197,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         # No NICs present
         b.wait_visible("#vm-subVmTest1-add-iface-button")  # open the Network Interfaces subtab
 
-        mac_address = get_next_mac(mac_address)
+        mac_address = self.get_next_mac(mac_address)
         self.NICAddDialog(
             self,
             source_type="network",
@@ -217,7 +207,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         ).execute()
 
         # Test direct
-        mac_address = get_next_mac(mac_address)
+        mac_address = self.get_next_mac(mac_address)
         self.NICAddDialog(
             self,
             mac=mac_address,
@@ -225,7 +215,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         ).execute()
 
         # Test Bridge
-        mac_address = get_next_mac(mac_address)
+        mac_address = self.get_next_mac(mac_address)
         self.NICAddDialog(
             self,
             mac=mac_address,
@@ -234,7 +224,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         ).execute()
 
         # Test model
-        mac_address = get_next_mac(mac_address)
+        mac_address = self.get_next_mac(mac_address)
         self.NICAddDialog(
             self,
             mac=mac_address,
@@ -247,48 +237,51 @@ class TestMachinesNICs(VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-state", "Running")
         wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
 
-        # Test permanent attachment to running VM
-        mac_address = get_next_mac(mac_address)
-        self.NICAddDialog(
-            self,
-            mac=mac_address,
-            source_type="network",
-            source="test_network",
-            permanent=True,
-        ).execute()
+        # Because of bug in debian-testing, attachment of virtio vNICs after restarting VM will fail
+        # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1005284
+        if m.image not in ["debian-stable", "debian-testing"]:
+            # Test permanent attachment to running VM
+            mac_address = self.get_next_mac(mac_address)
+            self.NICAddDialog(
+                self,
+                mac=mac_address,
+                source_type="network",
+                source="test_network",
+                permanent=True,
+            ).execute()
 
-        # Test NIC attaching to non-persistent VM
-        m.execute("virsh dumpxml --inactive subVmTest1 > /tmp/subVmTest1.xml; virsh undefine subVmTest1")
-        b.wait_visible("div[data-vm-transient=\"true\"]")
-        mac_address = get_next_mac(mac_address)
-        self.NICAddDialog(
-            self,
-            source_type="network",
-            source="test_network",
-            mac=mac_address,
-            nic_num=3,
-            persistent_vm=False,
-        ).execute()
-        m.execute("virsh define /tmp/subVmTest1.xml")
-        b.wait_visible("div[data-vm-transient=\"false\"]")
-        b.click("#vm-subVmTest1-action-kebab button")
-        b.click("#vm-subVmTest1-forceOff")
-        b.wait_in_text("#vm-subVmTest1-state", "Shut off")
+            # Test NIC attaching to non-persistent VM
+            m.execute("virsh dumpxml --inactive subVmTest1 > /tmp/subVmTest1.xml; virsh undefine subVmTest1")
+            b.wait_visible("div[data-vm-transient=\"true\"]")
+            mac_address = self.get_next_mac(mac_address)
+            self.NICAddDialog(
+                self,
+                source_type="network",
+                source="test_network",
+                mac=mac_address,
+                nic_num=2,
+                persistent_vm=False,
+            ).execute()
+            m.execute("virsh define /tmp/subVmTest1.xml")
+            b.wait_visible("div[data-vm-transient=\"false\"]")
+            b.click("#vm-subVmTest1-action-kebab button")
+            b.click("#vm-subVmTest1-forceOff")
+            b.wait_in_text("#vm-subVmTest1-state", "Shut off")
 
-        mac_address = get_next_mac(mac_address)
-        self.NICAddDialog(
-            self,
-            mac=mac_address,
-            remove=False,
-        ).execute()
+            mac_address = self.get_next_mac(mac_address)
+            self.NICAddDialog(
+                self,
+                mac=mac_address,
+                remove=False,
+            ).execute()
 
-        mac_address = get_next_mac(mac_address)
-        self.NICAddDialog(
-            self,
-            mac=mac_address,
-            nic_num=3,
-            remove=False,
-        ).execute()
+            mac_address = self.get_next_mac(mac_address)
+            self.NICAddDialog(
+                self,
+                mac=mac_address,
+                nic_num=2,
+                remove=False,
+            ).execute()
 
     class NICEditDialog:
 
@@ -297,7 +290,7 @@ class TestMachinesNICs(VirtualMachinesCase):
             test_obj,
             mac="52:54:00:f0:eb:63",
             model=None,
-            nic_num=2,
+            nic_num=1,
             source=None,
             source_type=None,
         ):
@@ -452,6 +445,10 @@ class TestMachinesNICs(VirtualMachinesCase):
 
         self.goToVmPage("subVmTest1")
 
+        # Remove default vNIC
+        self.deleteIface(1)
+
+        # Test Warning message when changes are done in a running VM
         self.NICAddDialog(
             self,
             source_type="bridge",
@@ -463,9 +460,9 @@ class TestMachinesNICs(VirtualMachinesCase):
         # The dialog fields should reflect the permanent configuration
         dialog = self.NICEditDialog(self)
         dialog.open()
-        b.wait_in_text("#vm-subVmTest1-network-2-edit-dialog-source", "eth42")
-        b.wait_val("#vm-subVmTest1-network-2-edit-dialog-mac", "52:54:00:f0:eb:63")
-        b.assert_pixels("#vm-subVmTest1-network-2-edit-dialog-modal-window", "vm-edit-nic-modal")
+        b.wait_in_text("#vm-subVmTest1-network-1-edit-dialog-source", "eth42")
+        b.wait_val("#vm-subVmTest1-network-1-edit-dialog-mac", "52:54:00:f0:eb:63")
+        b.assert_pixels("#vm-subVmTest1-network-1-edit-dialog-modal-window", "vm-edit-nic-modal")
         dialog.cancel()
 
         # Changing the NIC configuration for a shut off VM should not display any warning
@@ -496,16 +493,16 @@ class TestMachinesNICs(VirtualMachinesCase):
             source_type="direct",
             source="eth43",
             mac="52:54:00:f0:eb:64",
-            nic_num=3,
+            nic_num=2,
             remove=False
         ).execute()
-        b.wait_visible("#vm-subVmTest1-network-3-edit-dialog[aria-disabled=true]")
+        b.wait_visible("#vm-subVmTest1-network-2-edit-dialog[aria-disabled=true]")
 
     class NICAddDialog:
 
         def __init__(
             # We have always have to specify mac and source_type to identify the device in xml and $virsh detach-interface
-            self, test_obj, source_type="direct", source=None, model=None, nic_num=2,
+            self, test_obj, source_type="direct", source=None, model=None, nic_num=1,
             permanent=False, mac=None, remove=True, persistent_vm=True,
             xfail=False, xfail_error=None, pixel_test_tag=None
         ):

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -139,7 +139,6 @@ class TestMachinesNICs(VirtualMachinesCase):
         self.goToVmPage("subVmTest1")
 
         self.deleteIface(1)
-        b.wait_not_present(".pf-c-modal-box")
         b.wait_not_present("#vm-subVmTest1-network-1-mac")
 
         # Detach NIC when the VM is shutoff, Also check this issue: https://bugzilla.redhat.com/show_bug.cgi?id=1791543
@@ -158,8 +157,6 @@ class TestMachinesNICs(VirtualMachinesCase):
         b.wait_text("#vm-subVmTest1-network-3-mac", "52:54:00:4b:73:6f")
         # Detach
         self.deleteIface(2)
-        # Make sure popup dialog disappeared
-        b.wait_not_present(".pf-c-modal-box")
         b.wait_text_not("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:5f")
         b.wait_text("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:6f")
 

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -147,18 +147,30 @@ class TestMachinesNICs(VirtualMachinesCase):
         m.execute("virsh attach-interface --domain subVmTest1 --type network --source default --model virtio --mac 52:54:00:4b:73:5f --config")
         m.execute("virsh attach-interface --domain subVmTest1 --type bridge --source virbr0 --model virtio --mac 52:54:00:4b:73:6f --config")
         m.execute("virsh attach-interface --domain subVmTest1 --type network --source default --model virtio --mac 52:54:00:4b:73:4f --config")
+        # Add network with the same MAC address
+        m.execute("virsh attach-interface --domain subVmTest1 --type network --source default --model e1000e --mac 52:54:00:4b:73:5f --config")
         # Refresh for getting new added NIC
         b.reload()
         b.enter_page('/machines')
         b.wait_in_text("body", "Virtual machines")
         # Check NIC MAC addresses
-        b.wait_text("#vm-subVmTest1-network-1-mac", "52:54:00:4b:73:4f")
-        b.wait_text("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:5f")
-        b.wait_text("#vm-subVmTest1-network-3-mac", "52:54:00:4b:73:6f")
+        b.wait_text("#vm-subVmTest1-network-1-mac", "52:54:00:4b:73:6f")
+        b.wait_text("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:4f")
+        b.wait_text("#vm-subVmTest1-network-3-mac", "52:54:00:4b:73:5f")
+        b.wait_text("#vm-subVmTest1-network-3-model", "virtio")
+        b.wait_text("#vm-subVmTest1-network-4-mac", "52:54:00:4b:73:5f")
+        b.wait_text("#vm-subVmTest1-network-4-model", "e1000e")
         # Detach
         self.deleteIface(2)
-        b.wait_text_not("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:5f")
-        b.wait_text("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:6f")
+        b.wait_not_present("#vm-subVmTest1-network-4-mac")
+        b.wait_text_not("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:4f")
+        b.wait_text("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:5f")
+        b.wait_text("#vm-subVmTest1-network-2-model", "virtio")
+        # Test deleting the interface with same MAC address as the other vNIC will delete the correct one
+        self.deleteIface(2)
+        b.wait_not_present("#vm-subVmTest1-network-3-mac")
+        b.wait_text("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:5f")
+        b.wait_text("#vm-subVmTest1-network-2-model", "e1000e")
 
     def testNICAdd(self):
         b = self.browser
@@ -608,10 +620,6 @@ class TestMachinesNICs(VirtualMachinesCase):
                 self.browser.wait_in_text("body", "Virtual machines")
             else:
                 self.deleteIface(self.nic_num)
-                vm_state = self.browser.text("#vm-subVmTest1-state")
-                # On a running VM detaching NIC takes longer and we can see the spinner
-                if vm_state == "Running":
-                    self.browser.wait_visible(".pf-c-modal-box__footer button.pf-m-in-progress")
 
                 # Check NIC is no longer in list
                 self.browser.wait_not_present(f"#vm-subVmTest1-network-{self.nic_num}-mac")

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -214,6 +214,7 @@ class VirtualMachinesCaseHelpers:
         b.click(f"#delete-vm-subVmTest1-iface-{iface}")
         b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Delete network interface")
         b.click(".pf-c-modal-box__footer button:contains(Delete)")
+        b.wait_not_present(".pf-c-modal-box")
 
     def get_next_mac(self, last_mac):
         parts = last_mac.split(':')

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -208,9 +208,23 @@ class VirtualMachinesCaseHelpers:
         else:
             return m.execute(cmd)
 
+    def deleteIface(self, iface):
+        b = self.browser
+
+        b.click(f"#delete-vm-subVmTest1-iface-{iface}")
+        b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Delete network interface")
+        b.click(".pf-c-modal-box__footer button:contains(Delete)")
+
+    def get_next_mac(self, last_mac):
+        parts = last_mac.split(':')
+        suffix = parts[-1]
+        new_suffix = format(int(suffix, 16) + 1, "x").zfill(2)
+        parts[-1] = new_suffix
+        new_mac = ':'.join(parts)
+        return new_mac
+
 
 class VirtualMachinesCase(MachineCase, VirtualMachinesCaseHelpers, StorageHelpers, NetworkHelpers):
-
     def setUp(self):
         super().setUp()
 


### PR DESCRIPTION
Libvirt allows to have multiple network interfaces attached to the same VM to have the same MAC address, therefore that's not a good parameter to uniquely identify an attached vNIC. Ideally we should identify a vNIC to detach by a number of slot, bus, function and domain. Such detachment is however broken, so instead let's detach it by the index of <interface> in array of VM's XML <devices>
This serves as a workaround for https://github.com/virt-manager/virt-manager/issues/356
It also fixes https://bugzilla.redhat.com/show_bug.cgi?id=1867478
