### PR TITLE
Trim RPM package dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ rpm: $(TARFILE) $(SPEC)
 
 # build a VM with locally built distro pkgs installed
 $(VM_IMAGE): $(TARFILE) packaging/debian/rules packaging/debian/control packaging/arch/PKGBUILD bots
-	bots/image-customize --verbose --no-network --fresh --build $(TARFILE) --script $(CURDIR)/test/vm.install $(TEST_OS)
+	bots/image-customize --no-network --fresh --build $(TARFILE) --script $(CURDIR)/test/vm.install $(TEST_OS)
 
 # convenience target for the above
 vm: $(VM_IMAGE)

--- a/packaging/cockpit-machines.spec.in
+++ b/packaging/cockpit-machines.spec.in
@@ -35,8 +35,21 @@ Requires: cockpit-bridge >= 215
 %if 0%{?suse_version}
 Requires: libvirt-daemon-qemu
 %else
-Requires: libvirt-daemon-kvm
+Requires: libvirt-daemon-driver-qemu
+Requires: libvirt-daemon-driver-network
+Requires: libvirt-daemon-driver-nodedev
+Requires: libvirt-daemon-driver-storage-core
+Requires: (libvirt-daemon-driver-interface if virt-install)
 Requires: (libvirt-daemon-config-network if virt-install)
+Recommends: libvirt-daemon-driver-storage-disk
+%if 0%{?rhel}
+Requires: qemu-kvm
+%else
+# smaller footprint on Fedora, as qemu-kvm is really expensive on a server
+Requires: qemu-kvm-core
+Recommends: qemu-block-curl
+Recommends: qemu-device-usb-redirect
+%endif
 %endif
 Requires: libvirt-client
 Requires: libvirt-dbus >= 1.2.0

--- a/packaging/cockpit-machines.spec.in
+++ b/packaging/cockpit-machines.spec.in
@@ -36,6 +36,7 @@ Requires: cockpit-bridge >= 215
 Requires: libvirt-daemon-qemu
 %else
 Requires: libvirt-daemon-kvm
+Requires: (libvirt-daemon-config-network if virt-install)
 %endif
 Requires: libvirt-client
 Requires: libvirt-dbus >= 1.2.0

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -16,7 +16,7 @@ chmod a+w "$LOGS"
 
 # install firefox (available everywhere in Fedora and RHEL)
 # we don't need the H.264 codec, and it is sometimes not available (rhbz#2005760)
-dnf install --disablerepo=fedora-cisco-openh264 -y firefox
+dnf install --disablerepo=fedora-cisco-openh264 -y --setopt=install_weak_deps=False firefox
 
 #HACK: unbreak rhel-9-0's default choice of 999999999 rounds, see https://bugzilla.redhat.com/show_bug.cgi?id=1993919
 sed -ie 's/#SHA_CRYPT_MAX_ROUNDS 5000/SHA_CRYPT_MAX_ROUNDS 5000/' /etc/login.defs

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -14,6 +14,8 @@ require:
   - python3-yaml
   # required by tests
   - firewalld
+  - libvirt-daemon-driver-storage-iscsi
+  - libvirt-daemon-driver-storage-logical
   - targetcli
 test: ./browser.sh
 duration: 50m

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -14,7 +14,6 @@ require:
   - python3-yaml
   # required by tests
   - firewalld
-  - libvirt-daemon-config-network
   - targetcli
 test: ./browser.sh
 duration: 50m


### PR DESCRIPTION
libvirt-daemon-kvm is is a meta-package that pulls in the qemu-kvm
meta-package; that has tons of desktop support dependencies, plus all of
the storage/network libvirt drivers. Most of them are not required to
run cockpit-machines, so don't impose them on servers.

Instead, only depend on the basic packages for interacting with existing
VMs, and add some extra conditional dependencies if the recommended
virt-install is present (to be able to create new VMs).

Promote libvirt-daemon-config-network from a test to a runtime
dependency, as without it, creating system VMs does not work.

See https://libvirt.org/kbase/rpm-deployment.html

----

Similar to https://github.com/cockpit-project/cockpituous/pull/473 . See [recent discussion](https://lists.fedoraproject.org/archives/list/server@lists.fedoraproject.org/thread/SZKLLRC6ZRBFRYF5KFTWH7Z6MZ2GRX7V/) on Fedora Server list.

 - Fix or find a workaround for detecting spice QXL capability: https://bugzilla.redhat.com/show_bug.cgi?id=2064594: PR #643