### PR TITLE
test: Don't insist on alert when cancelling install, fix testCreatePXE race

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1352,14 +1352,11 @@ class TestMachinesCreate(VirtualMachinesCase):
             self.machine.execute("until test -z $(ls /home/admin/.local/share/libvirt/images/ 2>/dev/null); do sleep 1; done")
 
             # When we delete a VM while virt-install is running there will be an error
-            if dialog and dialog.start_vm and dialog.sourceType in ["url", "os"]:
-                b.wait_visible(".pf-c-alert-group")
-
             alerts = self.browser.call_js_func("ph_count", ".pf-c-alert-group li")
             for i in range(alerts):
                 b.click(".pf-c-alert-group li:first-of-type .pf-c-alert button.pf-m-plain")
 
-            b.wait_not_present(".pf-c-alert-group li .pf-c-alert")
+            b.wait_not_present(".pf-c-alert-group")
 
             return self
 

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -331,6 +331,9 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                       storage_size=128, storage_size_unit='MiB',
                                                       start_vm=True,
                                                       delete=False))
+        # Wait for virt-install to define the VM and then stop it
+        wait(lambda: "pxe-guest" in self.machine.execute("virsh list --persistent"), delay=3)
+        b.wait_in_text("#vm-pxe-guest-state", "Running")
         self.machine.execute("virsh destroy pxe-guest")
 
         # Verify that the newly created disk is first in the boot order and the network used for the PXE boot is not on the bootable devices list

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -35,7 +35,7 @@ class TestMachinesNICs(VirtualMachinesCase):
     def setUp(self):
         super().setUp()
         # querying object manager often runs into that on network changes; irrelevant
-        self.allow_journal_messages("org.freedesktop.NetworkManager: couldn't get managed objects at org/freedesktop: Timeout was reached")
+        self.allow_journal_messages("org.freedesktop.NetworkManager: couldn't get managed objects at /org/freedesktop: Timeout was reached")
 
     def deleteIface(self, iface):
         b = self.browser


### PR DESCRIPTION
In some cases, such as testCreateUrlSource's "ISO file in URL" scenario,
virt-install exits cleanly instead of staying around indefinitely and
then getting killed when stopping the VM. In that case there is no
"failed" alert. The condition was already quite subtle, and it's not
clear how to refine it in a robust way.

We also don't assert anything about it other than clicking all of them
away. So just drop it.

---

This fixes our #3 flake `TestMachinesCreate.testCreateUrlSource`, [example](https://logs.cockpit-project.org/logs/pull-626-20220321-153917-c3ef1e58-ubuntu-stable/log.html), [example](https://logs.cockpit-project.org/logs/pull-628-20220318-140634-5b0dfc7a-centos-8-stream/log.html)

It reproduces locally perfectly well. However, @skobyda , I'm not entirely sure about that -- if you have an idea how to refine that condition, or make this more predictable, I'm all ears.