### PR TITLE
Debian-testing now uses cpu host-passthrough by default on qemu x86

### DIFF
--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -35,7 +35,7 @@ from testlib import nondestructive, wait, test_main  # noqa
 # virt-install changed the default to "host-passthrough"
 # https://github.com/virt-manager/virt-manager/commit/2c477f330244e04614e174f50fbf37260c535705
 distrosWithDefaultHostModel = ["fedora-34", "fedora-35", "rhel-8-4", "rhel-8-5", "rhel-8-6", "rhel-9-0",
-                               "ubuntu-stable", "ubuntu-2004", "debian-testing", "debian-stable", "centos-8-stream", "arch"]
+                               "ubuntu-stable", "ubuntu-2004", "debian-stable", "centos-8-stream", "arch"]
 
 
 @nondestructive

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -406,6 +406,7 @@ class TestMachinesSettings(VirtualMachinesCase):
 
         # Change vCPUs setting
         b.click("#vm-subVmTest1-vcpus-count button")  # Open dialog
+        b.wait_visible("#machines-vcpu-modal-dialog")
         b.set_input_text("#machines-vcpu-max-field", "3")  # Change values
         b.set_input_text("#machines-vcpu-count-field", "3")
         b.click("#machines-vcpu-modal-dialog-apply")  # Save


### PR DESCRIPTION
Should fix 2 failures at debian-testing image-refresh: https://github.com/cockpit-project/bots/pull/3108