### PR TITLE
Cleanup VM creation process

### DIFF
--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -973,8 +973,6 @@ class CreateVmModal extends React.Component {
             };
 
             const promise = domainCreate(vmParams).then(() => {
-                close();
-
                 if (this.state.storagePool === "NewVolume") {
                     const storagePool = storagePools.find(pool => pool.connectionName === this.state.connectionName && pool.name === "default");
                     if (storagePool)
@@ -985,19 +983,19 @@ class CreateVmModal extends React.Component {
                     text: cockpit.format(_("Creation of VM $0 failed"), vmParams.vmName),
                     detail: exception.message.split(/Traceback(.+)/)[0],
                 });
-                close();
             });
 
             if (startVm) {
-                return promise;
+                promise();
             } else {
-                return promise
-                        .then(() => cockpit.location.go(["vm"], {
-                            ...cockpit.location.options,
-                            name: vmName,
-                            connection: this.state.connectionName
-                        }));
+                promise().then(() => cockpit.location.go(["vm"], {
+                    ...cockpit.location.options,
+                    name: vmName,
+                    connection: this.state.connectionName
+                }));
             }
+
+            close();
         }
     }
 

--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -972,7 +972,7 @@ class CreateVmModal extends React.Component {
                 startVm
             };
 
-            const promise = domainCreate(vmParams).then(() => {
+            domainCreate(vmParams).then(() => {
                 if (this.state.storagePool === "NewVolume") {
                     const storagePool = storagePools.find(pool => pool.connectionName === this.state.connectionName && pool.name === "default");
                     if (storagePool)
@@ -985,17 +985,15 @@ class CreateVmModal extends React.Component {
                 });
             });
 
-            if (startVm) {
-                promise();
-            } else {
-                promise().then(() => cockpit.location.go(["vm"], {
+            close();
+
+            if (!startVm) {
+                cockpit.location.go(["vm"], {
                     ...cockpit.location.options,
                     name: vmName,
                     connection: this.state.connectionName
-                }));
+                });
             }
-
-            close();
         }
     }
 

--- a/src/config.js
+++ b/src/config.js
@@ -23,7 +23,6 @@
  */
 const VMS_CONFIG = {
     DefaultRefreshInterval: 10000, // in ms
-    LeaveCreateVmDialogVisibleAfterSubmit: 3000, // in ms; to wait for an error
     DummyVmsWaitInterval: 10 * 60 * 1000, // show dummy vms for max 10 minutes; to let virt-install do work before getting vm from virsh
     WaitForRetryInstallVm: 3 * 1000, // wait for vm to recover in the ui after failed install to show the error
     Virsh: {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -346,53 +346,6 @@ export function storagePoolId(poolName, connectionName) {
     return `pool-${poolName}-${connectionName}`;
 }
 
-/**
- * Let promise resolve itself in specified delay or force resolve it with 0 arguments
- *
- * @param promise
- * @param delay of timeout in ms
- * @param afterTimeoutHandler called if promise succeeded before timeout expired
- * or timeout expired before promise returned
- * @param afterTimeoutFailHandler called only if promise failed after timeout
- * @returns new promise
- */
-export function timeoutedPromise(promise, delay, afterTimeoutHandler, afterTimeoutFailHandler) {
-    const deferred = cockpit.defer();
-    let done = false;
-
-    const timer = window.setTimeout(() => {
-        if (!done) {
-            deferred.resolve();
-            done = true;
-            afterTimeoutHandler();
-        }
-    }, delay);
-
-    promise.then(function(/* ... */) {
-        if (!done) {
-            done = true;
-            window.clearTimeout(timer);
-            deferred.resolve.apply(deferred, arguments);
-        }
-        if (typeof afterTimeoutHandler === 'function') {
-            afterTimeoutHandler.apply(afterTimeoutFailHandler, arguments);
-        }
-    });
-
-    promise.catch(function(/* ... */) {
-        if (!done) {
-            done = true;
-            window.clearTimeout(timer);
-            deferred.reject.apply(deferred, arguments);
-        }
-        if (typeof afterTimeoutFailHandler === 'function') {
-            afterTimeoutFailHandler.apply(afterTimeoutFailHandler, arguments);
-        }
-    });
-
-    return deferred.promise;
-}
-
 export function findMatchingNodeDevices(hostdev, nodeDevices) {
     let nodeDevs = [];
     switch (hostdev.type) {

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1145,8 +1145,6 @@ vnc_password= "{vnc_passwd}"
 
             error_location = ".pf-c-modal-box__footer div.pf-c-alert"
 
-            b.wait_visible(".pf-c-modal-box__footer button.pf-m-in-progress")
-            b.wait_not_present(".pf-c-modal-box__footer button.pf-m-in-progress")
             try:
                 with b.wait_timeout(10):
                     b.wait_visible(error_location)

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1337,7 +1337,14 @@ vnc_password= "{vnc_passwd}"
             init_state = "Creating VM installation" if dialog.create_and_run else "Creating VM"
             second_state = "Running" if dialog.create_and_run else "Shut off"
 
-            self._assertVmStates(dialog.name, dialog.connection, init_state, second_state)
+            # Getting rid of timeouts and unecessary waiting at VM creation dialog at
+            # https://github.com/cockpit-project/cockpit-machines/pull/699
+            # caused the VM creation process to get faster and sometimes tests might
+            # not catch "Creating VM" state.
+            # Therefore, test only for such states for VM which are created and
+            # STARTED IMMEDIATELLY as that causes "creating VM" stage to take longer time.
+            if dialog.create_and_run:
+                self._assertVmStates(dialog.name, dialog.connection, init_state, second_state)
             b.wait_not_present("#create-vm-dialog")
 
         def _tryCreate(self, dialog, generated_name=None):


### PR DESCRIPTION
- Don't timeout when creating VM
- Don't wait for VM creation to resolve to close the dialog, since we use asynchronous Toaster notifications for error handling
- When the user selects "Create and edit", redirect them to a new VM immediately





