### PR TITLE
Better handle delete resources modal messages

### DIFF
--- a/src/components/common/deleteResource.jsx
+++ b/src/components/common/deleteResource.jsx
@@ -49,7 +49,7 @@ export class DeleteResourceModal extends React.Component {
         this.props.deleteHandler()
                 .then(this.props.onClose, exc => {
                     this.setState({ inProgress: false });
-                    this.dialogErrorSet(cockpit.format(_("The $0 could not be deleted"), this.props.objectType.toLowerCase()), exc.message);
+                    this.dialogErrorSet(this.props.errorMessage, exc.message);
                 });
     }
 
@@ -58,12 +58,12 @@ export class DeleteResourceModal extends React.Component {
     }
 
     render() {
-        const { objectName, objectType, objectDescription, actionName, actionDescription, onClose } = this.props;
+        const { title, objectDescription, actionName, actionDescription, onClose } = this.props;
 
         return (
             <Modal position="top" variant="small" isOpen onClose={onClose}
                    id="delete-resource-modal"
-                   title={ (actionName || _("Delete")) + cockpit.format((" $0 $1"), objectType, objectName) }
+                   title={title}
                    footer={
                        <>
                            {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
@@ -90,8 +90,8 @@ export class DeleteResourceModal extends React.Component {
 }
 
 DeleteResourceModal.propTypes = {
-    objectType: PropTypes.string.isRequired,
-    objectName: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    errorMessage: PropTypes.string.isRequired,
     objectDescription: PropTypes.array,
     deleteHandler: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,

--- a/src/components/networks/network.jsx
+++ b/src/components/networks/network.jsx
@@ -53,7 +53,7 @@ export const getNetworkRow = ({ network, onAddErrorNotification }) => {
             { rephraseUI('networkForward', network.forward ? network.forward.mode : "none") }
         </span>);
     const state = (
-        <StateIcon error={network.error} state={network.active ? _("active") : "inactive" }
+        <StateIcon error={network.error} state={network.active ? _("active") : _("inactive") }
                    valueId={`${idPrefix}-state`}
                    dismissError={() => store.dispatch(updateOrAddNetwork({
                        connectionName: network.connectionName,

--- a/src/components/networks/network.jsx
+++ b/src/components/networks/network.jsx
@@ -131,8 +131,8 @@ const NetworkActions = ({ network }) => {
         }
     };
     const dialogProps = {
-        objectType: "Network",
-        objectName: network.name,
+        title: cockpit.format(_("Delete network $0"), network.name),
+        errorMessage: cockpit.format(_("Network $0 could not be deleted"), network.name),
         onClose: () => setDeleteDialogProps(undefined),
         deleteHandler: () => deleteHandler(network),
     };

--- a/src/components/networks/networkOverviewTab.jsx
+++ b/src/components/networks/networkOverviewTab.jsx
@@ -62,8 +62,8 @@ const DHCPHost = (host, index, family, idPrefix, network, parentIndex) => {
             isLink
             isInline
             showDialog={() => setDeleteDialogProps({
-                objectType: _("static host from DHCP"),
-                objectName: "",
+                title: _("Remove static host from DHCP"),
+                errorMessage: _("Static host from DHCP could not be removed"),
                 actionDescription: cockpit.format(_("The static host entry for $0 will be removed:"), host.ip),
                 objectDescription: [
                     { name: _("IP"), value: <span className="ct-monospace">{host.ip}</span> },

--- a/src/components/storagePools/storagePool.jsx
+++ b/src/components/storagePools/storagePool.jsx
@@ -61,7 +61,7 @@ export const getStoragePoolRow = ({ storagePool, vms, onAddErrorNotification }) 
     );
 
     const state = (
-        <StateIcon error={storagePool.error} state={storagePool.active ? _("active") : "inactive" }
+        <StateIcon error={storagePool.error} state={storagePool.active ? _("active") : _("inactive") }
                    valueId={`${idPrefix}-state`}
                    dismissError={() => store.dispatch(updateOrAddStoragePool({
                        connectionName: storagePool.connectionName,

--- a/src/components/vm/disks/vmDisksCard.jsx
+++ b/src/components/vm/disks/vmDisksCard.jsx
@@ -283,9 +283,9 @@ export class VmDisksCard extends React.Component {
                         });
             };
             const deleteDialogProps = {
-                objectType: _("disk"),
-                objectName: disk.target,
                 actionName: _("Remove"),
+                title: cockpit.format(_("Remove disk $0"), disk.target),
+                errorMessage: cockpit.format(_("Disk $0 could not be removed"), disk.target),
                 onClose: () => this.setState({ deleteDialogProps: undefined }),
                 deleteHandler: () => onRemoveDisk(),
             };

--- a/src/components/vm/filesystems/vmFilesystemsCard.jsx
+++ b/src/components/vm/filesystems/vmFilesystemsCard.jsx
@@ -58,9 +58,9 @@ export const VmFilesystemsCard = ({ connectionName, vmName, vmState, filesystems
                                       disabled={vmState != 'shut off'}
                                       actionName={_("Remove")}
                                       showDialog={() => setDeleteDialogProps({
-                                          objectType: _("filesystem"),
+                                          title: cockpit.format(_("Remove filesystem $0"), filesystemTarget),
+                                          errorMessage: cockpit.format(_("Filesystem $0 could not be removed"), filesystemTarget),
                                           actionName: _("Remove"),
-                                          objectName: filesystemTarget,
                                           onClose: () => setDeleteDialogProps(undefined),
                                           deleteHandler: () => domainDeleteFilesystem({ connectionName, vmName, target: filesystemTarget }),
                                       })}

--- a/src/components/vm/hostdevs/hostDevCard.jsx
+++ b/src/components/vm/hostdevs/hostDevCard.jsx
@@ -231,8 +231,8 @@ export const VmHostDevCard = ({ vm, nodeDevices, config }) => {
                     <DeleteResourceButton objectId={`${id}-hostdev-${hostdevId}`}
                                           actionName={_("Remove")}
                                           showDialog={() => setDeleteDialogProps({
-                                              objectType: cockpit.format(_("$1 host device"), hostdev.type),
-                                              objectName: "",
+                                              title: _("Remove host device"),
+                                              errorMessage: ("Host device could not be removed"),
                                               onClose: () => setDeleteDialogProps(undefined),
                                               deleteHandler: () => {
                                                   // refresh nodeDevice since usb number may be changed

--- a/src/components/vm/nics/vmNicsCard.jsx
+++ b/src/components/vm/nics/vmNicsCard.jsx
@@ -373,8 +373,8 @@ export class VmNetworkTab extends React.Component {
                     };
 
                     const deleteDialogProps = {
-                        objectType: _("network interface"),
-                        objectName: network.mac,
+                        title: cockpit.format(_("Delete network interface $0"), network.mac),
+                        errorMessage: cockpit.format(_("Network interface $0 could not be deleted"), network.mac),
                         onClose: () => this.setState({ deleteDialogProps: undefined }),
                         deleteHandler: () => domainDetachIface({ connectionName: vm.connectionName, index: network.index, vmName: vm.name, live: vm.state === 'running', persistent: nicPersistent }),
                     };

--- a/src/components/vm/snapshots/vmSnapshotsCard.jsx
+++ b/src/components/vm/snapshots/vmSnapshotsCard.jsx
@@ -178,8 +178,8 @@ export class VmSnapshotsCard extends React.Component {
 
                     const deleteSnapshotHelper = () => {
                         const deleteDialogProps = {
-                            objectType: _("snapshot"),
-                            objectName: snap.name,
+                            title: cockpit.format(_("Delete snapshot $0"), snap.name),
+                            errorMessage: cockpit.format(_("Snapshot $0 could not be deleted"), snap.name),
                             actionDescription: _("After deleting the snapshot, all its captured content will be lost."),
                             onClose: () => this.setState({ deleteDialogProps: undefined }),
                             deleteHandler: () => {

--- a/src/components/vm/snapshots/vmSnapshotsCreateModal.jsx
+++ b/src/components/vm/snapshots/vmSnapshotsCreateModal.jsx
@@ -91,9 +91,9 @@ export class CreateSnapshotModal extends React.Component {
         const validationError = {};
 
         if (vm.snapshots.findIndex(snap => snap.name === name) > -1)
-            validationError.name = "Name already exists";
+            validationError.name = _("Name already exists");
         else if (!name && submitted)
-            validationError.name = "Name should not be empty";
+            validationError.name = _("Name should not be empty");
 
         return validationError;
     }


### PR DESCRIPTION
The current approach had a few issues:
- Combining strings with `+` can lead to untranslatable situations
- `objectType` was not localized
- The title was title case (but should be sentence case)
- The error message always said `deleted` even when action was `Remove`
- Even if we would translate `objectType` it could lead to situations
  when the final sentence would not be correct, or correctly capitalized
  (for example `The network could not be deleted` is Czech would start
   with `network` as we don't have articles and thus the sentence would
   start with lowercase letter).