### PR TITLE
cockpit transclusion simplification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,30 +1,32 @@
+# Please keep this file sorted (LC_COLLATE=C.UTF-8),
+# grouped into the 3 categories below:
+#  - general patterns (match in all directories)
+#  - patterns to match files at the toplevel
+#  - patterns to match files in subdirs
+
+# general patterns
 *.pyc
 *.rpm
-*.tar.xz
-bots
-dist/
-lib/
-test/common/
-cockpit-machines.spec
-node_modules/
-package-lock.json
-packaging/arch/PKGBUILD
-packaging/debian/changelog
-test/images/
-tools/
-tmp/
 
-# Configuration directory of IDE and editor
-.vscode
-.idea
+# toplevel (/...)
+/Test*.html
+/Test*.json
+/Test*.log
+/Test*.png
+/bots
+/cockpit-*.tar.xz
+/cockpit-machines.spec
+/dist/
+/node_modules/
+/package-lock.json
+/pkg/
+/tmp/
+/tools/
 
-# Test output
-Test*.log
-cockpit-*.tar*
-Test*.png
-Test*.html
-Test*.json
-
-# Translation temporary files
-*.pot
+# subdirs (/subdir/...)
+/packaging/arch/PKGBUILD
+/packaging/debian/changelog
+/po/*.pot
 /po/LINGUAS
+/test/common/
+/test/images/

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ package-lock.json
 packaging/arch/PKGBUILD
 packaging/debian/changelog
 test/images/
+tools/
 tmp/
 
 # Configuration directory of IDE and editor

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 NODE_MODULES_TEST=node_modules/.bin/webpack
 # one example file in dist/ from webpack to check if that already ran
 WEBPACK_TEST=dist/manifest.json
-# one example file in src/lib to check if it was already checked out
-LIB_TEST=src/lib/cockpit-po-plugin.js
+# one example file in pkg/lib to check if it was already checked out
+LIB_TEST=pkg/lib/cockpit-po-plugin.js
 
 WEBLATE_REPO=tmp/weblate-repo
 WEBLATE_REPO_URL=https://github.com/cockpit-project/cockpit-machines-weblate.git
@@ -127,7 +127,7 @@ $(TARFILE): export NODE_ENV=production
 $(TARFILE): $(WEBPACK_TEST) $(SPEC) packaging/arch/PKGBUILD packaging/debian/changelog
 	tar --xz -cf $(TARFILE) --transform 's,^,cockpit-$(PACKAGE_NAME)/,' \
 		--exclude '*.in' --exclude test/reference \
-		$$(git ls-files) src/lib/ package-lock.json $(SPEC) packaging/arch/PKGBUILD packaging/debian/changelog dist/
+		$$(git ls-files) pkg/lib/ package-lock.json $(SPEC) packaging/arch/PKGBUILD packaging/debian/changelog dist/
 
 $(NODE_CACHE): $(NODE_MODULES_TEST)
 	tar --xz -cf $@ node_modules

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ NODE_MODULES_TEST=node_modules/.bin/webpack
 # one example file in dist/ from webpack to check if that already ran
 WEBPACK_TEST=dist/manifest.json
 # one example file in pkg/lib to check if it was already checked out
-LIB_TEST=pkg/lib/cockpit-po-plugin.js
+COCKPIT_REPO_STAMP = pkg/lib/cockpit.js
 
 WEBLATE_REPO=tmp/weblate-repo
 WEBLATE_REPO_URL=https://github.com/cockpit-project/cockpit-machines-weblate.git
@@ -87,7 +87,7 @@ packaging/arch/PKGBUILD: packaging/arch/PKGBUILD.in
 packaging/debian/changelog: packaging/debian/changelog.in
 	sed 's/VERSION/$(VERSION)/' $< > $@
 
-$(WEBPACK_TEST): $(LIB_TEST) $(shell find src/ -type f) package.json webpack.config.js
+$(WEBPACK_TEST): $(COCKPIT_REPO_STAMP) $(shell find src/ -type f) package.json webpack.config.js
 	test/download-dist $${DOWNLOAD_DIST_OPTIONS:-} || \
 	    if [ -z "$$FORCE_DOWNLOAD_DIST" ]; then \
 		($(MAKE) $(NODE_MODULES_TEST) && NODE_ENV=$(NODE_ENV) node_modules/.bin/webpack); \
@@ -173,24 +173,8 @@ bots:
 	if [ -n "$$COCKPIT_BOTS_REF" ]; then git -C bots fetch --quiet --depth=1 origin "$$COCKPIT_BOTS_REF"; git -C bots checkout --quiet FETCH_HEAD; fi
 	@echo "checked out bots/ ref $$(git -C bots rev-parse HEAD)"
 
-# checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
-# when you start a new project, use the latest release, and update it from time to time
-test/common:
-	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 267; \
-	    git checkout --force FETCH_HEAD -- test/common; \
-	    git reset test/common'
-
 test/reference: test/common
 	test/common/pixel-tests pull
-
-# checkout Cockpit's PF/React/build library; again this has no API stability guarantee, so check out a stable tag
-$(LIB_TEST):
-	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 267; \
-	    git checkout --force FETCH_HEAD -- pkg/lib; \
-	    git reset -- pkg/lib'
-	mv pkg/lib src/ && rmdir -p pkg
 
 $(NODE_MODULES_TEST): package.json
 	# if it exists already, npm install won't update it; force that so that we always get up-to-date packages
@@ -200,3 +184,21 @@ $(NODE_MODULES_TEST): package.json
 	env -u NODE_ENV npm prune
 
 .PHONY: all clean install devel-install dist node-cache rpm check vm update-po
+
+# checkout common files from Cockpit repository required to build this project;
+# this has no API stability guarantee, so check out a stable tag when you start
+# a new project, use the latest release, and update it from time to time
+COCKPIT_REPO_FILES = \
+	pkg/lib \
+	test/common \
+	$(NULL)
+
+COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
+COCKPIT_REPO_COMMIT = 4f8ad7314676b375fcca5c98a543ef5078cc1af5 # 267
+
+$(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
+COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'
+$(COCKPIT_REPO_STAMP): Makefile
+	@git rev-list --quiet --objects $(COCKPIT_REPO_TREE) -- 2>/dev/null || \
+	    git fetch --no-tags --no-write-fetch-head --depth=1 $(COCKPIT_REPO_URL) $(COCKPIT_REPO_COMMIT)
+	git archive $(COCKPIT_REPO_TREE) -- tools/git-utils.sh $(COCKPIT_REPO_FILES) | tar x

--- a/Makefile
+++ b/Makefile
@@ -165,13 +165,8 @@ codecheck:
 check: $(NODE_MODULES_TEST) $(VM_IMAGE) test/common test/reference
 	test/common/run-tests ${RUN_TESTS_OPTIONS}
 
-# checkout Cockpit's bots for standard test VM images and API to launch them
-# must be from main, as only that has current and existing images; but testvm.py API is stable
-# support CI testing against a bots change
-bots:
-	git clone --quiet --reference-if-able $${XDG_CACHE_HOME:-$$HOME/.cache}/cockpit-project/bots https://github.com/cockpit-project/bots.git
-	if [ -n "$$COCKPIT_BOTS_REF" ]; then git -C bots fetch --quiet --depth=1 origin "$$COCKPIT_BOTS_REF"; git -C bots checkout --quiet FETCH_HEAD; fi
-	@echo "checked out bots/ ref $$(git -C bots rev-parse HEAD)"
+bots: tools/make-bots
+	tools/make-bots
 
 test/reference: test/common
 	test/common/pixel-tests pull
@@ -191,6 +186,8 @@ $(NODE_MODULES_TEST): package.json
 COCKPIT_REPO_FILES = \
 	pkg/lib \
 	test/common \
+	tools/git-utils.sh \
+	tools/make-bots \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git

--- a/packit.yaml
+++ b/packit.yaml
@@ -10,6 +10,7 @@ actions:
   post-upstream-clone: make cockpit-machines.spec
   create-archive:
     - make dist DOWNLOAD_DIST_OPTIONS=--wait FORCE_DOWNLOAD_DIST=1
+    - rm -f test/common/sizzle.js
     - find -name 'cockpit-machines-*.tar.xz'
 jobs:
   - job: tests

--- a/src/components/vm/hostdevs/hostDevAdd.scss
+++ b/src/components/vm/hostdevs/hostDevAdd.scss
@@ -1,4 +1,4 @@
-@import "../../../lib/_global-variables.scss";
+@import "_global-variables.scss";
 
 .pf-c-table.vm-device-table {
   /* Set overflow with a limiter on the list, so it scrolls instead of the dialog */

