### PR TITLE
Downloading RHEL images for new VMs

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -17,7 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 import React, { useState, useEffect } from 'react';
-import { AlertGroup, Button } from '@patternfly/react-core';
+import { AlertGroup, Button, Progress, ProgressMeasureLocation } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { superuser } from "superuser.js";
 import cockpit from 'cockpit';
@@ -241,18 +241,19 @@ class AppActive extends React.Component {
                                      }
                                      icon={ExclamationCircleIcon} />
                 </>);
-            }
-
-            if (vm.createInProgress) {
+            } else if (vm.createInProgress) {
                 return (<>
                     {allNotifications}
-                    <EmptyStatePanel title={ cockpit.format(_("Creating VM $0"), cockpit.location.options.name) }
+                    <EmptyStatePanel title={cockpit.format(vm.downloadProgress ? _("Downloading image for VM $0") : _("Creating VM $0"), cockpit.location.options.name)}
                                      action={
                                          <Button variant="link"
                                                  onClick={() => cockpit.location.go(["vms"])}>
                                              {_("Go to VMs list")}
                                          </Button>
                                      }
+                                     paragraph={vm.downloadProgress && <Progress aria-label={_("Download progress")}
+                                                                                 value={Number(vm.downloadProgress)}
+                                                                                 measureLocation={ProgressMeasureLocation.outside} />}
                                      loading />
                 </>);
             }

--- a/src/components/create-vm-dialog/createVmDialogUtils.js
+++ b/src/components/create-vm-dialog/createVmDialogUtils.js
@@ -141,3 +141,7 @@ export function correctSpecialCases(os) {
 
     return os;
 }
+
+export function needsRHToken(osName) {
+    return osName.startsWith("rhel");
+}

--- a/src/components/create-vm-dialog/uiState.js
+++ b/src/components/create-vm-dialog/uiState.js
@@ -58,10 +58,20 @@ export function setVmInstallInProgress(original_vm, settings) {
     setupCleanupTimeout(original_vm.name, original_vm.connectionName, INSTALL_TIMEOUT);
 }
 
