### PR TITLE
test: Manually enable virtstoraged.socket on Fedora 35, add missing QEMU dependencies

### DIFF
--- a/packaging/cockpit-machines.spec.in
+++ b/packaging/cockpit-machines.spec.in
@@ -48,6 +48,8 @@ Requires: qemu-kvm
 # smaller footprint on Fedora, as qemu-kvm is really expensive on a server
 Requires: qemu-kvm-core
 Recommends: qemu-block-curl
+Recommends: qemu-char-spice
+Recommends: qemu-device-usb-host
 Recommends: qemu-device-usb-redirect
 %endif
 %endif

--- a/test/vm.install
+++ b/test/vm.install
@@ -20,3 +20,8 @@ fi
 if grep -q 'UBUNTU_CODENAME=jammy' /usr/lib/os-release; then
     adduser libvirtdbus libvirt
 fi
+
+# HACK: libvirt-daemon-driver-storage-core is missing unit enablement script: https://bugzilla.redhat.com/show_bug.cgi?id=2025644
+if grep -q 'PLATFORM_ID="platform:f35"' /usr/lib/os-release; then
+    systemctl enable virtstoraged.socket
+fi


### PR DESCRIPTION
This works around a packaging bug when only
libvirt-daemon-driver-storage-core is installed, but not the
libvirt-daemon-driver-storage metapackage (as we try to do in [1]).

https://bugzilla.redhat.com/show_bug.cgi?id=2025644

[1] https://github.com/cockpit-project/bots/pull/3227