### PR TITLE
test: Drop obsolete special cases, enable Ubuntu 22.04

### DIFF
--- a/test/check-machines-filesystems
+++ b/test/check-machines-filesystems
@@ -104,7 +104,7 @@ class TestMachinesFilesystems(VirtualMachinesCase):
         b.set_file_autocomplete_val("#vm-subVmTest1-filesystems-modal-source-group", "/tmp/dir1/")
         b.set_input_text("#vm-subVmTest1-filesystems-modal-mountTag", "dir1")
         b.click("#vm-subVmTest1-filesystems-modal-add")
-        if m.image not in ['fedora-34', 'debian-stable']:
+        if m.image not in ['debian-stable']:
             b.wait_in_text(".pf-c-alert", "Failed to add shared directory")
             b.wait_in_text(".pf-c-alert", "filesystem target 'dir1' specified twice")
             b.click("#vm-subVmTest1-filesystems-modal-cancel")

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -273,11 +273,8 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         self.addCleanup(m.execute, f"echo '{core_pattern}' > /proc/sys/kernel/core_pattern")
 
         def stopLibvirtSocket():
-            # newer libvirtd versions use socket activation
-            # we should test that separately, but here we test only using the service unit
-            if m.image not in ["rhel-8-4"]:
-                m.execute(f"systemctl stop {self.getLibvirtServiceName()}-ro.socket {self.getLibvirtServiceName()}.socket {self.getLibvirtServiceName()}-admin.socket")
-                self.addCleanup(m.execute, f"systemctl start {self.getLibvirtServiceName()}-ro.socket {self.getLibvirtServiceName()}.socket {self.getLibvirtServiceName()}-admin.socket")
+            m.execute(f"systemctl stop {self.getLibvirtServiceName()}-ro.socket {self.getLibvirtServiceName()}.socket {self.getLibvirtServiceName()}-admin.socket")
+            self.addCleanup(m.execute, f"systemctl start {self.getLibvirtServiceName()}-ro.socket {self.getLibvirtServiceName()}.socket {self.getLibvirtServiceName()}-admin.socket")
 
         def stopLibvirtService():
             m.execute(f"systemctl stop {libvirtServiceName}")

--- a/test/check-machines-migrate
+++ b/test/check-machines-migrate
@@ -90,14 +90,14 @@ class TestMachinesMigration(VirtualMachinesCase):
     def testSharedStorageMigration(self):
         self._testMigrationGeneric(False, False, None)
 
-    @skipImage('RHEL does not provide support for copy-storage migration', "rhel-8-4", "rhel-8-5", "rhel-8-6", "rhel-9-0", "centos-9-stream")
+    @skipImage('RHEL does not provide support for copy-storage migration', "rhel-8-6", "rhel-9-0", "centos-9-stream")
     def testCopyStorageMigration(self):
         self._testMigrationGeneric(True, False, None)
 
     def testMoveTemporarilyMigration(self):
         self._testMigrationGeneric(False, True, None)
 
-    @skipImage('RHEL does not provide support for copy-storage migration', "rhel-8-4", "rhel-8-5", "rhel-8-6", "rhel-9-0", "centos-9-stream")
+    @skipImage('RHEL does not provide support for copy-storage migration', "rhel-8-6", "rhel-9-0", "centos-9-stream")
     def testFailMigrationPoolNotFound(self):
         # Equivalent storage pool is not present on the destination
         self._testMigrationGeneric(True, False, "pool")
@@ -163,7 +163,7 @@ class TestMachinesMigration(VirtualMachinesCase):
 
         b.set_checked("#temporary", temporary)
 
-        if self.machine.image in ["rhel-8-4", "rhel-8-5", "rhel-8-6", "rhel-9-0", "centos-9-stream"]:
+        if self.machine.image in ["rhel-8-6", "rhel-9-0", "centos-9-stream"]:
             b.wait_not_present("#copy")
         else:
             if copy_storage:

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -34,8 +34,8 @@ from testlib import nondestructive, wait, test_main  # noqa
 
 # virt-install changed the default to "host-passthrough"
 # https://github.com/virt-manager/virt-manager/commit/2c477f330244e04614e174f50fbf37260c535705
-distrosWithDefaultHostModel = ["fedora-34", "fedora-35", "rhel-8-4", "rhel-8-5", "rhel-8-6", "rhel-9-0",
-                               "ubuntu-stable", "ubuntu-2004", "debian-stable", "centos-8-stream"]
+distrosWithDefaultHostModel = ["fedora-35", "rhel-8-6", "rhel-9-0", "centos-8-stream",
+                               "ubuntu-stable", "debian-stable"]
 
 
 @nondestructive

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -19,7 +19,7 @@ from testlib import MachineCase
 from netlib import NetworkHelpers
 from storagelib import StorageHelpers
 
-distrosWithMonolithicDaemon = ["fedora-34", "rhel-8-6", "ubuntu-stable", "debian-testing", "debian-stable", "centos-8-stream", "arch"]
+distrosWithMonolithicDaemon = ["rhel-8-6", "ubuntu-stable", "debian-testing", "debian-stable", "centos-8-stream", "arch"]
 
 
 class VirtualMachinesCaseHelpers:

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -19,7 +19,7 @@ from testlib import MachineCase
 from netlib import NetworkHelpers
 from storagelib import StorageHelpers
 
-distrosWithMonolithicDaemon = ["rhel-8-6", "ubuntu-stable", "debian-testing", "debian-stable", "centos-8-stream", "arch"]
+distrosWithMonolithicDaemon = ["rhel-8-6", "ubuntu-stable", "ubuntu-2204", "debian-testing", "debian-stable", "centos-8-stream", "arch"]
 
 
 class VirtualMachinesCaseHelpers:

--- a/test/vm.install
+++ b/test/vm.install
@@ -15,3 +15,8 @@ printf "[WebService]\\nAllowUnencrypted=true\\n" > /etc/cockpit/cockpit.conf
 if type firewall-cmd >/dev/null 2>&1; then
     firewall-cmd --add-service=cockpit --permanent
 fi
+
+# HACK: libvirtdbus permissions regressed in jammy: https://launchpad.net/bugs/1802005
+if grep -q 'UBUNTU_CODENAME=jammy' /usr/lib/os-release; then
+    adduser libvirtdbus libvirt
+fi


### PR DESCRIPTION
We don't release to Fedora 34, Ubuntu 20.04, RHEL 8.4/8.5 any more.

Commit 0e5507720e already cleaned up a lot of these, but was missing
some spots.

----

This is an initial PR to get a place to run and fix ubuntu-2204.