### PR TITLE
DBG - update to test/common without expect_load

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 262; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git edec865986b2e0e37f7d34be77965185da16596b; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 


### PR DESCRIPTION
This is to see what happens.  There are no calls to expect_load in the tests themselves.