### PR TITLE
Allow changing firmware after importing VM

### DIFF
--- a/src/components/vm/overview/firmware.jsx
+++ b/src/components/vm/overview/firmware.jsx
@@ -105,6 +105,7 @@ export const FirmwareLink = ({ vm, loaderElems, idPrefix }) => {
 
     let firmwareLinkWrapper;
     const hasInstallPhase = vm.metadata && vm.metadata.hasInstallPhase;
+    const sourceType = vm.metadata && vm.metadata.installSourceType;
     const labelForFirmware = labelForFirmwarePath(vm.loader, vm.arch);
     let currentFirmware;
 
@@ -117,8 +118,8 @@ export const FirmwareLink = ({ vm, loaderElems, idPrefix }) => {
     else
         currentFirmware = "BIOS";
 
-    /* If the VM hasn't an install phase then don't show a link, just the text  */
-    if (!domainCanInstall(vm.state, hasInstallPhase)) {
+    /* If the VM hasn't an install phase and the VM was not imported then don't show a link, just the text */
+    if (!domainCanInstall(vm.state, hasInstallPhase) && sourceType !== "disk_image") {
         firmwareLinkWrapper = <div id={`${idPrefix}-firmware`}>{currentFirmware}</div>;
     } else {
         const uefiPaths = getOVMFBinariesOnHost(loaderElems).filter(elem => elem !== undefined);

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1428,9 +1428,15 @@ vnc_password= "{vnc_passwd}"
 
             vm_state = b.text(f"#vm-{name}-{connection}-state")
 
+            # check firmware configuration is available after importing and/or before installing VM
+            if vm_state != "Running" and (dialog.sourceType == "disk_image" or not dialog.create_and_run):
+                b.wait_visible(f"button#vm-{name}-firmware")
+            else:
+                b.wait_not_present(f"button#vm-{name}-firmware")
+
             # check bus type
             if dialog.storage_pool != "NoStorage":
-                self.browser.wait_in_text(f"#vm-{name}-disks-vda-bus", "virtio")
+                b.wait_in_text(f"#vm-{name}-disks-vda-bus", "virtio")
             # check memory
             # adjust to how cockpit_format_bytes() formats sizes > 1024 MiB -- this depends on how much RAM
             # the host has (less or more than 1 GiB), and thus needs to be dynamic


### PR DESCRIPTION
The reason why we disable the ability to change the firmware of an already installed VM is to prevent users from converting VM from one firmware to another, as that is a complex process that is not yet supported by the cockpit.
But we didn't take into account imported VMs when the user imports VM with different firmware than default and just wants to set the correct firmware. In this case, no conversion takes place, so this should be an exception where changing firmware on an already installed VM should be allowed.

Fixes: #702