### PR TITLE
Fix broken virt-install XML without "Immediately start VM"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 51cc384a60eb902cbd335a983b5b6cd40345fdbe; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 262; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 

--- a/src/scripts/install_machine.py
+++ b/src/scripts/install_machine.py
@@ -154,7 +154,7 @@ def prepare_installation_source(args):
     params = []
     only_define = args['type'] == 'create' and not args['startVm']
     if only_define:
-        params.append("--print-xml")
+        params.append("--print-xml=1")
 
     if args['sourceType'] == "pxe":
         params += ['--pxe', '--network', args['source']]

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -287,14 +287,14 @@ class TestMachinesCreate(VirtualMachinesCase):
         b.enter_page('/machines')
         b.wait_in_text("body", "Virtual machines")
 
-        # First create the PXE VM but do not start it. We 'll need to tweak a bit the XML
-        # to have serial console at bios and also redirect serial console to a file
+        # Create with immediate starting
         runner.createTest(TestMachinesCreate.VmDialog(self, name='pxe-guest', sourceType='pxe',
                                                       location="network=pxe-nat",
                                                       memory_size=128, memory_size_unit='MiB',
                                                       storage_pool="NoStorage",
                                                       start_vm=True, delete=False))
 
+        # Stop it, tweak the XML to have serial console at bios and also redirect serial console to a file
         # We don't want to use start_vm == False because if we get a separate install phase
         # virt-install will overwrite our changes.
 
@@ -307,7 +307,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         wait(lambda: "pxe-guest" in self.machine.execute("virsh list --persistent"), delay=3)
         self.machine.execute("virsh destroy pxe-guest")
 
-        # Remove all serial ports and consoles first and tehn add a console of type file
+        # Remove all serial ports and consoles first and then add a console of type file
         # virt-xml tool does not allow to remove both serial and console devices at once
         # https://bugzilla.redhat.com/show_bug.cgi?id=1685541
         # So use python xml parsing to change the domain XML.

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -449,6 +449,12 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                                  memory_size=128, memory_size_unit='MiB',
                                                                  storage_pool="NoStorage"), True)
 
+        # Check PXE boot with separate install phase
+        runner.createThenInstallTest(TestMachinesCreate.VmDialog(self, sourceType='pxe',
+                                                                 location="network=default",
+                                                                 memory_size=128, memory_size_unit='MiB',
+                                                                 storage_pool="NoStorage"))
+
         # Try performing an installation which will fail and ensure that the 'Install' button is still available
         runner.createThenInstallTest(TestMachinesCreate.VmDialog(self, sourceType='file',
                                                                  location=config.NOVELL_MOCKUP_ISO_PATH,
@@ -1268,7 +1274,7 @@ class TestMachinesCreate(VirtualMachinesCase):
                 # Wait for virt-install to define the VM and then stop it - otherwise we get 'domain is ready being removed' error
                 wait(lambda: dialog.name in self.machine.execute("virsh list --persistent"), delay=3)
 
-                # unfinished install script runs indefinitelly, so we need to force it off
+                # unfinished install script runs indefinitely, so we need to force it off
                 self.test_obj.performAction(name, "forceOff", False)
                 # https://bugzilla.redhat.com/show_bug.cgi?id=1818089
                 # After shutting it off virt-install will restart the domain and exit because of the above bug


### PR DESCRIPTION
Whenever there is an install phase (e.g. booting install media from an
iso or network and using that to install an OS into the guest),
virt-install will generate two slightly different guest
definitions: one for the very first boot (where the OS is installed to
the guest) and one for subsequent boots (after the OS is installed on
the guest). By default, --print-xml will print both the install phase
XML and the final XML, which resulted in a failure due to

    xml.etree.ElementTree.ParseError: junk after document element: line 61, column 0

Avoid that by only printing the XML for the first phase.

https://bugzilla.redhat.com/show_bug.cgi?id=2032462