### PR TITLE
fmf: Use official TMT test data directory for artifacts

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -8,9 +8,9 @@ if [ -d source ]; then
 else
     SOURCE="$(realpath $TESTS/../..)"
 fi
-# workaround until tmt-1.10 is out with https://github.com/psss/tmt/pull/1004
-# LOGS="$(pwd)/logs"
-LOGS="$TMT_TREE/../execute/data/test/browser/logs"
+
+# https://tmt.readthedocs.io/en/stable/overview.html#variables
+LOGS="${TMT_TEST_DATA:-logs}"
 mkdir -p "$LOGS"
 chmod a+w "$LOGS"
 


### PR DESCRIPTION
See https://tmt.readthedocs.io/en/stable/overview.html#variables

---

Exact same fix as in https://github.com/cockpit-project/cockpit-podman/pull/922 , where I tested it with a broken commit. As rawhide currently fails, we should get some artifacts on that.