### PR TITLE
Elements visible in VM listing should have connection name in their element ids

### DIFF
--- a/src/components/vm/overview/vmOverviewCard.jsx
+++ b/src/components/vm/overview/vmOverviewCard.jsx
@@ -183,7 +183,7 @@ class VmOverviewCard extends React.Component {
                                 <DescriptionListDescription>
                                     <StateIcon error={vm.error}
                                                state={vm.state}
-                                               valueId={`${idPrefix}-state`}
+                                               valueId={`${idPrefix}-${vm.connectionName}-state`}
                                                dismissError={() => store.dispatch(updateVm({
                                                    connectionName: vm.connectionName,
                                                    name: vm.name,

--- a/src/components/vm/vmActions.jsx
+++ b/src/components/vm/vmActions.jsx
@@ -77,7 +77,7 @@ const VmActions = ({ vm, storagePools, onAddErrorNotification, isDetailsPage }) 
         setOperationInProgress(false);
     }
 
-    const id = vmId(vm.name);
+    const id = `${vmId(vm.name)}-${vm.connectionName}`;
     const state = vm.state;
     const hasInstallPhase = vm.metadata && vm.metadata.hasInstallPhase;
     const dropdownItems = [];

--- a/src/components/vms/hostvmslist.jsx
+++ b/src/components/vms/hostvmslist.jsx
@@ -52,7 +52,7 @@ const VmState = ({ vm, dismissError }) => {
         state = vm.state;
     }
 
-    return <StateIcon dismissError={dismissError} error={vm.error} state={state} valueId={`${vmId(vm.name)}-state`} />;
+    return <StateIcon dismissError={dismissError} error={vm.error} state={state} valueId={`${vmId(vm.name)}-${vm.connectionName}-state`} />;
 };
 
 const _ = cockpit.gettext;

--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -42,7 +42,7 @@ class TestMachinesConsoles(VirtualMachinesCase):
         b.wait_in_text("body", "Virtual machines")
         self.waitVmRow("subVmTest1")
 
-        b.wait_in_text("#vm-subVmTest1-state", "Running")  # running or paused
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")  # running or paused
         self.goToVmPage("subVmTest1")
 
         # since VNC is not defined for this VM, the view for "Desktop Viewer" is rendered by default
@@ -80,7 +80,7 @@ class TestMachinesConsoles(VirtualMachinesCase):
         b.wait_in_text("body", "Virtual machines")
         self.waitVmRow("subVmTest1")
 
-        b.wait_in_text("#vm-subVmTest1-state", "Running")  # running or paused
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")  # running or paused
         self.goToVmPage("subVmTest1")
 
         # since VNC is defined for this VM, the view for "In-Browser Viewer" is rendered by default
@@ -109,7 +109,7 @@ class TestMachinesConsoles(VirtualMachinesCase):
         self.waitVmRow(name)
 
         self.goToVmPage(name)
-        b.wait_in_text(f"#vm-{name}-state", "Running")
+        b.wait_in_text(f"#vm-{name}-system-state", "Running")
 
         b.click("#pf-c-console__type-selector")
         b.wait_visible("#pf-c-console__type-selector + .pf-c-select__menu")
@@ -162,7 +162,7 @@ class TestMachinesConsoles(VirtualMachinesCase):
 
         self.waitVmRow(name)
         self.goToVmPage(name)
-        b.wait_in_text(f"#vm-{name}-state", "Running")
+        b.wait_in_text(f"#vm-{name}-system-state", "Running")
 
         b.wait_visible(f"#vm-{name}-consoles")
         b.wait_visible(".pf-c-console__vnc canvas")

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1326,13 +1326,13 @@ vnc_password= "{vnc_passwd}"
                 # created and redirected
                 self.test_obj.waitVmPage(name)
 
-            b.click(f"#vm-{name}-install")
+            b.click(f"#vm-{name}-{connection}-install")
 
             if tryWithFailInstall:
                 # Deleting the default network will make the installation to fail immediately
                 m.execute("virsh net-destroy default")
                 b.wait_in_text(f"#vm-{name}-{connection}-state", "Shut off")
-                b.wait_visible(f"#vm-{name}-install")
+                b.wait_visible(f"#vm-{name}-{connection}-install")
                 b.wait_in_text(".pf-c-alert", "failed to get installed")
             else:
                 b.wait_in_text(f"#vm-{name}-{connection}-state", "Running")
@@ -1350,7 +1350,7 @@ vnc_password= "{vnc_passwd}"
         def _deleteVm(self, dialog):
             b = self.browser
 
-            self.test_obj.performAction(dialog.name, "delete")
+            self.test_obj.performAction(dialog.name, "delete", connectionName=dialog.connection)
             b.wait_visible(f"#vm-{dialog.name}-delete-modal-dialog")
             b.click(f"#vm-{dialog.name}-delete-modal-dialog button:contains(Delete)")
             b.wait_not_present(f"#vm-{dialog.name}-delete-modal-dialog")
@@ -1650,7 +1650,7 @@ vnc_password= "{vnc_passwd}"
         m.execute("umount " + ovmf_path)
 
         # Install the VM
-        b.click("#vm-VmNotInstalled-install")
+        b.click("#vm-VmNotInstalled-system-install")
 
         # Wait for virt-install to define the VM and then stop it - otherwise we get 'domain is ready being removed' error
         wait(lambda: "VmNotInstalled" in m.execute("virsh list --persistent"), delay=3)
@@ -1727,7 +1727,7 @@ vnc_password= "{vnc_passwd}"
         b.wait_in_text("#vm-VmNotInstalledBios-firmware", "BIOS")
 
         # Install the VM
-        b.click("#vm-VmNotInstalledBios-install")
+        b.click("#vm-VmNotInstalledBios-system-install")
         b.wait_in_text("#vm-VmNotInstalledBios-system-state", "Running")
 
         domainXML = self.machine.execute("virsh dumpxml VmNotInstalledBios")

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -336,7 +336,7 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                       delete=False))
         # Wait for virt-install to define the VM and then stop it
         wait(lambda: "pxe-guest" in self.machine.execute("virsh list --persistent"), delay=3)
-        b.wait_in_text("#vm-pxe-guest-state", "Running")
+        b.wait_in_text("#vm-pxe-guest-system-state", "Running")
         self.machine.execute("virsh destroy pxe-guest")
 
         # Verify that the newly created disk is first in the boot order and the network used for the PXE boot is not on the bootable devices list
@@ -670,7 +670,7 @@ vnc_password= "{vnc_passwd}"
                      delete=True,
                      env_is_empty=True,
                      check_script_finished=True,
-                     connection=None,
+                     connection="system",
                      pixel_test_tag=None):
 
             TestMachinesCreate.VmDialog.vmId += 1  # This variable is static - don't use self here
