### PR TITLE
Use correct source for iface of type direct for InactiveWarning tooltip

### DIFF
--- a/src/components/vm/nics/vmNicsCard.jsx
+++ b/src/components/vm/nics/vmNicsCard.jsx
@@ -313,7 +313,7 @@ export class VmNetworkTab extends React.Component {
                         return (
                             <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }} id={`${id}-network-${networkId}-source`}>
                                 <FlexItem>{getSourceElem[network.type](getIfaceSourceName(network), networkId)}</FlexItem>
-                                {inactiveNIC && inactiveNIC.source[inactiveNIC.type] !== network.source[network.type] && <WarningInactive iconId={`${id}-network-${networkId}-source-tooltip`} tooltipId="tip-network" />}
+                                {inactiveNIC && getIfaceSourceName(inactiveNIC) !== getIfaceSourceName(network) && <WarningInactive iconId={`${id}-network-${networkId}-source-tooltip`} tooltipId="tip-network" />}
                             </Flex>
                         );
                     } else {

--- a/src/components/vm/nics/vmNicsCard.jsx
+++ b/src/components/vm/nics/vmNicsCard.jsx
@@ -221,12 +221,6 @@ export class VmNetworkTab extends React.Component {
                 }
             };
         };
-        const addressPortSource = (source, networkId) => (<table id={`${id}-network-${networkId}-source`}>
-            <tbody>
-                <tr><td className='machines-network-source-descr'>{_("Address")}</td><td className='machines-network-source-value'>{source.address}</td></tr>
-                <tr><td className='machines-network-source-descr'>{_("Port")}</td><td className='machines-network-source-value'>{source.port}</td></tr>
-            </tbody>
-        </table>);
 
         // Network data mapping to rows
         let detailMap = [
@@ -283,14 +277,20 @@ export class VmNetworkTab extends React.Component {
             {
                 name: _("Source"), value: (network, networkId) => {
                     const sourceElem = source => checkDeviceAviability(source) ? <Button variant="link" isInline onClick={sourceJump(source)}>{source}</Button> : source;
+                    const addressPortSourceElem = (source, networkId) => (<table id={`${id}-network-${networkId}-source`}>
+                        <tbody>
+                            <tr><td className='machines-network-source-descr'>{_("Address")}</td><td className='machines-network-source-value'>{source.address}</td></tr>
+                            <tr><td className='machines-network-source-descr'>{_("Port")}</td><td className='machines-network-source-value'>{source.port}</td></tr>
+                        </tbody>
+                    </table>);
                     const mapSource = {
                         direct: (source) => sourceElem(source.dev),
                         network: (source) => sourceElem(source.network),
                         bridge: (source) => sourceElem(source.bridge),
-                        mcast: addressPortSource,
-                        server: addressPortSource,
-                        client: addressPortSource,
-                        udp: addressPortSource,
+                        mcast: addressPortSourceElem,
+                        server: addressPortSourceElem,
+                        client: addressPortSourceElem,
+                        udp: addressPortSourceElem,
                     };
                     if (mapSource[network.type] !== undefined) {
                         const inactiveNIC = nicLookupByMAC(vm.inactiveXML.interfaces, network.mac);

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -411,6 +411,28 @@ class TestMachinesNICs(VirtualMachinesCase):
                 f"#vm-subVmTest1-network-{self.nic_num}-mac",
                 self.mac if self.mac and self.vm_state == "shut off" else self.mac_current
             )
+            if self.vm_state == "running":
+                if self.source_type is not None and self.source_type != self.source_type_current:
+                    b.wait_visible(f"#vm-subVmTest1-network-{self.nic_num}-type-tooltip")
+                else:
+                    b.wait_not_present(f"#vm-subVmTest1-network-{self.nic_num}-type-tooltip")
+
+                if self.source is not None and self.source != self.source_current:
+                    b.wait_visible(f"#vm-subVmTest1-network-{self.nic_num}-source-tooltip")
+                # Changing source_type may in effect also change source, so tooltip being present is correct
+                # Only changing source type beteen bridge and direct should not affect source
+                elif self.source_type in ["direct", "bridge"] and self.source_type_current in ["direct", "bridge"]:
+                    b.wait_not_present(f"#vm-subVmTest1-network-{self.nic_num}-source-tooltip")
+
+                if self.mac is not None and self.mac != self.mac_current:
+                    b.wait_visible(f"#vm-subVmTest1-network-{self.nic_num}-mac-tooltip")
+                else:
+                    b.wait_not_present(f"#vm-subVmTest1-network-{self.nic_num}-mac-tooltip")
+
+                if self.model is not None and self.model != self.model_current:
+                    b.wait_visible(f"#vm-subVmTest1-network-{self.nic_num}-model-tooltip")
+                else:
+                    b.wait_not_present(f"#vm-subVmTest1-network-{self.nic_num}-model-tooltip")
 
     def testNICEdit(self):
         b = self.browser

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -322,7 +322,7 @@ class TestMachinesNICs(VirtualMachinesCase):
             # select widget options are never visible for the headless chrome - call therefore directly the js function
             self.source_type_current = b.attr(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-type", "data-value")
             self.source_current = b.attr(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-source", "data-value")
-            self.mac_current = b.text(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-mac")
+            self.mac_current = b.val(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-mac")
             self.model_current = b.attr(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-model", "data-value")
 
         def fill(self):

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -425,7 +425,6 @@ class TestMachinesNICs(VirtualMachinesCase):
 
         self.goToVmPage("subVmTest1")
 
-        # Test Warning message when changes are done in a running VM
         self.NICAddDialog(
             self,
             source_type="bridge",


### PR DESCRIPTION
    When editing a source of iface of a running VM, a tooltip is shown to
    inform the user that changes will take effect after reboot.
    However, for a iface of type direct, we source 'source.direct' instead
    of 'source.dev', which resulted in a tooltip being shown even when not
    necessary.
    
Fixes #606