+export function updateImageDownloadProgress(name, connectionName, downloadProgress, settings) {
+    const vm = Object.assign({}, {
+        name,
+        connectionName,
+        downloadProgress,
+    }, settings);
+    store.dispatch(updateUiVm(vm));
+}
+
 export function finishVmCreateInProgress(name, connectionName, settings) {
     const vm = Object.assign({}, {
         name,
         connectionName,
+        downloadProgress: undefined,
         createInProgress: false,
     }, settings);
     store.dispatch(updateUiVm(vm));

--- a/src/components/vms/hostvmslist.jsx
+++ b/src/components/vms/hostvmslist.jsx
@@ -45,7 +45,9 @@ import "./hostvmslist.scss";
 const VmState = ({ vm, dismissError }) => {
     let state = null;
 
-    if (vm.installInProgress) {
+    if (vm.downloadProgress) {
+        state = cockpit.format(_("Downloading: $0%"), vm.downloadProgress);
+    } else if (vm.installInProgress) {
         state = _("Creating VM installation");
     } else if (vm.createInProgress) {
         state = _("Creating VM");

--- a/src/libvirtApi/rhel-images.js
+++ b/src/libvirtApi/rhel-images.js
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as python from "python.js";
+
+import downloadRhelImageScript from 'raw-loader!../scripts/rhsm/download_file_and_report_progress.py';
+import getRhelImageUrlScript from 'raw-loader!../scripts/rhsm/get_rhel_image_url.py';
+import getAccessTokenScript from 'raw-loader!../scripts/rhsm/get_access_token.py';
+
+import {
+    logDebug,
+} from "../helpers.js";
+
+/*
+ * Provider for Red Hat Subscription Manage API.
+ * See https://access.redhat.com/management/api/rhsm
+ */
+
+export function downloadRhelImage(accessToken, url, fileName, downloadDir, isSystem) {
+    logDebug(`Download rhel image: ${url}, ${fileName}, ${downloadDir}, ${isSystem}`);
+
+    const args = JSON.stringify({
+        accessToken,
+        url,
+        fileName,
+        downloadDir
+    });
+
+    return python.spawn(downloadRhelImageScript, args, { err: "message", superuser: isSystem && "require", environ: ['LC_ALL=C.UTF-8'] });
+}
+
+export function getAccessToken(offlineToken) {
+    logDebug(`Get access token`);
+
+    const args = JSON.stringify({ offlineToken });
+    return python.spawn(getAccessTokenScript, args, { err: "message", environ: ['LC_ALL=C.UTF-8'] });
+}
+
+export function getRhelImageUrl(accessToken, rhelVersion, arch) {
+    logDebug(`Download rhel image, ${rhelVersion}, ${arch}`);
+
+    const args = JSON.stringify({
+        accessToken,
+        rhelVersion,
+        arch,
+    });
+
+    return python.spawn(getRhelImageUrlScript, args, { err: "message", environ: ['LC_ALL=C.UTF-8'] });
+}

--- a/src/scripts/rhsm/download_file_and_report_progress.py
+++ b/src/scripts/rhsm/download_file_and_report_progress.py
@@ -1,0 +1,32 @@
+import urllib.request
+import urllib.error
+import sys
+import json
+import os
+
+args = json.loads(sys.argv[1], strict=False)
+
+download_path = os.path.join(args['downloadDir'], args['fileName'])
+if not os.path.exists(download_path):
+    # Create download directory, don't complain when it already exists
+    os.makedirs(args['downloadDir'], exist_ok=True)
+
+    try:
+        req = urllib.request.Request(args['url'])
+        req.add_header("Authorization", f"Bearer {args['accessToken']}")
+        with urllib.request.urlopen(req) as s, open(download_path, "wb") as f:
+            size = int(s.headers["content-length"])
+            done = 0
+            percentage = -1
+            block = s.read(2 ** 20)
+            while block:
+                done += len(block)
+                new_percentage = round(done * 100 / size)
+                if (new_percentage > percentage):
+                    percentage = new_percentage
+                    print(f"{percentage}", flush=True)  # print adds newling by default, which serves nicely as a delimeter
+                f.write(block)
+                block = s.read(2 ** 20)
+
+    except urllib.error.URLError as error:
+        sys.exit(error)

--- a/src/scripts/rhsm/get_access_token.py
+++ b/src/scripts/rhsm/get_access_token.py
@@ -1,0 +1,27 @@
+import urllib.request
+import urllib.error
+import sys
+import json
+
+args = json.loads(sys.argv[1], strict=False)
+
+data = {
+    "grant_type": "refresh_token",
+    "client_id": "rhsm-api",
+    "refresh_token": args["offlineToken"]
+}
+try:
+    req = urllib.request.Request("https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token",
+                                 urllib.parse.urlencode(data).encode(),
+                                 headers={"Content-Type": "application/x-www-form-urlencoded"})
+    with urllib.request.urlopen(req) as s:
+        response_body = s.read().decode()
+        ret_obj = json.loads(response_body)
+
+        # Handle RHSM API failure
+        if "error" in ret_obj:
+            sys.exit(ret_obj["error"])
+
+    print(ret_obj["access_token"])
+except Exception as error:
+    sys.exit(error)

--- a/src/scripts/rhsm/get_rhel_image_url.py
+++ b/src/scripts/rhsm/get_rhel_image_url.py
@@ -1,0 +1,25 @@
+import urllib.request
+import urllib.error
+import sys
+import json
+
+args = json.loads(sys.argv[1], strict=False)
+
+try:
+    req = urllib.request.Request(f"https://api.access.redhat.com/management/v1/images/rhel/{args['rhelVersion']}/{args['arch']}")
+    req.add_header("Authorization", f"Bearer {args['accessToken']}")
+    with urllib.request.urlopen(req) as s:
+        ret_obj = json.loads(s.read())
+except urllib.error.URLError as error:
+    sys.exit(error)
+
+if "error" in ret_obj:
+    sys.exit(ret_obj["error"])
+
+for downloadable_content in ret_obj["body"]:
+    if downloadable_content["filename"].endswith("boot.iso"):
+        download_url = downloadable_content["downloadHref"]
+        filename = downloadable_content["filename"]
+
+out = {"url": download_url, "filename": filename}
+print(json.dumps(out))

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -52,6 +52,7 @@ EXCLUDES="$EXCLUDES
           TestMachinesCreate.testConfigureBeforeInstallBios
           TestMachinesCreate.testCreateBasicValidation
           TestMachinesCreate.testCreateNameGeneration
+          TestMachinesCreate.testCreateDownloadRhel
           TestMachinesCreate.testDisabledCreate
 
           TestMachinesConsoles.testExternalConsole

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -701,6 +701,9 @@ vnc_password= "{vnc_passwd}"
         FEDORA_29 = 'Fedora 29'
         FEDORA_29_SHORTID = 'fedora29'
 
+        RHEL_5_0 = 'Red Hat Enterprise Linux 5.0 (Tikanga)'
+        RHEL_5_0_SHORTID = 'rhel5.0'
+
         CENTOS_7 = 'CentOS 7'
 
         MANDRIVA_2011_FILTERED_OS = 'Mandriva Linux 2011'
@@ -734,6 +737,7 @@ vnc_password= "{vnc_passwd}"
                      env_is_empty=True,
                      check_script_finished=True,
                      connection="system",
+                     offline_token=None,
                      pixel_test_tag=None):
 
             TestMachinesCreate.VmDialog.vmId += 1  # This variable is static - don't use self here
@@ -778,6 +782,7 @@ vnc_password= "{vnc_passwd}"
             self.check_script_finished = check_script_finished
             self.connection = connection
             self.name_generated = name_generated
+            self.offline_token = offline_token
 
             self.pixel_test_tag = pixel_test_tag
 
@@ -931,7 +936,8 @@ vnc_password= "{vnc_passwd}"
                 self.browser.click(".pf-c-modal-box__footer button:contains(Create and edit)")
             self.browser.wait_not_present("#create-vm-dialog")
 
-            self.goToVmPage(self.name)
+            if self.create_and_run:
+                self.goToVmPage(self.name)
             self.browser.wait_text(f"#vm-{self.name}-disks-vda-bus", "virtio")
             # A cloud-init NoCloud ISO file is generated, and attached to the VM as a CDROM device.
             self.browser.wait_text(f"#vm-{self.name}-disks-sda-device", "cdrom")
@@ -1028,6 +1034,7 @@ vnc_password= "{vnc_passwd}"
             if not self.name_generated:
                 b.set_input_text("#vm-name", self.name)
 
+            b.wait_not_present("#offline-token")
             if self.os_name:
                 b.click("#os-select-group > div button")
                 b.click(f"#os-select li:contains('{self.os_name}') button")
@@ -1058,6 +1065,9 @@ vnc_password= "{vnc_passwd}"
 
             if self.expected_os_name:
                 b.wait_attr("#os-select-group input", "value", self.expected_os_name)
+
+            if self.sourceType == "os" and self.os_name == TestMachinesCreate.TestCreateConfig.RHEL_5_0:
+                b.set_input_text("#offline-token", self.offline_token)
 
             if self.sourceType != 'disk_image':
                 if not self.expected_storage_size:
@@ -1214,10 +1224,11 @@ vnc_password= "{vnc_passwd}"
 
     class CreateVmRunner:
 
-        def __init__(self, test_obj):
+        def __init__(self, test_obj, rhel_download=False):
             self.browser = test_obj.browser
             self.machine = test_obj.machine
             self.assertTrue = test_obj.assertTrue
+            self.assertRegex = test_obj.assertRegex
             self.test_obj = test_obj
             self.run_admin = test_obj.run_admin
 
@@ -1227,8 +1238,12 @@ vnc_password= "{vnc_passwd}"
                 TestMachinesCreate.TestCreateConfig.NOVELL_MOCKUP_ISO_PATH,
                 TestMachinesCreate.TestCreateConfig.VALID_DISK_IMAGE_PATH))
 
-            self._fakeOsDBInfo()
-            self._fakeFedoraTree()
+            if rhel_download:
+                self._fakeOsDBInfoRhel()
+                self._fakeRhelDownload()
+            else:
+                self._fakeOsDBInfoFedora()
+                self._fakeFedoraTree()
 
             # Make sure we don't run into long DNS timeouts when trying to contact this server
             self.machine.execute("echo >>/etc/hosts 127.0.0.42 mirror.i3d.net")
@@ -1258,11 +1273,7 @@ vnc_password= "{vnc_passwd}"
             ]
             self.machine.execute(" && ".join(cmds))
 
