### PR TITLE
packit: Drop FMF hack, enable downstream job notifications

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -7,23 +7,12 @@ downstream_package_name: cockpit-machines
 # use the nicely formatted release description from our upstream release, instead of git shortlog
 copy_upstream_release_description: true
 
-# HACK: packit.yml and spec get synced by default; drop this when the plans/upstream.fmf HACK above gets dropped
-files_to_sync:
-  - packit.yaml
-  - cockpit-machines.spec
-  - src: tmp/upstream.fmf
-    dest: plans/upstream.fmf
-
 srpm_build_deps:
 - npm
 - make
 
 actions:
-  post-upstream-clone:
-    - make cockpit-machines.spec
-    # HACK: until FMF uses tests from dist-git source tarball: https://github.com/teemtee/tmt/issues/585
-    - sh -exc 'mkdir -p tmp; curl --silent --fail https://src.fedoraproject.org/rpms/cockpit-machines/raw/rawhide/f/plans/upstream.fmf | sed -r "/ref:/ s/[0-9.]+/$(git describe --abbrev=0)/" > tmp/upstream.fmf'
-
+  post-upstream-clone: make cockpit-machines.spec
   create-archive: make dist
 
 jobs:

--- a/packit.yaml
+++ b/packit.yaml
@@ -1,4 +1,6 @@
 upstream_project_url: https://github.com/cockpit-project/cockpit-machines
+# enable notification of failed downstream jobs as issues
+issue_repository: https://github.com/cockpit-project/cockpit-machines
 specfile_path: cockpit-machines.spec
 upstream_package_name: cockpit-machines
 downstream_package_name: cockpit-machines


### PR DESCRIPTION
tmt 1.14.0 can finally discover tests from the dist-git source, instead
of having them to checkout from upstream git.

https://src.fedoraproject.org/rpms/cockpit-machines/pull-request/4
dropped the hardcoded `ref:`, so we can drop all that hackery.
