### PR TITLE
Makefile: drop redundant git-utils.sh checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,4 +198,4 @@ COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'
 $(COCKPIT_REPO_STAMP): Makefile
 	@git rev-list --quiet --objects $(COCKPIT_REPO_TREE) -- 2>/dev/null || \
 	    git fetch --no-tags --no-write-fetch-head --depth=1 $(COCKPIT_REPO_URL) $(COCKPIT_REPO_COMMIT)
-	git archive $(COCKPIT_REPO_TREE) -- tools/git-utils.sh $(COCKPIT_REPO_FILES) | tar x
+	git archive $(COCKPIT_REPO_TREE) -- $(COCKPIT_REPO_FILES) | tar x


### PR DESCRIPTION
In a previous version of the commit which introduced this code, this
file was being used as a stamp, and thus excluded from the list.  That
was changed during the review process, causing the filename to be
duplicated.

Drop that.