### PR TITLE
Workaround tmt regression with artifacts syncing

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -8,7 +8,9 @@ if [ -d source ]; then
 else
     SOURCE="$(realpath $TESTS/../..)"
 fi
-LOGS="$(pwd)/logs"
+# workaround until tmt-1.10 is out with https://github.com/psss/tmt/pull/1004
+# LOGS="$(pwd)/logs"
+LOGS="$TMT_TREE/../execute/data/test/browser/logs"
 mkdir -p "$LOGS"
 chmod a+w "$LOGS"
 


### PR DESCRIPTION
Unfortunately tmt broke this feature if one of the releases,
with https://github.com/psss/tmt/pull/1004 this is being fixed
and should bring back the old behaviour, until use the only
path that is now pulled back from the guest.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>
