### PR TITLE
test: allow targetctl failing to pass on Fedora

### DIFF
--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -197,7 +197,9 @@ class VirtualMachinesCaseHelpers:
                   targetcli /iscsi/%(tgt)s/tpg1/acls create %(ini)s
                   """ % {"tgt": target_iqn, "ini": orig_iqn})
 
-        self.addCleanup(m.execute, "targetcli /backstores/ramdisk delete test && targetcli /iscsi delete %s && (iscsiadm -m node -o delete || true)" % target_iqn)
+        # targetcli throws an error but succeeds https://bugzilla.redhat.com/show_bug.cgi?id=2093976
+        self.addCleanup(m.execute, "targetcli /backstores/ramdisk delete test" + (" || true" if m.image.startswith("fedora") else ""))
+        self.addCleanup(m.execute, "targetcli /iscsi delete %s && (iscsiadm -m node -o delete || true)" % target_iqn)
         return orig_iqn
 
     def run_admin(self, cmd, connectionName='system'):


### PR DESCRIPTION
Work around targetcli erroring out but cleaning up the test ramdisk due
to https://bugzilla.redhat.com/show_bug.cgi?id=2093976