### PR TITLE
Make Arch Linux package build offline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,14 +152,9 @@ rpm: $(TARFILE) $(SPEC)
 	rm -r "`pwd`/rpmbuild"
 	rm -r "`pwd`/output" "`pwd`/build"
 
-# rpms/debs can be built offline; arch can't yet
-ifeq ($(filter arch,$(TEST_OS)),)
-NETWORK=--no-network
-endif
-
 # build a VM with locally built distro pkgs installed
 $(VM_IMAGE): $(TARFILE) packaging/debian/rules packaging/debian/control packaging/arch/PKGBUILD bots
-	bots/image-customize --verbose $(NETWORK) --fresh --build $(TARFILE) --script $(CURDIR)/test/vm.install $(TEST_OS)
+	bots/image-customize --verbose --no-network --fresh --build $(TARFILE) --script $(CURDIR)/test/vm.install $(TEST_OS)
 
 # convenience target for the above
 vm: $(VM_IMAGE)

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -35,7 +35,7 @@ from testlib import nondestructive, wait, test_main  # noqa
 # virt-install changed the default to "host-passthrough"
 # https://github.com/virt-manager/virt-manager/commit/2c477f330244e04614e174f50fbf37260c535705
 distrosWithDefaultHostModel = ["fedora-34", "fedora-35", "rhel-8-4", "rhel-8-5", "rhel-8-6", "rhel-9-0",
-                               "ubuntu-stable", "ubuntu-2004", "debian-stable", "centos-8-stream", "arch"]
+                               "ubuntu-stable", "ubuntu-2004", "debian-stable", "centos-8-stream"]
 
 
 @nondestructive


### PR DESCRIPTION
With a new Arch image, we can now build cockpit-machines offline.

 - Needs https://github.com/cockpit-project/bots/pull/3106