### PR TITLE
fmf: Trim tests to only exercise external APIs and be faster

### DIFF
--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -17,4 +17,4 @@ require:
   - libvirt-daemon-config-network
   - targetcli
 test: ./browser.sh
-duration: 2h
+duration: 50m

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -44,9 +44,42 @@ if [ "$ID" = "rhel" ]; then
     "
 fi
 
-if [ "$TEST_OS" = "centos-8-stream" ]; then
-    EXCLUDES="$EXCLUDES TestMachinesConsoles.testExternalConsole"
-fi
+# We only have one VM and tests should take at most one hour. So run those tests which exercise external API
+# (and thus are useful for reverse dependency testing and gating), and exclude those which test internal
+# functionality -- upstream CI covers that.
+EXCLUDES="$EXCLUDES
+          TestMachinesCreate.testConfigureBeforeInstall
+          TestMachinesCreate.testCreateBasicValidation
+          TestMachinesCreate.testDisabledCreate
+
+          TestMachinesConsoles.testExternalConsole
+          TestMachinesConsoles.testInlineConsole
+          TestMachinesConsoles.testInlineConsoleWithUrlRoot
+          TestMachinesConsoles.testSerialConsole
+          TestMachinesConsoles.testSwitchConsoleFromSerialToGraphical
+
+          TestMachinesDisks.testAddDiskAdditionalOptions
+          TestMachinesDisks.testAddDiskCustomPath
+          TestMachinesDisks.testDetachDisk
+          TestMachinesDisks.testDiskEdit
+
+          TestMachinesLifecycle.testBasicLibvirtUserUnprivileged
+          TestMachinesLifecycle.testBasicWheelUserUnprivileged
+          TestMachinesLifecycle.testDelete
+          TestMachinesLifecycle.testLibvirt
+
+          TestMachinesHostDevs.testHostDevAddMultipleDevices
+
+          TestMachinesMigration.testFailMigrationUriIncorrect
+          TestMachinesMigration.testFailMigrationDomainUnknown
+
+          TestMachinesNetworks.testNetworkSettings
+          TestMachinesNetworks.testNICPlugingAndUnpluging
+
+          TestMachinesNICs.NICAddDialog
+
+          TestMachinesSettings.testMultipleSettings
+          "
 
 if [ "$ID" = "fedora" ]; then
     # Testing Farm machines are really slow in European evenings


### PR DESCRIPTION
packit tests currently take ~ 80 minutes (SRPM+RPM builds, plus the
actual tests over an hour), which is too long for our "result after max.
1 hour" goal. Many of them are also not that useful in downstream
gating, as they only exercise internal functionality -- it's enough to
do that in upstream CI where we have a lot more performance (due to
parallelization).

Exclude some tests which don't exercise external APIs, and are thus not
much useful for reverse dependency gating.

Lower the maximum test duration to 50 minutes, so that we will notice
when tests are piling up too much again. That leaves ten minutes for the
webpack+srpm+rpm builds.