### PR TITLE
Revert "Pin eslint-plugin-react to the last non broken release"

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-react": "7.28.0",
+    "eslint-plugin-react": "^7.21.0",
     "eslint-plugin-react-hooks": "^4.1.2",
     "eslint-plugin-standard": "^4.0.1",
     "eslint-webpack-plugin": "^2.5.3",


### PR DESCRIPTION
This reverts commit 2de5c1c29bf8e9f46504ffd01ce555f848e7787b.

The broken key errors were fixed in 7.29.1.