### PR TITLE
fmf: Fix modular libvirt socket startup on Rawhide

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -56,7 +56,9 @@ systemctl start firewalld
 firewall-cmd --add-service=cockpit --permanent
 firewall-cmd --add-service=cockpit
 
-if grep -Eq 'PLATFORM_ID=.*(f35|f36|el9)' /etc/os-release; then
+. /usr/lib/os-release
+
+if [ "${PLATFORM_ID:-}" != "platform:f34" ] && [ "${PLATFORM_ID:-}" != "platform:el8" ]; then
     # HACK: new modular libvirt sockets are not running by default in f35
     # https://gitlab.com/libvirt/libvirt/-/issues/219
     systemctl start virtinterfaced.socket


### PR DESCRIPTION
Rawhide is Fedora 37 now.

Invert the condition to only exclude the old platforms which are known
not to have modular services.

---

See [current failure](http://artifacts.dev.testing-farm.io/5e3c5c7e-757b-4bf1-9ec3-89952739e74a/)