### PR TITLE
workflows: Fix building of PO template

### DIFF
--- a/.github/workflows/weblate-sync-pot.yml
+++ b/.github/workflows/weblate-sync-pot.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up dependencies
         run: |
           sudo apt update
-          sudo apt install -y --no-install-recommends npm make gettext
+          sudo apt install -y --no-install-recommends npm make gettext appstream
 
       - name: Clone source repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Commit 25445821c643 introduced i18n of our AppStream metainfo. Install
the package into the workflow machine which ships the necessary
`metainfo.{its,loc}` file for xgettext.

---

See [failed workflow](https://github.com/cockpit-project/cockpit-machines/actions/runs/1966721440). Same fix as https://github.com/cockpit-project/cockpit-podman/pull/941