### PR TITLE
fmf: Add workaround for RHEL/CentOS 9 OVMF regression

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -21,6 +21,11 @@ dnf install --disablerepo=fedora-cisco-openh264 -y firefox
 #HACK: unbreak rhel-9-0's default choice of 999999999 rounds, see https://bugzilla.redhat.com/show_bug.cgi?id=1993919
 sed -ie 's/#SHA_CRYPT_MAX_ROUNDS 5000/SHA_CRYPT_MAX_ROUNDS 5000/' /etc/login.defs
 
+# HACK: https://bugzilla.redhat.com/show_bug.cgi?id=2057769
+if [ "$(rpm -q edk2-ovmf)" = "edk2-ovmf-20220126gitbb1bba3d77-3.el9.noarch" ]; then
+    rm /usr/share/qemu/firmware/50-edk2-ovmf-amdsev.json
+fi
+
 # Show critical packages versions
 rpm -q qemu-kvm libvirt-daemon selinux-policy cockpit-bridge cockpit-machines
 


### PR DESCRIPTION
The most recent edk2-ovmf update completely broke `virsh
domcapabilities` due to the newly introduced broken
50-edk2-ovmf-amdsev.json file. Remove it until the fix lands, which we
ensure by applying this workaround only to the specific known-broken
version.

---

Fixes [this c9s mess](https://artifacts.dev.testing-farm.io/a880a31c-cf3b-40b3-b97c-460972cf6178/) which started to happen a few days ago. It will affect our next rhel-9-0 image refresh as well (then I'll add it to vm.install), but hopefully the fix will land soon.