-        def _setupMockFileServer(self):
-            server = setup_mock_server("mock-range-server.py", ["archive.fedoraproject.org"])
-            self.test_obj.addCleanup(self.machine.execute, f"kill {server}")
-
-        def _fakeOsDBInfo(self):
+        def _fakeOsDBInfoFedora(self):
             # Fake the osinfo-db data in order that it will allow spawn the installation - of course we don't expect it to succeed -
             # we just need to check that the VM was spawned
             fedora_28_xml = self.machine.execute("cat /usr/share/osinfo/os/fedoraproject.org/fedora-28.xml")
@@ -1287,8 +1298,21 @@ vnc_password= "{vnc_passwd}"
             self.machine.execute(f"mount -o bind  {self.test_obj.vm_tmpdir}/fedora-29.xml /usr/share/osinfo/os/fedoraproject.org/fedora-29.xml")
             self.test_obj.addCleanup(self.machine.execute, "umount /usr/share/osinfo/os/fedoraproject.org/fedora-29.xml || true")
 
+        def _fakeOsDBInfoRhel(self):
+            # Fake rhel image
+            rhel_5_0_xml = self.machine.execute("cat /usr/share/osinfo/os/redhat.com/rhel-5.0.xml")
+            root = ET.fromstring(rhel_5_0_xml)
+            root.find('os').find('resources').find('minimum').find('ram').text = '134217728'
+            root.find('os').find('resources').find('minimum').find('storage').text = '134217728'
+            root.find('os').find('eol-date').text = '9999-12-31'
+            new_rhel_5_0_xml = ET.tostring(root)
+            self.machine.execute(f"echo '{str(new_rhel_5_0_xml, 'utf-8')}' > {self.test_obj.vm_tmpdir}/rhel-5.0.xml")
+            self.machine.execute(f"mount -o bind  {self.test_obj.vm_tmpdir}/rhel-5.0.xml /usr/share/osinfo/os/redhat.com/rhel-5.0.xml")
+            self.test_obj.addCleanup(self.machine.execute, "umount /usr/share/osinfo/os/redhat.com/rhel-5.0.xml || true")
+
         def _fakeFedoraTree(self):
