### PR TITLE
test: enable skipped Arch test

### DIFF
--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -97,7 +97,6 @@ class TestMachinesConsoles(VirtualMachinesCase):
     def testInlineConsoleWithUrlRoot(self, urlroot=""):
         self.testInlineConsole(urlroot="/webcon")
 
-    @skipImage('TODO: setlocale: No such file or directory', "arch")
     def testSerialConsole(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
C.UTF-8 is now available on Arch Linux with the new glibc 2.53.