### PR TITLE
Makefile: Fix tools/node-modules dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ test/reference: test/common
 # We want tools/node-modules to run every time package-lock.json is requested
 # See https://www.gnu.org/software/make/manual/html_node/Force-Targets.html
 FORCE:
-package-lock.json: FORCE
+package-lock.json: FORCE tools/node-modules
 	tools/node-modules make_package_lock_json
 
 .PHONY: all clean install devel-install dist rpm check vm


### PR DESCRIPTION
It first needs to be checked out before we can call it. This fixes
`make po/machines.pot` in a clean checkout (as the weblate-sync-pot
workflow does).

---

Last night's [weblate-sync-pot workflow failed](https://github.com/cockpit-project/cockpit-machines/runs/6204918134?check_suite_focus=true). I [triggered a run against this branch](https://github.com/cockpit-project/cockpit-machines/runs/6205008238?check_suite_focus=true) and it succeeded.