### PR TITLE
test: increase test timeout

### DIFF
--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -18,4 +18,4 @@ require:
   - libvirt-daemon-driver-storage-logical
   - targetcli
 test: ./browser.sh
-duration: 50m
+duration: 60m


### PR DESCRIPTION
Fedora Rawhide timeouts now on 50 minutes, we already skipped two tests
in 7972eb8ae4985bede952 which did not improve the situation. This makes
the timeout the same as cockpit-podman.