### PR TITLE
packit: Fix copr owner

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -26,8 +26,8 @@ jobs:
   - job: copr_build
     trigger: release
     metadata:
-      owner: cockpit
-      project: cockpit-preview
+      owner: "@cockpit"
+      project: "cockpit-preview"
       preserve_project: True
       targets:
       - fedora-35


### PR DESCRIPTION
"cockpit" is a group, not an user, so add the missing `@` prefix.

---

See https://github.com/cockpit-project/cockpit-ostree/pull/257