### PR TITLE
Clarify difference between VM creation and import

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -212,7 +212,7 @@ class AppActive extends React.Component {
         };
         const createVmAction = <CreateVmAction {...properties} mode='create' />;
         const importDiskAction = <CreateVmAction {...properties} mode='import' />;
-        const vmActions = <> {createVmAction} {importDiskAction} </>;
+        const vmActions = <> {importDiskAction} {createVmAction} </>;
         const pathVms = path.length == 0 || (path.length > 0 && path[0] == 'vms');
 
         let vmContent;

--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -1217,7 +1217,7 @@ export class CreateVmAction extends React.Component {
         let createButton = (
             <Button isDisabled={testdata !== undefined}
                     testdata={testdata}
-                    id={this.props.mode == 'create' ? 'create-new-vm' : 'import-vm-disk'}
+                    id={this.props.mode == 'create' ? 'create-new-vm' : 'import-existing-vm'}
                     variant='secondary'
                     onClick={this.open}>
                 {this.props.mode == 'create' ? _("Create VM") : _("Import VM")}
@@ -1227,6 +1227,21 @@ export class CreateVmAction extends React.Component {
             createButton = (
                 <Tooltip id='virt-install-not-available-tooltip'
                          content={_("virt-install package needs to be installed on the system in order to create new VMs")}>
+                    <span>
+                        {createButton}
+                    </span>
+                </Tooltip>
+            );
+        else
+            createButton = (
+                <Tooltip id={this.props.mode + '-button-tooltip'}
+                         position={this.props.mode === "create" ? "top-end" : "top"}
+                         className={this.props.mode === "create" && "custom-arrow"}
+                         content={this.props.mode === "create"
+                             ? _("Create VM from local or network installation medium")
+                             : _("Create VM by importing a disk image of an existing VM installation")
+                         }
+                         isContentLeftAligned>
                     <span>
                         {createButton}
                     </span>

--- a/src/components/create-vm-dialog/createVmDialog.scss
+++ b/src/components/create-vm-dialog/createVmDialog.scss
@@ -1,3 +1,7 @@
 .unit-select, .size-input {
     max-width: 5rem;
 }
+
+.pf-c-tooltip__arrow {
+    margin-right: var(--pf-global--spacer--xl);
+}

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -37,7 +37,7 @@ from machinesxmls import NETWORK_XML_PXE, PXE_SERVER_CFG  # noqa
 @nondestructive
 class TestMachinesCreate(VirtualMachinesCase):
 
-    # This test contains basic form validation of the Create VM dialog
+    # This test contains basic button and form validation of the Create VM dialog
     # None of the sub-tests will actually call virt-install
     def testCreateBasicValidation(self):
         runner = TestMachinesCreate.CreateVmRunner(self)
@@ -49,6 +49,9 @@ class TestMachinesCreate(VirtualMachinesCase):
 
         self.login_and_go("/machines")
         self.browser.wait_in_text("body", "Virtual machines")
+
+        # test create and import [VM] buttons show appropriate tooltips when hovered over
+        runner.createAndImportTooltipsTest()
 
         # test just the DIALOG CREATION and cancel
         print("    *\n    * validation errors and ui info/warn messages expected:\n    * ")
@@ -775,7 +778,7 @@ vnc_password= "{vnc_passwd}"
             b = self.browser
 
             if self.sourceType == 'disk_image':
-                b.click("#import-vm-disk")
+                b.click("#import-existing-vm")
             else:
                 b.click("#create-new-vm")
 
@@ -1544,6 +1547,18 @@ vnc_password= "{vnc_passwd}"
                 self._deleteVm(dialog)
                 if check_env_empty:
                     self.checkEnvIsEmpty(dialog)
+
+        def createAndImportTooltipsTest(self):
+            b = self.browser
+
+            b.wait_visible("#import-existing-vm:not(:disabled)")
+            b.mouse("#import-existing-vm", "mouseenter")
+            b.wait_in_text("#import-button-tooltip", "existing")
+            b.mouse("#import-existing-vm", "mouseleave")
+            b.wait_visible("#create-new-vm:not(:disabled)")
+            b.mouse("#create-new-vm", "mouseenter")
+            b.wait_in_text("#create-button-tooltip", "medium")
+            b.mouse("#create-new-vm", "mouseleave")
 
         def cancelDialogTest(self, dialog):
             dialog.open() \


### PR DESCRIPTION
In https://github.com/cockpit-project/cockpit-machines/issues/612, which was recently closed because the initial bug which was reported was fixed, @garrett  mentioned few issues with Create VM vs Import VM buttons. Let's fixed them immediately so it doesn't get forgotten about:

> In other words, I think there are these issues:
>     0. Adjust Create vs. Import.
>        
>        * Swap Create and Import buttons, so Create is in the default position (on the right)

Done:
![Screenshot from 2022-04-28 13-37-56](https://user-images.githubusercontent.com/42733240/165753861-4143753d-b240-46f8-b690-162ba1d955b3.png)

>        * Perhaps we should consider having some tooltips (when hovering the buttons) that talk about creation being an installation process (such as with an iso) whereas import is using a disk image as-is.

I took some text from [redhat docs](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_virtualization/getting-started-with-virtualization-in-rhel-8_configuring-and-managing-virtualization#creating-vms-using-the-rhel-8-web-console_creating-vms-and-installing-an-os-using-the-rhel-8-web-console) and adjusted them for our tooltip messages, but I'm of course open to discussion about them:
![Screenshot from 2022-04-28 14-42-04](https://user-images.githubusercontent.com/42733240/165754339-1c61e3a5-72ef-4995-8a74-4471ed31492e.png)
![Screenshot from 2022-04-28 14-41-19](https://user-images.githubusercontent.com/42733240/165754356-7e88cda7-56f4-4f8d-b1f7-6fd7a9285164.png)

Tooltips positions are auto "auto", and there is not enough space on the screen for the tooltip for "Create VM" to do anything else than align to the left. Should we hard-code the other tooltip to also align to the left?

>        * Possibly think about "Install" instead of "Create"? (Not sure about this one; just throwing an idea out there)

I'm not sure about this, as "installation" is a different phase, which you can avoid (or postpone to be more precise) by clicking "Create and edit". So the button would be called "Install", bu it would open a dialog where user can choose to _not install_

We would end up with following flow:

1. There would be button "Install", which opens a dialog

![Screenshot from 2022-04-28 14-47-57](https://user-images.githubusercontent.com/42733240/165755504-0ed6a28a-dd95-41c8-9675-8e0a6fe023f2.png)

2. You fill out the dialog, but decide not to install VM immediatelly, but instead click on "Create and edit"
3. You end up on a VM page and there is another "Install" button
![Screenshot from 2022-04-28 14-47-37](https://user-images.githubusercontent.com/42733240/165755770-82ab4a4a-e29e-4d05-8a64-bd7b41d2a8c0.png)

Having "Install" twice in the same flow feels a bit weird to me, but that's just my subjective opinion.