### PR TITLE
Test improvements, fix testCreateThenInstall flake

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1335,12 +1335,21 @@ vnc_password= "{vnc_passwd}"
             return self
 
         def _assertDomainDefined(self, name, connection):
-            dumpxmlCmd = f"virsh -c qemu:///system dumpxml --inactive {name}"
-
-            wait(lambda: "7" in self.run_admin(dumpxmlCmd + " | grep cockpit_machines | wc -l", connection))
-            # The running XML has always substituted port
-            # This checks that the defined domain is using the proper inactive XML
-            wait(lambda: self.run_admin(dumpxmlCmd + " | grep \"type='vnc' port='-1'\"", connection))
+            for retry in range(5):
+                dumpxml = self.run_admin(f"virsh -c qemu:///system dumpxml --inactive {name}", connection)
+                try:
+                    # has cockpit-machines specific metadata
+                    self.test_obj.assertIn("<cockpit_machines:has_install_phase>", dumpxml)
+                    self.test_obj.assertIn("<cockpit_machines:install_source>", dumpxml)
+                    # The running XML has always substituted port
+                    # This checks that the defined domain is using the proper inactive XML
+                    self.test_obj.assertIn("type='vnc' port='-1'", dumpxml)
+                    break
+                except AssertionError as e:
+                    fail = e
+                    time.sleep(2)
+            else:
+                raise fail
 
             return self
 

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-import functools
-import subprocess
 import time
 import xml.etree.ElementTree as ET
 import os
@@ -279,7 +277,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         wait(lambda: "pxe-guest" in self.machine.execute("virsh list --name --persistent"), delay=3)
         wait(lambda: "pxe-guest" in self.machine.execute("virsh list --name"), delay=3)
         self.machine.execute("virsh destroy pxe-guest")
-        self.machine.execute("while pgrep virt-install; do sleep 1; done")
+        runner._assertScriptFinished()
         self.assertEqual(self.machine.execute("virsh list --name").strip(), "")
 
         # Remove all serial ports and consoles first and then add a console of type file
@@ -1279,13 +1277,6 @@ vnc_password= "{vnc_passwd}"
             self.test_obj.waitVmRow(dialog.name, "system", False)
             return self
 
-        def _commandNotRunning(self, command):
-            try:
-                self.machine.execute(f"pgrep -c {command}")
-                return False
-            except subprocess.CalledProcessError as e:
-                return hasattr(e, 'returncode') and e.returncode == 1
-
         def _assertCorrectConfiguration(self, dialog):
             b = self.browser
             name = dialog.name
@@ -1340,9 +1331,7 @@ vnc_password= "{vnc_passwd}"
             return self
 
         def _assertScriptFinished(self):
-            with self.browser.wait_timeout(20):
-                self.browser.wait(functools.partial(self._commandNotRunning, "virt-install"))
-
+            self.machine.execute("while pgrep virt-install; do sleep 1; done", timeout=20)
             return self
 
         def _assertDomainDefined(self, name, connection):

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1261,8 +1261,7 @@ vnc_password= "{vnc_passwd}"
 
                 # unfinished install script runs indefinitely, so we need to force it off
                 self.test_obj.performAction(name, "forceOff", False)
-                # https://bugzilla.redhat.com/show_bug.cgi?id=1818089
-                # After shutting it off virt-install will restart the domain and exit because of the above bug
+                b.wait_in_text(f"#vm-{name}-state", "Shut off")
 
             return self
 


### PR DESCRIPTION
I'm trying to debug https://artifacts.dev.testing-farm.io/19531be9-b707-4fec-8b9b-b4795df9fe0b/ , but the test fails in a mostly useless way. Supposedly the domain XML does not have any metadata, but it could also have a different count. Let's make this more useful in the future.

This also fixes this different [testCreateThenInstall failure](https://artifacts.dev.testing-farm.io/237d681f-3da2-4c04-85d6-d95f597efa93/).