@@ -873,7 +873,7 @@ vnc_password= "{vnc_passwd}"
 
                 self.assertIn("\nssh_pwauth: true", user_data)
 
-            self.browser.wait_text(f"#vm-{self.name}-state", "Running")
+            self.browser.wait_text(f"#vm-{self.name}-{self.connection}-state", "Running")
 
             # Wait for it to become permanent before destruction.  If
             # we destroy it while it is still transient, the domain
@@ -884,7 +884,7 @@ vnc_password= "{vnc_passwd}"
             # wait for virt-install to finish
             self.machine.execute(f"while {virt_install_cmd}; do sleep 1; done")
 
-            self.browser.wait_text(f"#vm-{self.name}-state", "Shut off")
+            self.browser.wait_text(f"#vm-{self.name}-{self.connection}-state", "Shut off")
 
             self.assertIn(f"backing file: {self.location}", self.machine.execute(f"qemu-img info /var/lib/libvirt/images/{self.name}.qcow2"))
 
@@ -896,7 +896,7 @@ vnc_password= "{vnc_passwd}"
             else:
                 self.browser.click(".pf-c-modal-box__footer button:contains(Create and edit)")
             self.browser.wait_not_present("#create-vm-dialog")
-            self.browser.wait_text(f"#vm-{self.name}-state", "Shut off")
+            self.browser.wait_text(f"#vm-{self.name}-{self.connection}-state", "Shut off")
 
             domainXML = m.execute(f"virsh dumpxml --security-info {self.name}")
             root = ET.fromstring(domainXML)
@@ -1256,9 +1256,9 @@ vnc_password= "{vnc_passwd}"
             self.test_obj.restore_file("/etc/hosts")
             self.machine.execute('echo "127.0.0.1 archive.fedoraproject.org" >> /etc/hosts')
 
-        def _assertVmStates(self, name, before, after):
+        def _assertVmStates(self, name, connection, before, after):
             b = self.browser
-            selector = f"#vm-{name}-state"
+            selector = f"#vm-{name}-{connection}-state"
 
             b.wait_in_text(selector, before)
 
@@ -1284,7 +1284,7 @@ vnc_password= "{vnc_passwd}"
             init_state = "Creating VM installation" if dialog.create_and_run else "Creating VM"
             second_state = "Running" if dialog.create_and_run else "Shut off"
 
-            self._assertVmStates(dialog.name, init_state, second_state)
+            self._assertVmStates(dialog.name, dialog.connection, init_state, second_state)
             b.wait_not_present("#create-vm-dialog")
 
         def _tryCreate(self, dialog):
@@ -1296,7 +1296,7 @@ vnc_password= "{vnc_passwd}"
 
             if dialog.create_and_run:
                 # successfully created
-                self.test_obj.waitVmRow(name, dialog.connection or "system")
+                self.test_obj.waitVmRow(name, dialog.connection)
             else:
                 # created and redirected
                 self.test_obj.waitVmPage(name)
@@ -1310,6 +1310,7 @@ vnc_password= "{vnc_passwd}"
             m = self.machine
             dialog.create_and_run = False
             name = dialog.name
