### PR TITLE
fmf: qemu-virtiofsd does not exist on RHEL 9

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -75,8 +75,8 @@ if [ "${PLATFORM_ID:-}" != "platform:f34" ] && [ "${PLATFORM_ID:-}" != "platform
     systemctl start virtstoraged.socket
 fi
 
-# Fedora 36/37 and RHEL 9 split out qemu-virtiofsd; once this is in all supported OSes, move to main.fmf
-if [ "${PLATFORM_ID:-}" != "platform:f35" ] && [ "${PLATFORM_ID:-}" != "platform:el8" ]; then
+# Fedora 36+ split out qemu-virtiofsd
+if [ "$ID" = fedora ] && [ "$VERSION_ID" -ge "36" ]; then
     dnf install -y qemu-virtiofsd
 fi
 


### PR DESCRIPTION
The functionality is merged into the qemu-kvm package there. So only
install it for Fedora ≥ 36.

---

This broke [gating on RHEL 9.1](https://dashboard.osci.redhat.com/#/artifact/brew-build/aid/45292119) (only visible inside Red Hat, sorry).