### PR TITLE
fmf: Skip TestMachinesSettings.testVCPU on Rawhide

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -54,6 +54,10 @@ EXCLUDES="$EXCLUDES TestMachinesHostDevs.testHostDevAdd"
 # FIXME: https://github.com/cockpit-project/cockpit-machines/issues/581
 EXCLUDES="$EXCLUDES TestMachinesCreate.testCreateThenInstall"
 
+if [ "$TEST_OS" = "fedora-37" ]; then
+    EXCLUDES="$EXCLUDES TestMachinesSettings.testVCPU"
+fi
+
 if [ "$ID" = "fedora" ]; then
     # Testing Farm machines are really slow in European evenings
     export TEST_TIMEOUT_FACTOR=3


### PR DESCRIPTION
This test fails on the infra and seems to break all subsequent tests.
Let's disable it until we figure out what is wrong.

----

Let's use this place to debug why it [fails so bitterly](https://artifacts.dev.testing-farm.io/0ba083c6-a50b-4ede-af16-ead336a87437/) right now. This started a few days ago, and is apparently some regression in the virt/qemu stack:

    error: Disconnected from qemu:///system due to end of file

unfortunately there are no [artifacts](https://artifacts.dev.testing-farm.io/0ba083c6-a50b-4ede-af16-ead336a87437/work-allTaHERb/plans/all/execute/data/test/browser/data/) for that or any test beyond that, something thoroughly corrupts the VM.

Unfortunately I'm unable to reproduce that locally, as Fedora 36 and rawhide images fail to start -- I can get a `virsh console`, but not ssh in -- the packets never arrive in the VM. (Fedora 35 and C9S image works fine, though).

For the initial run, let's figure out if that is the sole reason, or whether anything else is broken as well.