### PR TITLE
Print error in console in case first attempt to use libvirt's dbus API failed

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -87,7 +87,8 @@ export const App = () => {
                                                 });
                                                 setError(errorMsgs.join(', '));
                                             });
-                                }, () => {
+                                }, ex => {
+                                    console.error("Failed to get libvirt version from the dbus API:" + ex.message);
                                     /* If the API call failed on system connection and the user has superuser privileges then show the Empty state screen */
                                     if (conn == "system")
                                         setSystemSocketInactive(true);


### PR DESCRIPTION
This could help debug issues like #578