### PR TITLE
Show PCI device's slot as one combined string in bootorder dialog

### DIFF
--- a/src/components/vm/overview/bootOrder.jsx
+++ b/src/components/vm/overview/bootOrder.jsx
@@ -48,6 +48,7 @@ import {
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
 import {
     findMatchingNodeDevices,
+    getNodeDevSource,
     getSortedBootOrderDevices,
     rephraseUI,
     vmId
@@ -154,10 +155,7 @@ const DeviceRow = ({ idPrefix, device, index, onToggle, upDisabled, downDisabled
                 addOptional(additionalInfo, device.device.type, _("Type"));
                 addOptional(additionalInfo, nodeDev.capability.vendor._value, _("Vendor"));
                 addOptional(additionalInfo, nodeDev.capability.product._value, _("Product"));
-                addOptional(additionalInfo, nodeDev.capability.bus, _("Bus"));
-                addOptional(additionalInfo, nodeDev.capability.domain, _("Domain"));
-                addOptional(additionalInfo, nodeDev.capability.function, _("Function"));
-                addOptional(additionalInfo, nodeDev.capability.slot, _("Slot"));
+                addOptional(additionalInfo, getNodeDevSource(nodeDev), _("Slot"));
                 break;
             }
             case "scsi": {

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -265,9 +265,10 @@ class TestMachinesSettings(VirtualMachinesCase):
 
     def testBootOrder(self):
         b = self.browser
+        m = self.machine
 
         args = self.createVm("subVmTest1")
-        self.machine.execute("touch /var/lib/libvirt/images/phonycdrom; virsh attach-disk subVmTest1 /var/lib/libvirt/images/phonycdrom sdb --type cdrom --config")
+        m.execute("touch /var/lib/libvirt/images/phonycdrom; virsh attach-disk subVmTest1 /var/lib/libvirt/images/phonycdrom sdb --type cdrom --config")
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual machines")
@@ -283,6 +284,21 @@ class TestMachinesSettings(VirtualMachinesCase):
         b.wait_visible("#vm-subVmTest1-boot-order button[aria-disabled=true]")
         self.performAction("subVmTest1", "forceOff")
 
+        # No host device is attached to VM by default, so attach a PCI device to have at least 1 host device in boot order
+        # Take a device from the end of the list, since first device might be a root pci device
+        pci_output = m.execute("virsh nodedev-list --cap pci").strip().splitlines()[-1]
+        m.execute("virsh nodedev-list --cap pci").strip()
+        m.execute("virsh nodedev-list --cap pci").strip().splitlines()
+        m.execute("virsh nodedev-list --cap pci").strip().splitlines()[-1]
+        # Turn 'pci_0123_45_67_8' into '0123:45:67.8'
+        split = pci_output[len("pci_"):].split('_')
+        pci_slot = f"{split[0]}:{split[1]}:{split[2]}.{split[3]}"
+        m.execute(f"virt-xml subVmTest1 --add-device --hostdev {pci_slot}")
+
+        # Older libvirt versions don't fire events for host device attachement so we have to reload the page
+        b.reload()
+        b.enter_page('/machines')
+
         # Open dialog
         b.click("#vm-subVmTest1-boot-order button")
         b.wait_visible("#vm-subVmTest1-order-modal-window")
@@ -290,9 +306,10 @@ class TestMachinesSettings(VirtualMachinesCase):
         # Checking the VM system disk path is the same with virsh command results
         # Checking the VM MAC address is the same with virsh command results
         b.wait_in_text("#vm-subVmTest1-order-modal-device-row-0 .boot-order-additional-info",
-                       self.machine.execute("virsh domblklist subVmTest1 | awk 'NR==3{print $2}'").strip())
+                       m.execute("virsh domblklist subVmTest1 | awk 'NR==3{print $2}'").strip())
         b.wait_in_text("#vm-subVmTest1-order-modal-device-row-1 .boot-order-additional-info",
-                       self.machine.execute("virsh domiflist subVmTest1 | awk 'NR==3{print $5}'").strip())
+                       m.execute("virsh domiflist subVmTest1 | awk 'NR==3{print $5}'").strip())
+        b.wait_visible(f".boot-order-additional-info .pf-c-description-list__description:contains('{pci_slot}')")
         # Check a cdrom attributes are shown correctly
         cdrom_row = b.text(".boot-order-list-view li:nth-child(3) .boot-order-additional-info")
         self.assertTrue("cdrom" and "/var/lib/libvirt/images/phonycdrom" in cdrom_row)


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2033599