### PR TITLE
Work around virt-install mis-detecting SPICE graphics support

### DIFF
--- a/src/scripts/install_machine.py
+++ b/src/scripts/install_machine.py
@@ -39,6 +39,21 @@ def get_graphics_capabilies(connection):
         for value in graphics.find('enum').findall('value'):
             consoles.append(value.text)
 
+    # HACK: spice requires QXL driver which is modular in Fedora https://bugzilla.redhat.com/show_bug.cgi?id=2064594
+    if 'spice' in consoles:
+        try:
+            out = subprocess.check_output(['qemu-system-x86_64', '-vga', 'help'])
+            for line in out.splitlines():
+                if line.startswith(b'qxl'):
+                    logging.debug('get_graphics_capabilies: qemu-system-x86_84 -vga help confirmed QXL support')
+                    break
+            else:
+                logging.debug('get_graphics_capabilies: qemu-system-x86_84 -vga help shows no QXL support, disabling spice')
+                consoles.remove('spice')
+        except (FileNotFoundError, subprocess.CalledProcessError) as e:
+            # non-x86 architectures/weird setups
+            logging.debug('get_graphics_capabilies: Querying qemu-system-x86_84 -vga help failed: %s', str(e))
+
     logging.debug('get_graphics_capabilies: ' + ', '.join(consoles))
 
     return [c for c in consoles if c in ['vnc', 'spice']]

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -545,8 +545,14 @@ vnc_password= "{vnc_passwd}"
                                                       start_vm=True))
 
     def testCreateUrlSource(self):
+        m = self.machine
         runner = TestMachinesCreate.CreateVmRunner(self)
         config = TestMachinesCreate.TestCreateConfig
+
+        # disable QXL driver for Fedora, which builds this as a module -- should work and not add a spice console then
+        if 'fedora' in m.image:
+            m.execute("mount -o bind /dev/null /usr/lib64/qemu/hw-display-qxl.so")
+            self.addCleanup(m.execute, "umount /usr/lib64/qemu/hw-display-qxl.so")
 
         self.login_and_go("/machines")
         self.browser.wait_in_text("body", "Virtual machines")
@@ -566,7 +572,7 @@ vnc_password= "{vnc_passwd}"
         runner.checkDialogFormValidationTest(TestMachinesCreate.VmDialog(self, "existing-name", storage_size=1,
                                                                          env_is_empty=False), {"vm-name": "already exists"})
 
-        self.machine.execute("virsh undefine existing-name")
+        m.execute("virsh undefine existing-name")
 
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='url',
                                                       location=config.TREE_URL,
@@ -596,9 +602,9 @@ vnc_password= "{vnc_passwd}"
 
         # This functionality works on debian only because of extra qemu-block-extra dep.
         # Check error is returned if dependency is missing
-        if self.machine.image.startswith("debian"):
-            self.machine.execute("mount -o bind /dev/null /usr/lib/x86_64-linux-gnu/qemu/block-curl.so")
-            self.addCleanup(self.machine.execute, "umount /usr/lib/x86_64-linux-gnu/qemu/block-curl.so")
+        if m.image.startswith("debian"):
+            m.execute("mount -o bind /dev/null /usr/lib/x86_64-linux-gnu/qemu/block-curl.so")
+            self.addCleanup(m.execute, "umount /usr/lib/x86_64-linux-gnu/qemu/block-curl.so")
             runner.checkDialogErrorTest(TestMachinesCreate.VmDialog(self, sourceType='url',
                                                                     location=config.ISO_URL,
                                                                     memory_size=128, memory_size_unit='MiB',


### PR DESCRIPTION
Currently, spice graphics support requires QXL graphics, mostly
accidentally [1]. When uninstalling the qemu-device-display-qxl package,
`virsh domcapabilities` still includes "spice", but creating the domain
fails with:

    unsupported configuration: domain configuration does not support video model 'qxl'

Work around that by explicitly asking QEMU whether it supports QXL, and
disable spice if not. Only check qemu-system-x86_84, and ignore other
architectures for the time being. Spice is being deprecated anyway.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2064594