+            connection = dialog.connection
 
             dialog.open() \
                 .fill()
@@ -1317,7 +1318,7 @@ vnc_password= "{vnc_passwd}"
 
             if dialog.create_and_run:
                 # successfully created
-                self.test_obj.waitVmRow(name, dialog.connection or "system")
+                self.test_obj.waitVmRow(name, dialog.connection)
 
                 if installFromVmDetails:
                     self.test_obj.goToVmPage(name)
@@ -1330,19 +1331,19 @@ vnc_password= "{vnc_passwd}"
             if tryWithFailInstall:
                 # Deleting the default network will make the installation to fail immediately
                 m.execute("virsh net-destroy default")
-                b.wait_in_text(f"#vm-{name}-state", "Shut off")
+                b.wait_in_text(f"#vm-{name}-{connection}-state", "Shut off")
                 b.wait_visible(f"#vm-{name}-install")
                 b.wait_in_text(".pf-c-alert", "failed to get installed")
             else:
-                b.wait_in_text(f"#vm-{name}-state", "Running")
+                b.wait_in_text(f"#vm-{name}-{connection}-state", "Running")
                 self._assertCorrectConfiguration(dialog)
 
                 # Wait for virt-install to define the VM and then stop it - otherwise we get 'domain is ready being removed' error
                 wait(lambda: dialog.name in self.machine.execute("virsh list --persistent"), delay=3)
 
                 # unfinished install script runs indefinitely, so we need to force it off
-                self.test_obj.performAction(name, "forceOff", False)
-                b.wait_in_text(f"#vm-{name}-state", "Shut off")
+                self.test_obj.performAction(name, "forceOff", checkExpectedState=False)
+                b.wait_in_text(f"#vm-{name}-{connection}-state", "Shut off")
 
             return self
 
@@ -1354,21 +1355,22 @@ vnc_password= "{vnc_passwd}"
             b.click(f"#vm-{dialog.name}-delete-modal-dialog button:contains(Delete)")
             b.wait_not_present(f"#vm-{dialog.name}-delete-modal-dialog")
 
-            self.test_obj.waitVmRow(dialog.name, "system", False)
+            self.test_obj.waitVmRow(dialog.name, dialog.connection, False)
             return self
 
         def _assertCorrectConfiguration(self, dialog):
             b = self.browser
             name = dialog.name
+            connection = dialog.connection
 
             if not (b.is_present("#vm-details") and b.is_visible("#vm-details")):
                 self.test_obj.goToVmPage(name, dialog.connection or "system")
 
-            vm_state = b.text(f"#vm-{dialog.name}-state")
+            vm_state = b.text(f"#vm-{name}-{connection}-state")
 
             # check bus type
             if dialog.storage_pool != "NoStorage":
-                self.browser.wait_in_text(f"#vm-{dialog.name}-disks-vda-bus", "virtio")
+                self.browser.wait_in_text(f"#vm-{name}-disks-vda-bus", "virtio")
             # check memory
             # adjust to how cockpit_format_bytes() formats sizes > 1024 MiB -- this depends on how much RAM
             # the host has (less or more than 1 GiB), and thus needs to be dynamic
@@ -1654,8 +1656,8 @@ vnc_password= "{vnc_passwd}"
         wait(lambda: "VmNotInstalled" in m.execute("virsh list --persistent"), delay=3)
         logfile = "/var/log/libvirt/qemu/VmNotInstalled.log"
         m.execute(f"> {logfile}")  # clear logfile
-        self.performAction("VmNotInstalled", "forceOff", False)
-        b.wait_in_text("#vm-VmNotInstalled-state", "Shut off")
+        self.performAction("VmNotInstalled", "forceOff", checkExpectedState=False)
+        b.wait_in_text("#vm-VmNotInstalled-system-state", "Shut off")
         wait(lambda: "133120" in m.execute("virsh dominfo VmNotInstalled | grep 'Used memory'"), delay=1)  # Wait until memory parameters get adjusted after shutting the VM
 
         # Check configuration changes survived installation
@@ -1726,7 +1728,7 @@ vnc_password= "{vnc_passwd}"
 
         # Install the VM
         b.click("#vm-VmNotInstalledBios-install")
-        b.wait_in_text("#vm-VmNotInstalledBios-state", "Running")
+        b.wait_in_text("#vm-VmNotInstalledBios-system-state", "Running")
 
         domainXML = self.machine.execute("virsh dumpxml VmNotInstalledBios")
         # no explicit "firmware=" field

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -97,7 +97,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual machines")
         self.waitVmRow("subVmTest1")
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         self.goToVmPage("subVmTest1")
 
@@ -199,7 +199,7 @@ class TestMachinesDisks(VirtualMachinesCase):
 
         # Start Vm
         b.click("#vm-subVmTest1-run")
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # Test disk's bus and cache cannot be changed on running VM
         open("sda")
@@ -221,7 +221,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         b.wait_in_text("body", "Virtual machines")
         self.waitVmRow("subVmTest1")
 
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         self.goToVmPage("subVmTest1")
 
