### PR TITLE
vcpuModal: correct required propType for maxVcpu

### DIFF
--- a/src/components/vm/overview/vcpuModal.jsx
+++ b/src/components/vm/overview/vcpuModal.jsx
@@ -272,6 +272,6 @@ export class VCPUModal extends React.Component {
 }
 VCPUModal.propTypes = {
     vm: PropTypes.object.isRequired,
-    maxVcpu: PropTypes.number.isRequired,
+    maxVcpu: PropTypes.string.isRequired,
     close: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
The modal wants a number however libvirt provides a string and as the
modal also uses parseInt to convert the string into a number. The
invalid property seems to make testMultipleSettings flake 10% of the
time.

Logs show that we open the dialog and it closes directly as the property is not a number. The weird thing is that this doesn't always happen... The memory leak is a seperate thing which should be fixed.
```
showVcpuModal false [index.js:49028:13](http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js)
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
VmActions@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:49923:12
td
TdBase@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:35583:331
Td
tr
TrBase@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:35870:208
Tr
tbody
TbodyBase@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:35534:102
Tbody
table
TableComposableBase@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:35473:33
TableComposable
ListingTable@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:53747:22
div
CardBody@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:16264:83
article
Card@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:16185:351
div
Gallery@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:28614:107
section
PageSection@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:20136:229
main
div
Page@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:19911:9
HostVmsList@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:51596:13 [index.js:122337:30](http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js)
open VcpuModal [index.js:49072:13](http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js)
Warning: Failed prop type: Invalid prop `maxVcpu` of type `string` supplied to `VCPUModal`, expected `number`.
VCPUModal@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:48677:5
VmOverviewCard@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:49020:5
div
CardBody@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:16264:83
article
Card@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:16185:351
div
Gallery@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:28614:107
section
PageSection@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:20136:229
main
div
Page@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:19911:9
VmDetailsPage@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:50630:12
AppActive@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:36525:5
App@http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:36471:66 [index.js:149010:30](http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js)
    printWarning http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:149010
    error http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:148986
    checkPropTypes http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:150725
    validatePropTypes http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:150926
    createElementWithValidation http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:151030
    render http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:49211
    finishClassComponent http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:139755
    updateClassComponent http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:139705
    beginWork http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:141343
    beginWork$1 http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:146205
    performUnitOfWork http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:145044
    workLoopSync http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:144972
    renderRootSync http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:144935
    performSyncWorkOnRoot http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:144558
    flushSyncCallbackQueueImpl http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:133597
    unstable_runWithPriority http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:153608
    runWithPriority$1 http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:133546
    flushSyncCallbackQueueImpl http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:133592
    flushSyncCallbackQueue http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:133579
    discreteUpdates$1 http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:144685
    discreteUpdates http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:126026
    dispatchDiscreteEvent http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js:128159
    ph_mouse debugger eval code:156
    <anonymous> debugger eval code:1
close vpcumodal [index.js:49213:17](http://127.0.0.2:9092/cockpit/$b3a0a4324cf12660ce56c711137b850f7da59517ad8772c8ce8e9f3c256d18c3/machines/index.js)
Navigated to http://127.0.0.2:9092/machines#vm?name=subVmTest1&connection=system
```