### PR TITLE
Show toast notication if VM's storage deletion fails

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -194,7 +194,7 @@ class AppActive extends React.Component {
 
     getInlineNotifications(notifications) {
         return notifications.map((notification, index) =>
-            <InlineNotification type='danger' key={index}
+            <InlineNotification type={notification.type || 'danger'} key={index}
                 isLiveRegion
                 isInline={false}
                 onDismiss={() => this.onDismissErrorNotification(index)}

--- a/src/components/vm/deleteDialog.jsx
+++ b/src/components/vm/deleteDialog.jsx
@@ -94,10 +94,10 @@ const DeleteDialogBody = ({ disks, vmName, destroy, onChange }) => {
         );
 
     return (
-        <div className="modal-body">
+        <>
             {alert}
             {disksBody}
-        </div>
+        </>
     );
 };
 

--- a/src/components/vm/deleteDialog.jsx
+++ b/src/components/vm/deleteDialog.jsx
@@ -23,6 +23,7 @@ import {
     Button,
     DataList, DataListItem, DataListItemRow, DataListCheck, DataListItemCells, DataListCell,
     Form,
+    FormGroup,
     Modal
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
@@ -78,27 +79,17 @@ const DeleteDialogBody = ({ disks, vmName, destroy, onChange }) => {
         );
     }
 
-    let alert = null;
-    if (destroy)
-        alert = <p>{cockpit.format(_("The VM $0 is running and will be forced off before deletion."), vmName)}</p>;
-
-    let disksBody = null;
-    if (disks.length > 0)
-        disksBody = (
-            <Form onSubmit={e => e.preventDefault()}>
-                <p>{_("Delete associated storage files:")}</p>
+    return (<Form onSubmit={e => e.preventDefault()}>
+        <FormGroup>
+            {destroy && <p>{cockpit.format(_("The VM $0 is running and will be forced off before deletion."), vmName)}</p>}
+            {disks.length > 0 && <>
+                <p className="pf-u-mb-sm">{_("Delete associated storage files:")}</p>
                 <DataList isCompact>
                     { disks.map(disk_row) }
                 </DataList>
-            </Form>
-        );
-
-    return (
-        <>
-            {alert}
-            {disksBody}
-        </>
-    );
+            </>}
+        </FormGroup>
+    </Form>);
 };
 
 export class DeleteDialog extends React.Component {

--- a/src/components/vm/vmActions.jsx
+++ b/src/components/vm/vmActions.jsx
@@ -355,7 +355,7 @@ const VmActions = ({ vm, onAddErrorNotification, isDetailsPage }) => {
         } else {
             dropdownItems.push(
                 <DropdownItem className='pf-m-danger' key={`${id}-delete`} id={`${id}-delete`}
-                              onClick={() => Dialogs.show(<DeleteDialog vm={vm} />)}>
+                              onClick={() => Dialogs.show(<DeleteDialog vm={vm} onAddErrorNotification={onAddErrorNotification} />)}>
                     {_("Delete")}
                 </DropdownItem>
             );

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -434,14 +434,14 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         name = "vm-keep-vol"
         args = self.createVm(name)
         self.waitVmRow(name)
-        wait(lambda: "vm-keep-vol" in m.execute("virsh list --all --name"))
+        wait(lambda: name in m.execute("virsh list --all --name"))
 
         self.performAction(name, "delete")
         b.set_checked(f"#vm-{name}-delete-modal-dialog input[type=checkbox]", False)
         b.click(f"#vm-{name}-delete-modal-dialog button:contains(Delete)")
 
         self.waitVmRow(name, present=False)
-        wait(lambda: "vm-keep-vol" not in m.execute("virsh list --all --name"))
+        wait(lambda: name not in m.execute("virsh list --all --name"))
         m.execute(f"test -f {args['image']}")
 
         # Try to delete a transient VM
@@ -454,6 +454,28 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         b.click(f"#vm-{name}-system-forceOff")
         self.waitVmRow(name, 'system', False)
         b.wait_not_present(f'#vm-{name}-system-state button:contains("view more")')
+
+        # Try to delete a VM where storage deletion will fail
+        name = "vm-fail-storage-deletion"
+        args = self.createVm(name)
+        self.waitVmRow(name)
+        wait(lambda: name in m.execute("virsh list --all --name"))
+        # Remove VM's disk from command line
+        m.execute(f"rm {args['image']}")
+
+        self.performAction(name, "delete")
+        b.set_checked(f"#vm-{name}-delete-modal-dialog input[type=checkbox]", True)
+        b.click(f"#vm-{name}-delete-modal-dialog button:contains(Delete)")
+
+        # Check VM got deleted, but there is a warning about unsuccessful storage deletion
+        self.waitVmRow(name, present=False)
+        wait(lambda: name not in m.execute("virsh list --all --name"))
+        b.wait_visible(".pf-c-alert-group li .pf-c-alert")
+        b.wait_in_text(".pf-c-alert-group li .pf-c-alert .pf-c-alert__title", f"Storage of VM {name} failed to get deleted")
+        b.click("button.alert-link.more-button")
+        b.wait_in_text(".pf-c-alert-group li .pf-c-alert .pf-c-alert__description", args['image'])
+        # Close the notification
+        b.click(".pf-c-alert-group li .pf-c-alert button.pf-m-plain")
 
         # Delete a shut-off guest and verify the storage was removed
         name = "vm-shutoff"

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -373,7 +373,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
 
         self.performAction(name, "delete")
 
-        b.wait_visible(f"#vm-{name}-delete-modal-dialog .modal-body:contains(The VM {name} is running)")
+        b.wait_visible(f"#vm-{name}-delete-modal-dialog .pf-c-modal-box__body:contains(The VM {name} is running)")
         b.wait_visible(f"#vm-{name}-delete-modal-dialog ul li:first-child .disk-source-file:contains({img2})")
         # virsh attach-disk does not create disks of type volume
         b.wait_visible(f"#vm-{name}-delete-modal-dialog .disk-source-volume:contains({secondDiskVolName})")

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -471,7 +471,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         self.waitVmRow(name, present=False)
         wait(lambda: name not in m.execute("virsh list --all --name"))
         b.wait_visible(".pf-c-alert-group li .pf-c-alert")
-        b.wait_in_text(".pf-c-alert-group li .pf-c-alert .pf-c-alert__title", f"Storage of VM {name} failed to get deleted")
+        b.wait_in_text(".pf-c-alert-group li .pf-c-alert .pf-c-alert__title", f"Could not delete storage for {name}")
         b.click("button.alert-link.more-button")
         b.wait_in_text(".pf-c-alert-group li .pf-c-alert .pf-c-alert__description", args['image'])
         # Close the notification


### PR DESCRIPTION
Show toast notication if VM's storage deletion fails

If VM deletion fails user is shown an error message in the VM deletion
dialog. But if VM deletion passes, but subsequent deletion of its
storage fails, there is no error message shown, as the VM along with
its dialog is already deleted and a VM deletion dialog unmounted from
the UI.
Fix this by adding a warning message about unsuccessful storage deletion
to the toast alerts.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2105984
