### PR TITLE
test: Fix TestMachinesCreate.testCreate{PXE,AndVerifyQemuConf}

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1352,14 +1352,11 @@ class TestMachinesCreate(VirtualMachinesCase):
             self.machine.execute("until test -z $(ls /home/admin/.local/share/libvirt/images/ 2>/dev/null); do sleep 1; done")
 
             # When we delete a VM while virt-install is running there will be an error
-            if dialog and dialog.start_vm and dialog.sourceType in ["url", "os"]:
-                b.wait_visible(".pf-c-alert-group")
-
             alerts = self.browser.call_js_func("ph_count", ".pf-c-alert-group li")
             for i in range(alerts):
                 b.click(".pf-c-alert-group li:first-of-type .pf-c-alert button.pf-m-plain")
 
-            b.wait_not_present(".pf-c-alert-group li .pf-c-alert")
+            b.wait_not_present(".pf-c-alert-group")
 
             return self
 

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -349,13 +349,17 @@ class TestMachinesCreate(VirtualMachinesCase):
         config = TestMachinesCreate.TestCreateConfig
         m = self.machine
 
+        self.restore_file("/etc/libvirt/qemu.conf")
+
         self.login_and_go("/machines")
         self.browser.wait_in_text("body", "Virtual machines")
 
         vnc_listen = "192.168.2.6"
-        m.execute(f"echo 'vnc_listen = \"{vnc_listen}\"' >> /etc/libvirt/qemu.conf")
         vnc_passwd = "mypass"