-            self._setupMockFileServer()
+            server = self.test_obj.setup_mock_server("mock-range-server.py", ["archive.fedoraproject.org"])
+            self.test_obj.addCleanup(self.machine.execute, f"kill {server}")
             distro_tree_path = "/var/lib/libvirt/pub/archive/fedora/linux/releases/28/Server/x86_64/os/"
             self.machine.execute(f"mkdir -p {distro_tree_path}")
             self.machine.upload(["files/fakefedoratree/.treeinfo", "files/fakefedoratree/images"], distro_tree_path)
@@ -1298,6 +1322,10 @@ vnc_password= "{vnc_passwd}"
             else:
                 self.machine.execute(f"cp /boot/vmlinuz-{self.machine.execute('uname -r').rstrip()} {distro_tree_path}images/pxeboot/vmlinuz")
             self.machine.execute("chown -R 777 /var/lib/libvirt/pub")
+
+        def _fakeRhelDownload(self):
+            server = self.test_obj.setup_mock_server("mock-rhsm-rest", ["sso.redhat.com", "api.access.redhat.com"])
+            self.test_obj.addCleanup(self.machine.execute, f"kill {server}")
 
         def _assertVmStates(self, name, connection, before, after):
             b = self.browser
@@ -1324,17 +1352,31 @@ vnc_password= "{vnc_passwd}"
                     b.click(".pf-c-modal-box__footer button:contains(Create and run)")
                 else:
                     b.click(".pf-c-modal-box__footer button:contains(Create and edit)")
-            init_state = "Creating VM installation" if dialog.create_and_run else "Creating VM"
-            second_state = "Running" if dialog.create_and_run else "Shut off"
 