@@ -537,7 +537,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual machines")
 
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
 
         if "debian" not in m.image and "ubuntu" not in m.image:
@@ -591,7 +591,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual machines")
 
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
 
         self.VMAddDiskDialog(
@@ -651,7 +651,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual machines")
 
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
 
         partition = os.path.basename(dev) + "1"
@@ -709,7 +709,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual machines")
 
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
 
         transient_targets.append(get_next_free_target(used_targets)[-1])
@@ -786,7 +786,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         if "debian" not in m.image and "ubuntu" not in m.image:
             # Run VM
             b.click("#vm-subVmTest1-run")
-            b.wait_in_text("#vm-subVmTest1-state", "Running")
+            b.wait_in_text("#vm-subVmTest1-system-state", "Running")
             # Test disk attachment to non-persistent VM
             m.execute("virsh undefine subVmTest1")
             self.VMAddDiskDialog(
@@ -838,7 +838,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual machines")
 
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
 
         # Using directory path for disk should create API failure
@@ -1060,7 +1060,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         wait(lambda: "login as 'cirros' user" in self.machine.execute(f"cat {args['logfile']}"), delay=3)
 
         # Test detaching non permanent disk of a running domain
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
 
         b.wait_visible("#vm-subVmTest1-disks-vdc-device")
@@ -1123,7 +1123,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         # Make sure that the VM booted normally before attempting to suspend it
         wait(lambda: "login as 'cirros' user" in m.execute(f"cat {args['logfile']}"), delay=3)
         m.execute("virsh suspend subVmTest1")
-        b.wait_in_text("#vm-subVmTest1-state", "Paused")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Paused")
         b.wait_attr("#delete-subVmTest1-disk-vde", "disabled", "")
         m.execute("virsh resume subVmTest1")
         wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -198,7 +198,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         b.wait_not_present("#vm-subVmTest1-disks-hda-edit-writable-shareable")
 
         # Start Vm
-        b.click("#vm-subVmTest1-run")
+        b.click("#vm-subVmTest1-system-run")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # Test disk's bus and cache cannot be changed on running VM
@@ -785,7 +785,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         # https://bugs.launchpad.net/ubuntu/+source/libvirt/+bug/1677398
         if "debian" not in m.image and "ubuntu" not in m.image:
             # Run VM
-            b.click("#vm-subVmTest1-run")
+            b.click("#vm-subVmTest1-system-run")
             b.wait_in_text("#vm-subVmTest1-system-state", "Running")
             # Test disk attachment to non-persistent VM
             m.execute("virsh undefine subVmTest1")

--- a/test/check-machines-filesystems
+++ b/test/check-machines-filesystems
@@ -121,7 +121,7 @@ class TestMachinesFilesystems(VirtualMachinesCase):
         b.click("#vm-subVmTest1-filesystems-modal-cancel")
 
         # Start VM and ensure that adding filesystem is disabled
-        b.click("#vm-subVmTest1-run")
+        b.click("#vm-subVmTest1-system-run")
         b.wait_visible("#vm-subVmTest1-filesystems-add[aria-disabled=true]")
 
     @skipImage("Older libvirt does not support virtiofs", "rhel-8-6", "centos-8-stream")

--- a/test/check-machines-hostdevs
+++ b/test/check-machines-hostdevs
@@ -50,7 +50,7 @@ class TestMachinesHostDevs(VirtualMachinesCase):
         b.wait_in_text("body", "Virtual machines")
         self.waitVmRow("subVmTest1")
 
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         self.goToVmPage("subVmTest1")
 
@@ -72,7 +72,7 @@ class TestMachinesHostDevs(VirtualMachinesCase):
                 b.wait_in_text("#vm-subVmTest1-hostdev-1-source #1-bus", "1")
 
         m.execute("virsh destroy subVmTest1")
-        b.wait_in_text("#vm-subVmTest1-state", "Shut off")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Shut off")
 
         # Test attachment of non-existent host device
         m.execute(f"echo \"{USB_HOSTDEV_NONEXISTENT}\" > /tmp/usbnonexistenthostedxml")

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -161,7 +161,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
 
         # start another one, should appear automatically
         self.createVm("subVmTest2")
-        b.wait_in_text("#vm-subVmTest2-state", "Running")
+        b.wait_in_text("#vm-subVmTest2-system-state", "Running")
         self.goToVmPage("subVmTest2")
         b.wait_in_text("#vm-subVmTest2-vcpus-count", "1")
         b.wait_in_text("#vm-subVmTest2-boot-order", "disk,network")
@@ -173,7 +173,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         # stop second VM, event handling should still work
         self.performAction("subVmTest2", "forceOff")
 
-        b.click("#vm-subVmTest2-run")
+        b.click("#vm-subVmTest2-system-run")
 
         b.set_input_text("#text-search", "subVmTest2")
         self.waitVmRow("subVmTest2")
@@ -200,22 +200,22 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         self.createVm("subVmTest3")
         m.execute("virsh destroy subVmTest2 && virsh destroy subVmTest3 && virsh net-destroy default")
 
-        def tryRunDomain(index, name):
+        def tryRunDomain(index, name, connection):
             self.waitVmRow(name)
 
-            b.click(f"#vm-{name}-run")
+            b.click(f"#vm-{name}-{connection}-run")
 
         # Try to run subVmTest1 - it will fail because of inactive default network
-        tryRunDomain(1, 'subVmTest1')
+        tryRunDomain(1, 'subVmTest1', 'system')
         b.click('#vm-subVmTest1-system-state button:contains("view more")')
         b.wait_in_text(".pf-c-popover", "VM subVmTest1 failed to start")
         b.click('#vm-subVmTest1-system-state button[aria-label=Close]')
 
         # Try to run subVmTest2
-        tryRunDomain(2, 'subVmTest2')
-        b.click('#vm-subVmTest2-state button:contains("view more")')
+        tryRunDomain(2, 'subVmTest2', 'system')
+        b.click('#vm-subVmTest2-system-state button:contains("view more")')
         b.wait_in_text(".pf-c-popover", "VM subVmTest2 failed to start")
-        b.click('#vm-subVmTest2-state button[aria-label=Close]')
+        b.click('#vm-subVmTest2-system-state button[aria-label=Close]')
 
     def testCloneSessionConnection(self):
         self.testClone(connectionName='session')
@@ -233,7 +233,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
 
         self.waitVmRow("subVmTest1", connectionName=connectionName)
 
-        self.performAction("subVmTest1", "clone")
+        self.performAction("subVmTest1", "clone", connectionName=connectionName)
 
         b.wait_text(".pf-c-modal-box__title-text", "Create a clone VM based on subVmTest1")
         b.click("footer button.pf-m-primary")
@@ -449,9 +449,9 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         args = self.createVm(name)
         m.execute(f"virsh undefine {name}")
         b.wait_visible(f"tr[data-row-id=vm-{name}-system][data-vm-transient=true]")
-        b.click(f"#vm-{name}-action-kebab button")
-        b.wait_visible(f"#vm-{name}-delete a.pf-m-disabled")
-        b.click(f"#vm-{name}-forceOff")
+        b.click(f"#vm-{name}-system-action-kebab button")
+        b.wait_visible(f"#vm-{name}-system-delete a.pf-m-disabled")
+        b.click(f"#vm-{name}-system-forceOff")
         self.waitVmRow(name, 'system', False)
         b.wait_not_present(f'#vm-{name}-system-state button:contains("view more")')
 

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -88,7 +88,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         b.wait_in_text("body", "Virtual machines")
         self.waitVmRow("subVmTest1")
 
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
         b.wait_in_text("#vm-subVmTest1-vcpus-count", "1")
 
@@ -110,10 +110,10 @@ class TestMachinesLifecycle(VirtualMachinesCase):
 
         # suspend/resume
         m.execute("virsh suspend subVmTest1")
-        b.wait_in_text("#vm-subVmTest1-state", "Paused")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Paused")
         # resume sometimes fails with "unable to execute QEMU command 'cont': Resetting the Virtual Machine is required"
         m.execute('virsh resume subVmTest1 || { virsh destroy subVmTest1 && virsh start subVmTest1; }')
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # Wait for the system to completely start
         wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
@@ -136,13 +136,13 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         self.machine.execute(f"echo '' > {args['logfile']}")
         self.performAction("subVmTest1", "reboot")
         wait(lambda: "reboot: Power down" in self.machine.execute(f"cat {args['logfile']}"), delay=3)
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # force reboot
         self.machine.execute(f"echo '' > {args['logfile']}")
         self.performAction("subVmTest1", "forceReboot")
         wait(lambda: "Initializing cgroup subsys" in self.machine.execute(f"cat {args['logfile']}"), delay=3)
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # shut off
         self.performAction("subVmTest1", "forceOff")
@@ -155,7 +155,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         m.execute("virsh dumpxml subVmTest1 > /tmp/subVmTest1.xml")
         m.execute("virsh start {0} && virsh undefine {0}".format("subVmTest1"))
         b.wait_visible("div[data-vm-transient=\"true\"]")
-        self.performAction("subVmTest1", "forceOff", False)
+        self.performAction("subVmTest1", "forceOff", checkExpectedState=False)
         b.wait_in_text("#virtual-machines-listing .pf-c-empty-state", "No VM is running")
         m.execute("virsh define --file /tmp/subVmTest1.xml")
 
@@ -207,9 +207,9 @@ class TestMachinesLifecycle(VirtualMachinesCase):
 
         # Try to run subVmTest1 - it will fail because of inactive default network
         tryRunDomain(1, 'subVmTest1')
-        b.click('#vm-subVmTest1-state button:contains("view more")')
+        b.click('#vm-subVmTest1-system-state button:contains("view more")')
         b.wait_in_text(".pf-c-popover", "VM subVmTest1 failed to start")
-        b.click('#vm-subVmTest1-state button[aria-label=Close]')
+        b.click('#vm-subVmTest1-system-state button[aria-label=Close]')
 
         # Try to run subVmTest2
         tryRunDomain(2, 'subVmTest2')
@@ -399,7 +399,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         wait(lambda: "login as 'cirros' user" in self.machine.execute(f"cat {args['logfile']}"), delay=3)
 
         self.machine.execute(f"virsh -c qemu:///system suspend {name}")
-        b.wait_in_text(f"#vm-{name}-state", "Paused")
+        b.wait_in_text(f"#vm-{name}-system-state", "Paused")
         self.performAction(name, "delete")
         b.click(f"#vm-{name}-delete-modal-dialog button:contains(Delete)")
         self.waitVmRow(name, 'system', False)
@@ -453,7 +453,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         b.wait_visible(f"#vm-{name}-delete a.pf-m-disabled")
         b.click(f"#vm-{name}-forceOff")
         self.waitVmRow(name, 'system', False)
-        b.wait_not_present(f'#vm-{name}-state button:contains("view more")')
+        b.wait_not_present(f'#vm-{name}-system-state button:contains("view more")')
 
         # Delete a shut-off guest and verify the storage was removed
         name = "vm-shutoff"

--- a/test/check-machines-networks
+++ b/test/check-machines-networks
@@ -512,7 +512,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
         b.wait_in_text("body", "Virtual machines")
         self.waitVmRow("subVmTest1")
 
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # Make sure that the Networks are loaded into the global state
         b.wait_in_text("#card-pf-networks .card-pf-title-link", "2 Networks")
@@ -663,7 +663,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
         self.addCleanup(m.execute, "ip link delete br1")
 
         m.execute("virsh start subVmTest1")
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # Open the modal dialog
         b.click("#vm-subVmTest1-network-1-edit-dialog")

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -48,7 +48,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         b.wait_in_text("body", "Virtual machines")
         self.waitVmRow("subVmTest1")
 
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # Wait for the dynamic IP address to be assigned before logging in
         # If the IP will change or get assigned after fetching the domain data the user will not see any
@@ -94,7 +94,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         b.wait_in_text("body", "Virtual machines")
 
         self.waitVmRow("subVmTest1")
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
 
         # Plug and unplug NICs
@@ -134,7 +134,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual machines")
         self.waitVmRow("subVmTest1")
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
         self.goToVmPage("subVmTest1")
 
@@ -201,7 +201,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         # Shut off domain
         b.click("#vm-subVmTest1-action-kebab button")
         b.click("#vm-subVmTest1-forceOff")
-        b.wait_in_text("#vm-subVmTest1-state", "Shut off")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Shut off")
 
         # No NICs present
         b.wait_visible("#vm-subVmTest1-add-iface-button")  # open the Network Interfaces subtab
@@ -243,7 +243,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         # Start vm and wait until kernel is booted
         m.execute(f"> {args['logfile']}")  # clear logfile
         b.click("#vm-subVmTest1-run")
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
 
         # Because of bug in debian-testing, attachment of virtio vNICs after restarting VM will fail
@@ -275,7 +275,7 @@ class TestMachinesNICs(VirtualMachinesCase):
             b.wait_visible("div[data-vm-transient=\"false\"]")
             b.click("#vm-subVmTest1-action-kebab button")
             b.click("#vm-subVmTest1-forceOff")
-            b.wait_in_text("#vm-subVmTest1-state", "Shut off")
+            b.wait_in_text("#vm-subVmTest1-system-state", "Shut off")
 
             mac_address = self.get_next_mac(mac_address)
             self.NICAddDialog(
@@ -482,7 +482,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         ).execute()
 
         b.click("#vm-subVmTest1-run")
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # Test a warning shows up when editing a vNIC for a running VM
         self.NICEditDialog(

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -199,9 +199,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         ).execute()
 
         # Shut off domain
-        b.click("#vm-subVmTest1-action-kebab button")
-        b.click("#vm-subVmTest1-forceOff")
-        b.wait_in_text("#vm-subVmTest1-system-state", "Shut off")
+        self.performAction("subVmTest1", "forceOff")
 
         # No NICs present
         b.wait_visible("#vm-subVmTest1-add-iface-button")  # open the Network Interfaces subtab
@@ -242,7 +240,7 @@ class TestMachinesNICs(VirtualMachinesCase):
 
         # Start vm and wait until kernel is booted
         m.execute(f"> {args['logfile']}")  # clear logfile
-        b.click("#vm-subVmTest1-run")
+        b.click("#vm-subVmTest1-system-run")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
 
@@ -273,9 +271,7 @@ class TestMachinesNICs(VirtualMachinesCase):
             ).execute()
             m.execute("virsh define /tmp/subVmTest1.xml")
             b.wait_visible("div[data-vm-transient=\"false\"]")
-            b.click("#vm-subVmTest1-action-kebab button")
-            b.click("#vm-subVmTest1-forceOff")
-            b.wait_in_text("#vm-subVmTest1-system-state", "Shut off")
+            self.performAction("subVmTest1", "forceOff")
 
             mac_address = self.get_next_mac(mac_address)
             self.NICAddDialog(
@@ -481,7 +477,7 @@ class TestMachinesNICs(VirtualMachinesCase):
             source="eth43",
         ).execute()
 
-        b.click("#vm-subVmTest1-run")
+        b.click("#vm-subVmTest1-system-run")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # Test a warning shows up when editing a vNIC for a running VM

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -51,7 +51,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         b.wait_in_text("body", "Virtual machines")
         self.waitVmRow("subVmTest1")
 
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
 
         b.click("#vm-subVmTest1-vcpus-count button")  # open VCPU modal detail window
@@ -91,7 +91,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         # Check after boot
         # Run VM
         b.click("#vm-subVmTest1-run")
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # Check VCPU count
         b.wait_in_text("#vm-subVmTest1-vcpus-count", "3")
@@ -137,7 +137,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         # Run VM - this ensures that the internal state is updated before we move on.
         # We need this here because we can't wait for UI updates after we open the modal dialog.
         b.click("#vm-subVmTest1-run")
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # Wait for the VCPUs link to get new values before opening the dialog
         b.wait_visible("#vm-subVmTest1-vcpus-count")
@@ -173,7 +173,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         def checkAutostart(vm_name, running):
             self.createVm(vm_name, running=running)
             self.waitVmRow(vm_name)
-            b.wait_in_text(f"#vm-{vm_name}-state", "Running" if running else "Shut off")
+            b.wait_in_text(f"#vm-{vm_name}-system-state", "Running" if running else "Shut off")
             self.goToVmPage(vm_name)
 
             # set checkbox state and check state of checkbox
@@ -218,7 +218,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         self.waitVmRow("subVmTest1")
 
         self.goToVmPage("subVmTest1")
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         cpu_model = "host-model"
         if m.image in distrosWithDefaultHostModel:
@@ -273,7 +273,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         b.wait_in_text("body", "Virtual machines")
         self.waitVmRow("subVmTest1")
 
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
 
         # Wait for the edit button
@@ -366,7 +366,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         b.wait_in_text("body", "Virtual machines")
         self.waitVmRow("subVmTest1")
 
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
 
         # Wait for the edit link
@@ -422,7 +422,7 @@ class TestMachinesSettings(VirtualMachinesCase):
 
         # Run VM
         b.click("#vm-subVmTest1-run")
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         # Non-persistent VM doesn't have configurable memory
         m.execute("virsh undefine subVmTest1")
         b.wait_visible("#vm-subVmTest1-memory-count button:disabled")
@@ -437,7 +437,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         b.wait_in_text("body", "Virtual machines")
         self.waitVmRow("subVmTest1")
 
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
 
         wait(lambda: "login as 'cirros' user" in m.execute(f"cat {args['logfile']}"), delay=3)

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -90,7 +90,7 @@ class TestMachinesSettings(VirtualMachinesCase):
 
         # Check after boot
         # Run VM
-        b.click("#vm-subVmTest1-run")
+        b.click("#vm-subVmTest1-system-run")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # Check VCPU count
@@ -136,7 +136,7 @@ class TestMachinesSettings(VirtualMachinesCase):
 
         # Run VM - this ensures that the internal state is updated before we move on.
         # We need this here because we can't wait for UI updates after we open the modal dialog.
-        b.click("#vm-subVmTest1-run")
+        b.click("#vm-subVmTest1-system-run")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # Wait for the VCPUs link to get new values before opening the dialog
@@ -258,7 +258,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         b.click("#cpu-config-dialog-apply")
         b.wait_not_present("#machines-cpu-type-modal")
         b.wait_in_text("#vm-subVmTest1-cpu-model .pf-c-description-list__text", "host")
-        b.click("#vm-subVmTest1-run")
+        b.click("#vm-subVmTest1-system-run")
         b.wait_in_text("#vm-subVmTest1-cpu-model .pf-c-description-list__text", "custom")
         # In the test ENV libvirt does not properly set the CPU model so we see a tooltip https://bugzilla.redhat.com/show_bug.cgi?id=1913337
         # b.wait_not_present("#cpu-tooltip")
@@ -421,7 +421,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         b.wait_attr("#vm-subVmTest1-memory-modal-memory", "value", "0")
 
         # Run VM
-        b.click("#vm-subVmTest1-run")
+        b.click("#vm-subVmTest1-system-run")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         # Non-persistent VM doesn't have configurable memory
         m.execute("virsh undefine subVmTest1")

--- a/test/check-machines-snapshots
+++ b/test/check-machines-snapshots
@@ -54,7 +54,7 @@ class TestMachinesSnapshots(VirtualMachinesCase):
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual machines")
         self.waitVmRow("subVmTest1")
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         self.goToVmPage("subVmTest1")
         if m.image in distrosWithoutSnapshot:
@@ -72,7 +72,7 @@ class TestMachinesSnapshots(VirtualMachinesCase):
 
         b.reload()  # snapshots events not available yet: https://gitlab.com/libvirt/libvirt/-/issues/44
         b.enter_page('/machines')
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         b.wait_in_text("#vm-subVmTest1-snapshot-0-name", "snapshotB")
         b.wait_in_text("#vm-subVmTest1-snapshot-0-description", "Description of snapshotB")
@@ -238,7 +238,7 @@ class TestMachinesSnapshots(VirtualMachinesCase):
         m.execute("virsh snapshot-delete subVmTest1 test_snap_1")
 
         b.click("#vm-subVmTest1-run")
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # Test snapshot creation on running VM
         SnapshotCreateDialog(

--- a/test/check-machines-snapshots
+++ b/test/check-machines-snapshots
@@ -237,7 +237,7 @@ class TestMachinesSnapshots(VirtualMachinesCase):
         ).execute()
         m.execute("virsh snapshot-delete subVmTest1 test_snap_1")
 
-        b.click("#vm-subVmTest1-run")
+        b.click("#vm-subVmTest1-system-run")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # Test snapshot creation on running VM

--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -87,7 +87,7 @@ class TestMachinesStoragePools(VirtualMachinesCase):
         # disks later
         b.click("#vm-subVmTest1-action-kebab button")
         b.click("#vm-subVmTest1-forceOff")
-        b.wait_in_text("#vm-subVmTest1-state", "Shut off")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Shut off")
 
         # Click on Storage pools card
         b.click(".pf-c-card .pf-c-card__header button:contains(Storage pools)")

--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -85,9 +85,7 @@ class TestMachinesStoragePools(VirtualMachinesCase):
 
         # Shuf off the VM in order to allow deleting volumes that are used as
         # disks later
-        b.click("#vm-subVmTest1-action-kebab button")
-        b.click("#vm-subVmTest1-forceOff")
-        b.wait_in_text("#vm-subVmTest1-system-state", "Shut off")
+        self.performAction("subVmTest1", "forceOff")
 
         # Click on Storage pools card
         b.click(".pf-c-card .pf-c-card__header button:contains(Storage pools)")

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -25,7 +25,7 @@ distrosWithMonolithicDaemon = ["rhel-8-6", "ubuntu-stable", "ubuntu-2204", "debi
 class VirtualMachinesCaseHelpers:
     created_pool = False
 
-    def performAction(self, vmName, action, checkExpectedState=True):
+    def performAction(self, vmName, action, checkExpectedState=True, connectionName="system"):
         b = self.browser
         b.click("#vm-{0}-action-kebab button".format(vmName))
         b.wait_visible("#vm-{0}-action-kebab > .pf-c-dropdown__menu".format(vmName))
@@ -35,11 +35,11 @@ class VirtualMachinesCaseHelpers:
             return
 
         if action == "pause":
-            b.wait_in_text("#vm-{0}-state".format(vmName), "Paused")
+            b.wait_in_text("#vm-{0}-{1}-state".format(vmName, connectionName), "Paused")
         if action == "resume" or action == "run":
-            b.wait_in_text("#vm-{0}-state".format(vmName), "Running")
+            b.wait_in_text("#vm-{0}-{1}-state".format(vmName, connectionName), "Running")
         if action == "forceOff":
-            b.wait_in_text("#vm-{0}-state".format(vmName), "Shut off")
+            b.wait_in_text("#vm-{0}-{1}-state".format(vmName, connectionName), "Shut off")
 
     def goToVmPage(self, vmName, connectionName='system'):
         self.browser.click("tbody tr[data-row-id=vm-{0}-{1}] a.vm-list-item-name".format(vmName, connectionName))  # click on the row

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -27,9 +27,9 @@ class VirtualMachinesCaseHelpers:
 
     def performAction(self, vmName, action, checkExpectedState=True, connectionName="system"):
         b = self.browser
-        b.click("#vm-{0}-action-kebab button".format(vmName))
-        b.wait_visible("#vm-{0}-action-kebab > .pf-c-dropdown__menu".format(vmName))
-        b.click("#vm-{0}-{1} a".format(vmName, action))
+        b.click("#vm-{0}-{1}-action-kebab button".format(vmName, connectionName))
+        b.wait_visible("#vm-{0}-{1}-action-kebab > .pf-c-dropdown__menu".format(vmName, connectionName))
+        b.click("#vm-{0}-{1}-{2} a".format(vmName, connectionName, action))
 
         if not checkExpectedState:
             return


### PR DESCRIPTION
In https://github.com/cockpit-project/cockpit-machines/pull/665, I wrote a test which has 2 VMs with same name, but on different connection.
This unearthed many places in code where we don't put connectionName to an element id.
In our tests, this creates cases when referring to elements in VM list is ambigious (as there may be multiple VMs with same id)