--- a/src/components/vm/vmDetailsPage.scss
+++ b/src/components/vm/vmDetailsPage.scss
@@ -1,4 +1,4 @@
-@import "../../lib/ct-card.scss";
+@import "ct-card.scss";
 
 .vm-details .pf-c-card {
     @extend .ct-card;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,8 +7,8 @@ const TerserJSPlugin = require('terser-webpack-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const CompressionPlugin = require("compression-webpack-plugin");
 const ESLintPlugin = require('eslint-webpack-plugin');
-const CockpitPoPlugin = require("./src/lib/cockpit-po-plugin");
-const CockpitRsyncPlugin = require("./src/lib/cockpit-rsync-plugin");
+const CockpitPoPlugin = require("./pkg/lib/cockpit-po-plugin");
+const CockpitRsyncPlugin = require("./pkg/lib/cockpit-rsync-plugin");
 
 // absolute path disables recursive module resolution, so build a relative one
 const nodedir = path.relative(process.cwd(), path.resolve((process.env.SRCDIR || __dirname), "node_modules"));
@@ -47,7 +47,7 @@ if (production) {
 module.exports = {
     mode: production ? 'production' : 'development',
     resolve: {
-        modules: [ nodedir, path.resolve(__dirname, 'src/lib') ],
+        modules: [ nodedir, path.resolve(__dirname, 'pkg/lib') ],
         alias: { 'font-awesome': path.resolve(nodedir, 'font-awesome-sass/assets/stylesheets') },
         // TODO: The following fallbacks are needed for ip module - replace this module with one better maintained
         fallback: {
@@ -57,7 +57,7 @@ module.exports = {
         }
     },
     resolveLoader: {
-        modules: [ nodedir, path.resolve(__dirname, 'src/lib') ],
+        modules: [ nodedir, path.resolve(__dirname, 'pkg/lib') ],
     },
     watchOptions: {
         ignored: /node_modules/,


### PR DESCRIPTION
Simplify and unify our support for including files from the [cockpit-project/cockpit](https://github.com/cockpit-project/cockpit) repository.

Use the increased flexibility to also import `tools/make-bots` and use it.

One drawback is that we now have to depend on a single version of the cockpit repository, and indeed this PR bumps our `pkg/lib` depend from `262` to `264-137-gd1a410cf9`.

 - [x] Land after PR #672
 - [x] Land after PR #673