### PR TITLE
test: add cockpit 266 memory format compatibility

### DIFF
--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -346,6 +346,9 @@ class TestMachinesSettings(VirtualMachinesCase):
         b.wait_attr("#vm-subVmTest1-memory-modal-max-memory-slider  div[role=slider]", "aria-valuemin", "128")
 
         # VM initially should have 256MiB
+        def mib_to_mb(memory):
+            return round(memory * (1024 * 1024)/1000/1000)
+
         current_memory = int(b.attr("#vm-subVmTest1-memory-modal-memory", "value"))
         self.assertEqual(current_memory, 256)
         b.wait_attr("#vm-subVmTest1-memory-modal-max-memory", "disabled", "")
@@ -360,11 +363,17 @@ class TestMachinesSettings(VirtualMachinesCase):
         b.click("#vm-subVmTest1-memory-modal-save")
         b.wait_not_present("#vm-memory-modal")
 
-        b.wait_in_text("#vm-subVmTest1-memory-count", f"{current_memory - 10} MiB")
+        if self.system_before(266):
+            b.wait_in_text("#vm-subVmTest1-memory-count", f"{current_memory - 10} MiB")
+        else:
+            b.wait_in_text("#vm-subVmTest1-memory-count", f"{mib_to_mb(current_memory - 10)} MB")
 
         # Shut off domain and check changes are  still there
         self.performAction("subVmTest1", "forceOff")
-        b.wait_in_text("#vm-subVmTest1-memory-count", f"{current_memory - 10} MiB")
+        if self.system_before(266):
+            b.wait_in_text("#vm-subVmTest1-memory-count", f"{current_memory - 10} MiB")
+        else:
+            b.wait_in_text("#vm-subVmTest1-memory-count", f"{mib_to_mb(current_memory - 10)} MB")
 
         # Click for the edit link
         b.click("#vm-subVmTest1-memory-count button")


### PR DESCRIPTION
This fixes https://logs.cockpit-project.org/logs/pull-3166-20220331-085217-f6501668-arch-cockpit-project-cockpit-machines/log.html#65-2

In the recent arch refresh https://github.com/cockpit-project/bots/pull/3166