### PR TITLE
fmf: Run tests without QEMU QXL support

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -24,12 +24,6 @@ $DNF --setopt=install_weak_deps=False firefox
 # RHEL/CentOS 8 and Fedora have this, but not RHEL 9; tests check this more precisely
 $DNF libvirt-daemon-driver-storage-iscsi-direct || true
 
-# FIXME: tests currently require spice QXL support; fix them to get along without
-# Fedora has split packages (much smaller footprint), RHEL doesn't
-if grep -q 'ID=fedora' /usr/lib/os-release; then
-    $DNF qemu-device-display-qxl qemu-char-spice
-fi
-
 #HACK: unbreak rhel-9-0's default choice of 999999999 rounds, see https://bugzilla.redhat.com/show_bug.cgi?id=1993919
 sed -ie 's/#SHA_CRYPT_MAX_ROUNDS 5000/SHA_CRYPT_MAX_ROUNDS 5000/' /etc/login.defs
 

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -549,11 +549,6 @@ vnc_password= "{vnc_passwd}"
         runner = TestMachinesCreate.CreateVmRunner(self)
         config = TestMachinesCreate.TestCreateConfig
 
-        # disable QXL driver for Fedora, which builds this as a module -- should work and not add a spice console then
-        if 'fedora' in m.image:
-            m.execute("mount -o bind /dev/null /usr/lib64/qemu/hw-display-qxl.so")
-            self.addCleanup(m.execute, "umount /usr/lib64/qemu/hw-display-qxl.so")
-
         self.login_and_go("/machines")
         self.browser.wait_in_text("body", "Virtual machines")
 

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -862,17 +862,27 @@ vnc_password= "{vnc_passwd}"
             self.assertIn(f"backing file: {self.location}", self.machine.execute(f"qemu-img info /var/lib/libvirt/images/{self.name}.qcow2"))
 
         def createRespectQemuConfConsoleConfig(self, vnc_listen, spice_listen, vnc_passwd, spice_passwd):
+            m = self.machine
+
             self.browser.click(".pf-c-modal-box__footer button:contains(Create)")
             self.browser.wait_not_present("#create-vm-dialog")
             self.browser.wait_text(f"#vm-{self.name}-state", "Shut off")
 
-            domainXML = self.machine.execute(f"virsh dumpxml --security-info {self.name}")
+            domainXML = m.execute(f"virsh dumpxml --security-info {self.name}")
             root = ET.fromstring(domainXML)
 
-            if self.machine.image not in ["rhel-9-0", "centos-9-stream"]:
-                spice = root.findall(".//graphics[@type='spice']")[0]
-                self.assertEqual(spice_listen, spice.attrib['listen'])
-                self.assertEqual(spice_passwd, spice.attrib.get('passwd', None))
+            expect_spice = m.image not in ["rhel-9-0", "centos-9-stream"]
+            if m.image.startswith("fedora"):
+                # HACK: Fedora splits out the driver into a separate package, which we don't depend on
+                # spice currently requires this, but shouldn't: https://bugzilla.redhat.com/show_bug.cgi?id=2064594
+                expect_spice = m.execute("if rpm -q qemu-device-display-qxl >/dev/null; then echo yes; fi").strip() == "yes"
+
+            spice = root.findall(".//graphics[@type='spice']")
+            if expect_spice:
+                self.assertEqual(spice_listen, spice[0].attrib['listen'])
+                self.assertEqual(spice_passwd, spice[0].attrib.get('passwd', None))
+            else:
+                self.assertEqual(spice, [])
 
             vnc = root.findall(".//graphics[@type='vnc']")[0]
             self.assertEqual(vnc_listen, vnc.attrib['listen'])


### PR DESCRIPTION
We recently dropped the QXL dependency from our package, as it is so
expensive (see commit 1edd79909eb). Start testing without that in FMF.

Drop the QXL disabling hack from testCreateUrlSource(), we don't need
this any more -- all tests (including that one) now run without QXL in
FMF.

 - Builds on top of PR #622