### PR TITLE
fmf: Drop test/common and test/reference setup

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -5,7 +5,7 @@ set -eux
 cd $SOURCE
 git init
 rm -f bots  # common local case: existing bots symlink
-make bots test/common test/reference
+make bots
 
 # support running from clean git tree
 if [ ! -d node_modules/chrome-remote-interface ]; then


### PR DESCRIPTION
We don't actually want to do pixel tests on the testing farm, and this
breaks tmt source tarball test discovery.

Also, since 270.1, test/common/ is part of the upstream tarball, so we
can drop this as well.

----
See [this failure](https://artifacts.dev.testing-farm.io/19fba485-ad09-43ce-ac92-9b607b96ac4b/) in https://src.fedoraproject.org/rpms/cockpit-machines/pull-request/4# . c-podman does not do this either, and works fine.