### PR TITLE
Show warning about user password being empty when user login is set

### DIFF
--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -606,6 +606,7 @@ const UsersConfigurationRow = ({
             {showUserFields &&
             <>
                 <FormGroup fieldId="user-login"
+                           id="create-vm-dialog-user-login-group"
                            helperTextInvalid={validationFailed.userLogin}
                            validated={validationFailed.userLogin ? "error" : "default"}
                            label={_("User login")}>

--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -620,7 +620,7 @@ const UsersConfigurationRow = ({
                                     idPrefix="create-vm-dialog-user-password"
                                     password_message={user_pwd_message}
                                     password_label_info={_("Leave the password blank if you do not wish to have a user account created")}
-                                    error_password={validationFailed && (validationFailed.userLogin ? validationFailed.userLogin : user_pwd_errors.password)}
+                                    error_password={validationFailed && (validationFailed.userPassword ? validationFailed.userPassword : user_pwd_errors.password)}
                                     change={(_, value) => onValueChanged('userPassword', value)} />
             </>}
         </>

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -154,7 +154,15 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                                          location=config.VALID_DISK_IMAGE_PATH,
                                                                          user_login="foo",
                                                                          create_and_run=True),
-                                             {"create-vm-dialog-user-password": "User password must not be empty when user login is set"})
+                                             {"create-vm-dialog-user-password-pw1": "User password must not be empty when user login is set"})
+
+        # user login
+        runner.checkDialogFormValidationTest(TestMachinesCreate.VmDialog(self, sourceType='cloud',
+                                                                         storage_size=10, storage_size_unit='MiB',
+                                                                         location=config.VALID_DISK_IMAGE_PATH,
+                                                                         user_password="catsaremybestfr13nds",
+                                                                         create_and_run=True),
+                                             {"create-vm-dialog-user-login": "User login must not be empty when user password is set"})
 
     def testCreateNameGeneration(self):
         config = TestMachinesCreate.TestCreateConfig

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -148,6 +148,14 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                                          create_and_run=False),
                                              {"source-url": "Installation source must not be empty"})
 
+        # user password
+        runner.checkDialogFormValidationTest(TestMachinesCreate.VmDialog(self, sourceType='cloud',
+                                                                         storage_size=10, storage_size_unit='MiB',
+                                                                         location=config.VALID_DISK_IMAGE_PATH,
+                                                                         user_login="foo",
+                                                                         create_and_run=True),
+                                             {"create-vm-dialog-user-password": "User password must not be empty when user login is set"})
+
     def testCreateNameGeneration(self):
         config = TestMachinesCreate.TestCreateConfig
         runner = TestMachinesCreate.CreateVmRunner(self)


### PR DESCRIPTION
Additionally, test both cases when either login is specified without password or vice versa.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2096210