### PR TITLE
tests: Adjust for RHEL 9.1 getting virt-manager 4.0

### DIFF
--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -34,7 +34,7 @@ from testlib import nondestructive, wait, test_main  # noqa
 
 # virt-install changed the default to "host-passthrough"
 # https://github.com/virt-manager/virt-manager/commit/2c477f330244e04614e174f50fbf37260c535705
-distrosWithDefaultHostModel = ["fedora-35", "rhel-8-6", "rhel-8-7", "rhel-9-0", "rhel-9-1", "centos-8-stream",
+distrosWithDefaultHostModel = ["fedora-35", "rhel-8-6", "rhel-8-7", "rhel-9-0", "centos-8-stream",
                                "ubuntu-stable", "debian-stable"]
 
 


### PR DESCRIPTION
This changed the default host model.

---

Needs to land in lockstep with https://github.com/cockpit-project/bots/pull/3616