### PR TITLE
Robustify OS name sorting in VM creation dialog

### DIFF
--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -379,13 +379,20 @@ class OSRow extends React.Component {
                 .map(os => correctSpecialCases(os))
                 .filter(os => filterReleaseEolDates(os) && !IGNORE_VENDORS.find(vendor => vendor == os.vendor))
                 .sort((a, b) => {
-                    if (a.vendor == b.vendor)
-                        if (a.releaseDate || b.releaseDate)
+                    if (a.vendor == b.vendor) {
+                        // Sort OS with numbered version by version
+                        if ((a.version && b.version) && (a.version !== b.version))
+                            return b.version.localeCompare(a.version, undefined, { numeric: true, sensitivity: 'base' });
+                        // Sort OS with non-numbered version (e.g. "testing", "rawhide") by release date
+                        else if ((a.releaseDate || b.releaseDate) && (a.releaseDate !== b.releaseDate))
                             return compareDates(a.releaseDate, b.releaseDate, true) > 0;
-                        else
-                            return a.version < b.version;
-                    else
-                        return getOSStringRepresentation(a).toLowerCase() > getOSStringRepresentation(b).toLowerCase();
+
+                        // Sort OSes of the same vendor in DESCENDING order
+                        return getOSStringRepresentation(a).toLowerCase() < getOSStringRepresentation(b).toLowerCase() ? 1 : -1;
+                    }
+
+                    // Sort different vendors in ASCENDING order
+                    return getOSStringRepresentation(a).toLowerCase() > getOSStringRepresentation(b).toLowerCase() ? 1 : -1;
                 });
 
         this.state = {

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -98,6 +98,9 @@ class TestMachinesCreate(VirtualMachinesCase):
         # check that newer oses are present and searchable with substring match
         runner.checkFilteredOsTest(TestMachinesCreate.VmDialog(self, os_name=config.WINDOWS_SERVER_10, os_search_name=config.WINDOWS_SERVER_10_SHORT))
 
+        # check OS versons are sorted in alphabetical order
+        runner.checkSortedOsTest(TestMachinesCreate.VmDialog(self), [config.FEDORA_29, config.FEDORA_28])
+
         # Memory unit conversion
         runner.unitPredictionTest(TestMachinesCreate.VmDialog(self, sourceType='disk-image'))
 
@@ -694,6 +697,9 @@ vnc_password= "{vnc_passwd}"
         FEDORA_28 = 'Fedora 28'
         FEDORA_28_SHORTID = 'fedora28'
 
+        FEDORA_29 = 'Fedora 29'
+        FEDORA_29_SHORTID = 'fedora29'
+
         CENTOS_7 = 'CentOS 7'
 
         MANDRIVA_2011_FILTERED_OS = 'Mandriva Linux 2011'
@@ -897,6 +903,17 @@ vnc_password= "{vnc_passwd}"
                     raise AssertionError(f"{self.os_name} was not filtered")
             else:
                 b.wait_visible(f"#os-select li button:contains({self.os_search_name})")
+
+        def checkOsSorted(self, sorted_list):
+            b = self.browser
+
+            b.click("#os-select-group .pf-c-select .pf-c-button")
+
+            # Find the first OS from the sorted list, and get a text of it's next neighbour
+            next_os = b.text(f"#os-select-group li:contains({sorted_list[0]}) + li")
+            # The next neighbour should contain the second OS from the sorted list
+            self.assertEqual(next_os, sorted_list[1])
+            return self
 
         def checkPXENotAvailableSession(self):
             self.browser.set_checked(f"#connectionName-{self.connection}", True)
@@ -1586,6 +1603,13 @@ vnc_password= "{vnc_passwd}"
             dialog.open() \
                 .checkOsFiltered() \
                 .assert_pixels() \
+                .cancel(True)
+            self._assertScriptFinished() \
+                .checkEnvIsEmpty()
+
+        def checkSortedOsTest(self, dialog, sorted_list):
+            dialog.open() \
+                .checkOsSorted(sorted_list) \
                 .cancel(True)
             self._assertScriptFinished() \
                 .checkEnvIsEmpty()


### PR DESCRIPTION
Split from https://github.com/cockpit-project/cockpit-machines/pull/704

- OS version now has higher priority in sorting than release date
  (It solves the problem when OS of lower version, e.g. rhel-8.11,
   is released later than OS of higher version, e.g. rhel-9.0)
- If neither os version or release date are present, or both are the
  same, sort by by OS name shown in the UI
  (e.g. centos-8 and centos-8-stream have the same version and release
   date, so the only sensible thing left to do is to sort by their name)