-        m.execute(f"echo 'vnc_password= \"{vnc_passwd}\"' >> /etc/libvirt/qemu.conf")
+
+        m.write("/etc/libvirt/qemu.conf", f'''vnc_listen = "{vnc_listen}"
+vnc_password= "{vnc_passwd}"
+''', append=True)
 
         runner.createAndVerifyQemuConfParsedTest(
             TestMachinesCreate.VmDialog(self, sourceType='file',
@@ -364,7 +368,6 @@ class TestMachinesCreate(VirtualMachinesCase):
             vnc_listen, "127.0.0.1", vnc_passwd, None)
 
         # Ensure that missing qemu.conf would not crash the script but just pick the 127.0.0.1 default value
-        self.restore_file("/etc/libvirt/qemu.conf")
         m.execute("rm /etc/libvirt/qemu.conf")
         runner.createAndVerifyQemuConfParsedTest(
             TestMachinesCreate.VmDialog(self, sourceType='file',

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -857,6 +857,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         def createRespectQemuConfConsoleConfig(self, vnc_listen, spice_listen, vnc_passwd, spice_passwd):
             self.browser.click(".pf-c-modal-box__footer button:contains(Create)")
             self.browser.wait_not_present("#create-vm-dialog")
+            self.browser.wait_text(f"#vm-{self.name}-state", "Shut off")
 
             domainXML = self.machine.execute(f"virsh dumpxml --security-info {self.name}")
             root = ET.fromstring(domainXML)

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -313,7 +313,8 @@ class TestMachinesCreate(VirtualMachinesCase):
         # Redefine the domain with the new XML
         xmlstr = ET.tostring(root, encoding='unicode', method='xml')
 
-        self.machine.execute(f"echo '{xmlstr}' > /tmp/domain.xml && virsh define --file /tmp/domain.xml")
+        self.write_file("/tmp/domain.xml", xmlstr)
+        self.machine.execute("virsh define --file /tmp/domain.xml")
 
         self.machine.execute("virsh start pxe-guest")
 

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -331,6 +331,9 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                       storage_size=128, storage_size_unit='MiB',
                                                       start_vm=True,
                                                       delete=False))
+        # Wait for virt-install to define the VM and then stop it
+        wait(lambda: "pxe-guest" in self.machine.execute("virsh list --persistent"), delay=3)
+        b.wait_in_text("#vm-pxe-guest-state", "Running")
         self.machine.execute("virsh destroy pxe-guest")
 
         # Verify that the newly created disk is first in the boot order and the network used for the PXE boot is not on the bootable devices list

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -275,9 +275,12 @@ class TestMachinesCreate(VirtualMachinesCase):
         # We don't want to use start_vm == False because if we get a separate install phase
         # virt-install will overwrite our changes.
 
-        # Wait for virt-install to define the VM and then stop it
-        wait(lambda: "pxe-guest" in self.machine.execute("virsh list --persistent"), delay=3)
+        # Wait for virt-install to define the VM, stop it, and wait for virt-install to be done
+        wait(lambda: "pxe-guest" in self.machine.execute("virsh list --name --persistent"), delay=3)
+        wait(lambda: "pxe-guest" in self.machine.execute("virsh list --name"), delay=3)
         self.machine.execute("virsh destroy pxe-guest")
+        self.machine.execute("while pgrep virt-install; do sleep 1; done")
+        self.assertEqual(self.machine.execute("virsh list --name").strip(), "")
 
         # Remove all serial ports and consoles first and then add a console of type file
         # virt-xml tool does not allow to remove both serial and console devices at once

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -35,7 +35,7 @@ class TestMachinesNICs(VirtualMachinesCase):
     def setUp(self):
         super().setUp()
         # querying object manager often runs into that on network changes; irrelevant
-        self.allow_journal_messages("org.freedesktop.NetworkManager: couldn't get managed objects at org/freedesktop: Timeout was reached")
+        self.allow_journal_messages("org.freedesktop.NetworkManager: couldn't get managed objects at /org/freedesktop: Timeout was reached")
 
     def deleteIface(self, iface):
         b = self.browser


### PR DESCRIPTION
Destroying pxe-guest does not immediatel stop virt-install. Instead,
this interferes with our redefinition and restarting of the domain, so
that sometimes either failed. This resulted in the domain sometimes not
actually having the /tmp/serial.txt console, or already running when
the test tried to start it.

----

This fails [very](https://logs.cockpit-project.org/logs/pull-631-20220322-175241-f9703f15-arch/log.html#65-1) [often](https://logs.cockpit-project.org/logs/pull-630-20220322-131300-6b7ecc3e-fedora-36/log.html#13) like this:
```
sed: can't read /tmp/serial.txt: No such file or directory
Traceback (most recent call last):
  File "/usr/lib64/python3.10/unittest/case.py", line 549, in _callTestMethod
    method()
  File "/work/bots/make-checkout-workdir/test/check-machines-create", line 321, in testCreatePXE
    wait(lambda: self.machine.execute(r"sed 's,\x1B\[[0-9;]*[a-zA-Z],,g' /tmp/serial.txt | grep 'Rebooting in 60'"), delay=3)
  File "/work/bots/make-checkout-workdir/test/common/testlib.py", line 2131, in wait
    val = func()
  File "/work/bots/make-checkout-workdir/test/check-machines-create", line 321, in <lambda>
    wait(lambda: self.machine.execute(r"sed 's,\x1B\[[0-9;]*[a-zA-Z],,g' /tmp/serial.txt | grep 'Rebooting in 60'"), delay=3)
  File "/work/bots/make-checkout-workdir/bots/machine/machine_core/ssh_connection.py", line 368, in execute
    raise subprocess.CalledProcessError(proc.returncode, command, output=output)
subprocess.CalledProcessError: Command 'sed 's,\x1B\[[0-9;]*[a-zA-Z],,g' /tmp/serial.txt | grep 'Rebooting in 60'' returned non-zero exit status 1.
```

i.e. /tmp/serial.txt never gets created. There seems to be a race condition when defining the VM, as the VNC console in the [screenshot](https://logs.cockpit-project.org/logs/pull-631-20220322-175241-f9703f15-arch/TestMachinesCreate-testCreatePXE-arch-127.0.0.2-2401-FAIL.png)  shows the successful PXE boot just fine.

I can't reproduce this locally, so debugging on the infra.

 - Builds on top of PR #631 