### PR TITLE
IGNORE: debug virt-install --cdrom bug https://bugzilla.redhat.com/show_bug.cgi?id=2063853

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -16,8 +16,5 @@ jobs:
     trigger: pull_request
     metadata:
       targets:
-      - fedora-35
       - fedora-36
       - fedora-rawhide
-      - centos-stream-8
-      - centos-stream-9

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -14,6 +14,7 @@ require:
   - python3-yaml
   # required by tests
   - firewalld
+  - libvirt-daemon-kvm
   - libvirt-daemon-config-network
   - targetcli
 test: ./browser.sh


### PR DESCRIPTION
Yesterday I [could still reproduce this](https://github.com/cockpit-project/cockpit-machines/pull/621#issuecomment-1066732646) on an upgraded F36 → 37 VM, but not today any more. It still seems to happen on the TF though, let's do a few debug runs. I still can't run F36/F37 in tmt locally.