### PR TITLE
workflows: Tag our releases in node-cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,3 +29,35 @@ jobs:
         uses: cockpit-project/action-release@62db9d9850a1adec300500d84035c4f523fd5290
         with:
           filename: "cockpit-machines-${{ github.ref_name }}.tar.xz"
+
+  node-cache:
+    # doesn't depend on it, but let's make sure the build passes before we do this
+    needs: [source]
+    runs-on: ubuntu-latest
+    environment: node-cache
+    # done via deploy key, token needs no write permissions at all
+    permissions: {}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Set up git
+        run: |
+            git config user.name "GitHub Workflow"
+            git config user.email "cockpituous@cockpit-project.org"
+
+      - name: Tag node-cache
+        run: |
+          set -eux
+          # this is a shared repo, prefix with project name
+          TAG="${GITHUB_REPOSITORY#*/}-$(basename $GITHUB_REF)"
+          tools/node-modules checkout
+          cd node_modules
+          git tag "$TAG"
+          git remote add cache "ssh://git@github.com/${GITHUB_REPOSITORY%/*}/node-cache"
+          eval $(ssh-agent)
+          ssh-add - <<< '${{ secrets.DEPLOY_KEY }}'
+          # make this idempotent: delete an existing tag
+          git push cache :"$TAG" || true
+          git push cache tag "$TAG"
+          ssh-add -D


### PR DESCRIPTION
Unmodified copy from cockpit.git. Copying this is a bit awkward, but
let's discuss how we can share these (composite actions or otherwise)
without time pressure.