### PR TITLE
workflows: Split npm-update to PF and non PF tasks

### DIFF
--- a/.github/workflows/npm-update-pf.yml
+++ b/.github/workflows/npm-update-pf.yml
@@ -1,7 +1,7 @@
-name: npm-update
+name: npm-update-pf
 on:
   schedule:
-    - cron: '0 2 * * 2,4,6'
+    - cron: '0 2 * * 1'
   # can be run manually on https://github.com/cockpit-project/cockpit-machines/actions
   workflow_dispatch:
 jobs:
@@ -29,4 +29,4 @@ jobs:
       - name: Run npm-update bot
         run: |
           make bots
-          bots/npm-update ~@patternfly
+          bots/npm-update @patternfly


### PR DESCRIPTION
Run PF update every Monday and anything else try to update on Tue, Thu and Sat.