### PR TITLE
packit: Disable Fedora 34, enable Fedora 36, fix test regressions

### DIFF
--- a/packaging/cockpit-machines.spec.in
+++ b/packaging/cockpit-machines.spec.in
@@ -39,6 +39,7 @@ Requires: libvirt-dbus >= 1.2.0
 Recommends: virt-install
 Recommends: libosinfo
 Recommends: python3-gobject-base
+Suggests: qemu-virtiofsd
 
 %description
 Cockpit component for managing virtual machines.

--- a/packit.yaml
+++ b/packit.yaml
@@ -13,8 +13,8 @@ jobs:
     trigger: pull_request
     metadata:
       targets:
-      - fedora-34
       - fedora-35
+      - fedora-36
       - fedora-rawhide
       - centos-stream-8
       - centos-stream-9

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -70,6 +70,11 @@ if [ "${PLATFORM_ID:-}" != "platform:f34" ] && [ "${PLATFORM_ID:-}" != "platform
     systemctl start virtstoraged.socket
 fi
 
+# Fedora 36/37 and RHEL 9 split out qemu-virtiofsd; once this is in all supported OSes, move to main.fmf
+if [ "${PLATFORM_ID:-}" != "platform:f35" ] && [ "${PLATFORM_ID:-}" != "platform:el8" ]; then
+    dnf install -y qemu-virtiofsd
+fi
+
 # Run tests as unprivileged user
 su - -c "env TEST_BROWSER=firefox SOURCE=$SOURCE LOGS=$LOGS $TESTS/run-test.sh" runtest
 


### PR DESCRIPTION
Corresponding to cockpituous changes in commit 72318f86194d1.

Investigating test regressions, also on Rawhide:

 - [x] `TestMachinesDisks.testAddDiskPool`: Genuinely broken, see https://github.com/cockpit-project/bots/pull/2977 for adding naughty
 - [x] `TestMachinesFilesystems:testBasicSystemConnection`: Fixed in separate commit
 - `TestMachinesCreate.testCreateThenInstall` (rawhide only): Moved to issue #581, this is more complex

These all reproduce in local tmt VM.

[f36 failure log](http://artifacts.dev.testing-farm.io/b402bb5c-7754-4dab-8743-2de515356db1/)
[rawhide failure log](http://artifacts.dev.testing-farm.io/438058c3-e338-4fd9-b055-293f6ac96adc/)