-            # Getting rid of timeouts and unecessary waiting at VM creation dialog at
-            # https://github.com/cockpit-project/cockpit-machines/pull/699
-            # caused the VM creation process to get faster and sometimes tests might
-            # not catch "Creating VM" state.
-            # Therefore, test only for such states for VM which are created and
-            # STARTED IMMEDIATELLY as that causes "creating VM" stage to take longer time.
-            if dialog.create_and_run:
-                self._assertVmStates(dialog.name, dialog.connection, init_state, second_state)
+            final_state = "Running" if dialog.create_and_run else "Shut off"
+            # Test dowloading RHEL image shows the progress of the download
+            if dialog.os_name == TestMachinesCreate.TestCreateConfig.RHEL_5_0:
+                # Check download percantage is shown as a whole number 0-100 followed by '%'
+                if dialog.create_and_run:
+                    b.wait_in_text(f"#vm-{dialog.name}-{dialog.connection}-state", "Downloading")
+                    # Progress is shown in VM state in VMs list
+                    self.assertRegex(b.text(f"#vm-{dialog.name}-{dialog.connection}-state"), r"^.*[0-9][0-9]?%$|^100%$")
+                else:
+                    b.wait_in_text(".pf-c-empty-state__content .pf-c-title", "Downloading image")
+                    # Progress is shown at VM page empty state
+                    self.assertRegex(b.text(".pf-c-empty-state__body .pf-c-progress__status"), r"^[0-9][0-9]?%$|^100%$")
+
+                b.wait_in_text(f"#vm-{dialog.name}-{dialog.connection}-state", final_state)
+            elif dialog.create_and_run:
+                init_state = "Creating VM installation" if dialog.create_and_run else "Creating VM"
+
+                # Getting rid of timeouts and unecessary waiting at VM creation dialog at
+                # https://github.com/cockpit-project/cockpit-machines/pull/699
+                # caused the VM creation process to get faster and sometimes tests might
+                # not catch "Creating VM" state.
+                # Therefore, test only for such states for VM which are created and
+                # STARTED IMMEDIATELLY as that causes "creating VM" stage to take longer time.
+                self._assertVmStates(dialog.name, dialog.connection, init_state, final_state)
             b.wait_not_present("#create-vm-dialog")
 
         def _tryCreate(self, dialog, generated_name=None):
@@ -1426,7 +1468,10 @@ vnc_password= "{vnc_passwd}"
 
             # check bus type
             if dialog.storage_pool != "NoStorage":
-                b.wait_in_text(f"#vm-{name}-disks-vda-bus", "virtio")
+                if dialog.os_name == TestMachinesCreate.TestCreateConfig.RHEL_5_0:
+                    b.wait_in_text(f"#vm-{name}-disks-hda-bus", "ide")
+                else:
+                    b.wait_in_text(f"#vm-{name}-disks-vda-bus", "virtio")
             # check memory
             # adjust to how cockpit_format_bytes() formats sizes > 1024 MiB -- this depends on how much RAM
             # the host has (less or more than 1 GiB), and thus needs to be dynamic
@@ -1438,7 +1483,7 @@ vnc_password= "{vnc_passwd}"
 
             # check disks
             # Test disk got imported/created
-            if dialog.sourceType == 'disk_image':
+            if dialog.sourceType == 'disk_image' or (dialog.os_name == TestMachinesCreate.TestCreateConfig.RHEL_5_0):
                 b.wait_visible(".disks-card table tbody > tr:first-child")
                 if b.is_present(f"#vm-{name}-disks-vda-device"):
                     b.wait_in_text(f"#vm-{name}-disks-vda-source-file", dialog.location)
@@ -1810,6 +1855,48 @@ vnc_password= "{vnc_passwd}"
         # no explicit "firmware=" field
         self.assertIn("<os>", domainXML)
         self.assertNotIn("efi", domainXML)
+
+    def testCreateDownloadRhel(self):
+        runner = TestMachinesCreate.CreateVmRunner(self, rhel_download=True)
+        config = TestMachinesCreate.TestCreateConfig
+
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/machines")
+        b.wait_in_text("body", "Virtual machines")
+
+        m.execute(f"qemu-img create {TestMachinesCreate.TestCreateConfig.VALID_DISK_IMAGE_PATH} 500M")
+
+        runner.checkDialogErrorTest(TestMachinesCreate.VmDialog(self, sourceType='os',
+                                                                os_name=config.RHEL_5_0,
+                                                                os_short_id=config.RHEL_5_0_SHORTID,
+                                                                offline_token="invalid_token",
+                                                                create_and_run=True),
+                                    ["404"])
+
+        runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='os',
+                                                      os_name=config.RHEL_5_0,
+                                                      os_short_id=config.RHEL_5_0_SHORTID,
+                                                      offline_token="my_offline_token",
+                                                      create_and_run=False))
+
+        m.execute("rm /var/lib/libvirt/images/rhel-5-0-boot.iso")
+
+        runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='os',
+                                                      os_name=config.RHEL_5_0,
+                                                      os_short_id=config.RHEL_5_0_SHORTID,
+                                                      offline_token="my_offline_token",
+                                                      create_and_run=True))
+
+        # If run on different connection, the downloaded iso should be stored in ~/.local/share/libvirt/images/
+        runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='os',
+                                                      os_name=config.RHEL_5_0,
+                                                      os_short_id=config.RHEL_5_0_SHORTID,
+                                                      offline_token="my_offline_token",
+                                                      create_and_run=True,
+                                                      connection="session"),
+                          check_env_empty=False)
 
 
 if __name__ == '__main__':

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -22,6 +22,7 @@ import xml.etree.ElementTree as ET
 import os
 import sys
 import math
