### PR TITLE
packit: Release to COPR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ jobs:
           chmod 600 ~/.ssh/id_rsa
           echo 'cockpit' > ~/.config/bodhi-user
           echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
-          echo '${{ secrets.COPR_TOKEN }}' > ~/.config/copr
           echo '${{ secrets.COCKPIT_FEDORA_PASSWORD }}' > ~/.fedora-password
 
       - name: Run cockpituous

--- a/README.md
+++ b/README.md
@@ -39,12 +39,14 @@ code, run, and test it.
 # Automated release
 
 Releases are automated using [Cockpituous release](https://github.com/cockpit-project/cockpituous/tree/main/release)
-which aims to fully automate project releases to GitHub, Fedora, Ubuntu, COPR, Docker
-Hub, and other places. The intention is that the only manual step for releasing
-a project is to create a signed tag for the version number.
+and [Packit](https://packit.dev/) which aim to fully automate project releases
+to GitHub, Fedora, Ubuntu, COPR, Docker Hub, and other places. The intention is
+that the only manual step for releasing a project is to create a signed tag for
+the version number.
 
 The release steps are controlled by the
-[cockpituous-release](./cockpituous-release) script.
+[cockpituous-release](./cockpituous-release) script and the [packit.yaml](./packit.yaml)
+control file.
 
 Pushing the release tag triggers the [release.yml](.github/workflows/release.yml)
 [GitHub action](https://github.com/features/actions) workflow. This uses the

--- a/cockpituous-release
+++ b/cockpituous-release
@@ -27,4 +27,3 @@ job release-bodhi F36
 # so that failures there will fail the release early, before publishing on GitHub
 
 job release-github
-job release-copr @cockpit/cockpit-preview

--- a/packit.yaml
+++ b/packit.yaml
@@ -22,3 +22,16 @@ jobs:
       - fedora-rawhide
       - centos-stream-8
       - centos-stream-9
+
+  - job: copr_build
+    trigger: release
+    metadata:
+      owner: cockpit
+      project: cockpit-preview
+      preserve_project: True
+      targets:
+      - fedora-35
+      - fedora-36
+      - fedora-development
+      - centos-stream-8-x86_64
+      - centos-stream-9-x86_64


### PR DESCRIPTION
This replaces our cockpituous job.

See https://packit.dev/docs/configuration/#copr_build

---

See https://github.com/cockpit-project/cockpit-podman/pull/969 for details.