+import re
 from datetime import datetime
 
 # import Cockpit's machinery for test VMs and its browser test API
@@ -795,8 +796,10 @@ vnc_password= "{vnc_passwd}"
                 b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Create new virtual machine")
 
             if self.os_name is not None:
+                # remove os codename from os name, e.g.: 'bullseye' in 'Debian 11 (bullseye)'
+                query_result = re.sub(r" \(.*\)", "", self.os_name)
+                query_result = f'{query_result}'
                 # check if there is os present in osinfo-query because it can be filtered out in the UI
-                query_result = f'{self.os_name}'
                 # throws exception if grep fails
                 self.machine.execute(
                     r"osinfo-query os --fields=name | tail -n +3 | sed -e 's/\s*|\s*/|/g; s/^\s*//g; s/\s*$//g' | grep '{0}'".format(

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1256,40 +1256,7 @@ vnc_password= "{vnc_passwd}"
             self.machine.execute(" && ".join(cmds))
 
         def _setupMockFileServer(self):
-            self.machine.upload(["files/min-openssl-config.cnf", "files/mock-range-server.py"], self.test_obj.vm_tmpdir)
-            cmds = [
-                # Generate certificate for https server
-                f"cd {self.test_obj.vm_tmpdir}",
-                "openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -subj '/CN=archive.fedoraproject.org' -nodes -config {0}/min-openssl-config.cnf".format(
-                    self.test_obj.vm_tmpdir),
-                "cat cert.pem key.pem > server.pem"
-            ]
-
-            if self.machine.image.startswith("ubuntu") or self.machine.image.startswith("debian"):
-                cmds += [
-                    f"cp {self.test_obj.vm_tmpdir}/cert.pem /usr/local/share/ca-certificates/cert.crt",
-                    "update-ca-certificates"
-                ]
-            elif self.machine.image.startswith("arch"):
-                cmds += [
-                    f"cp {self.test_obj.vm_tmpdir}/cert.pem /etc/ca-certificates/trust-source/anchors/cert.pem",
-                    "update-ca-trust"
-                ]
-            else:
-                cmds += [
-                    f"cp {self.test_obj.vm_tmpdir}/cert.pem /etc/pki/ca-trust/source/anchors/cert.pem",
-                    "update-ca-trust"
-                ]
-            self.machine.execute(" && ".join(cmds))
-
-            # Run https server with range option support. QEMU uses range option
-            # see: https://lists.gnu.org/archive/html/qemu-devel/2013-06/msg02661.html
-            # or
-            # https://github.com/qemu/qemu/blob/master/block/curl.c
-            #
-            # and on certain distribution supports only https (not http)
-            # see: block-drv-ro-whitelist option in qemu-kvm.spec for certain distribution
-            server = self.machine.spawn("cd /var/lib/libvirt && exec python3 {0}/mock-range-server.py {0}/server.pem".format(self.test_obj.vm_tmpdir), "httpsserver")
+            server = setup_mock_server("mock-range-server.py", ["archive.fedoraproject.org"])
             self.test_obj.addCleanup(self.machine.execute, f"kill {server}")
 
         def _fakeOsDBInfo(self):
@@ -1328,8 +1295,6 @@ vnc_password= "{vnc_passwd}"
             else:
                 self.machine.execute(f"cp /boot/vmlinuz-{self.machine.execute('uname -r').rstrip()} {distro_tree_path}images/pxeboot/vmlinuz")
             self.machine.execute("chown -R 777 /var/lib/libvirt/pub")
-            self.test_obj.restore_file("/etc/hosts")
-            self.machine.execute('echo "127.0.0.1 archive.fedoraproject.org" >> /etc/hosts')
 
         def _assertVmStates(self, name, connection, before, after):
             b = self.browser

--- a/test/files/min-openssl-config.cnf
+++ b/test/files/min-openssl-config.cnf
@@ -2,9 +2,10 @@
 
 [ req ]
 distinguished_name = dn
+prompt = no
 
 [ dn ]
-basicConstraints = CA:FALSE
+basicConstraints = CA:TRUE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 subjectAltName = @alt_names
 

--- a/test/files/mock-range-server.py
+++ b/test/files/mock-range-server.py
@@ -86,5 +86,5 @@ class RangeHTTPRequestHandler(SimpleHTTPRequestHandler):
 
 if __name__ == '__main__':
     httpd = HTTPServer(('localhost', 443), RangeHTTPRequestHandler)
-    httpd.socket = ssl.wrap_socket(httpd.socket, certfile=sys.argv[1], server_side=True)
+    httpd.socket = ssl.wrap_socket(httpd.socket, certfile=sys.argv[1], keyfile=sys.argv[2], server_side=True)
     httpd.serve_forever()

--- a/test/files/mock-rhsm-rest
+++ b/test/files/mock-rhsm-rest
@@ -1,0 +1,60 @@
+#! /usr/bin/python3
+
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import re
+import ssl
+import os
+import shutil
+import sys
+
+
+class handler(BaseHTTPRequestHandler):
+    def match(self, p):
+        return re.fullmatch(p, self.path)
+
+    def do_POST(self):
+        data = self.rfile.read(int(self.headers['Content-Length']))
+        m = self.match("/auth/realms/redhat-external/protocol/openid-connect/token")
+        if m and data == b'grant_type=refresh_token&client_id=rhsm-api&refresh_token=my_offline_token':
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'{ "access_token": "my_access_token" }\n')
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+    def do_GET(self):
+        authorization = self.headers['Authorization']
+        m = self.match("/management/v1/images/rhel/.*/.*")
+
+        if m and authorization == 'Bearer my_access_token':
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'{ "body": [\
+                {"imageName": "RHEL 5.0 Boot ISO", "filename": "rhel-5-0-boot.iso",\
+                "downloadHref": "https://api.access.redhat.com/management/v1/images/my_image_checksum/download"}\
+            ] }\n')
+            return
+
+        m = self.match("/management/v1/images/my_image_checksum/download")
+        if m and authorization == 'Bearer my_access_token':
+            filepath = "/var/lib/libvirt/images/example.img"
+            with open(filepath, 'rb') as f:
+                self.send_response(200)
+                self.send_header("Content-Type", 'application/octet-stream')
+                self.send_header("Content-Disposition", f"attachment; filename='{os.path.basename(filepath)}'")
+                fs = os.fstat(f.fileno())
+                self.send_header("Content-Length", str(fs.st_size))
+                self.end_headers()
+                shutil.copyfileobj(f, self.wfile, 10240)  # Specify 1KiB buffer size, otherwise the download might be too fast on some platforms
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+
+if __name__ == '__main__':
+    httpd = HTTPServer(('', 443), handler)
+    httpd.socket = ssl.wrap_socket(httpd.socket, certfile=sys.argv[1], keyfile=sys.argv[2], server_side=True)
+    httpd.serve_forever()


### PR DESCRIPTION
TODO list (some of it may go to follow-up PRs):
 - [ ] Store offline token for 30 days, so user doesn't have to retype it everytime they want to create a new RHEL VM
 - [ ] Refresh available RHEL versions based on supplied token
 - [ ] Check for validity of  offline token immediately after user supplies it
 - [ ] Add an option to cancel the ongoing image download
 - [ ] Handle download interruption
 - [ ] Add option to remove downloaded the image
 - [x] Have concensus on image download location (consensus: libvirt default storage pool at /var/lib/libvirt/images)
 - [x] tests

## Machines: Download RHEL images

You can now create Red Hat Enterprise Linux VMs. The dialog guides you to the page where you can get a download token for your Red Hat subscription, and uses that to download the VM image.

![download rhel images](https://user-images.githubusercontent.com/42733240/170017615-35b70dc6-02dc-4e6d-93ff-84889faae79b.png)