### PR TITLE
Downloading rhel images: Impromevents of offline token management

### DIFF
--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -594,7 +594,8 @@ const OfflineTokenRow = ({ offlineToken, onValueChanged, formValidationFailed })
                       disabled={disabled}
                       minLength={1}
                       value={offlineToken || ""}
-                      onChange={setOfflineTokenHelper} />
+                      onChange={setOfflineTokenHelper}
+                      rows="4" />
         </FormGroup>
     );
 };

--- a/src/components/create-vm-dialog/createVmDialog.scss
+++ b/src/components/create-vm-dialog/createVmDialog.scss
@@ -5,3 +5,7 @@
 .pf-c-tooltip__arrow {
     margin-right: var(--pf-global--spacer--xl);
 }
+
+.invalid-token-helper {
+    color: var(--pf-c-form__helper-text--m-error--Color);
+}

--- a/src/components/create-vm-dialog/createVmDialog.scss
+++ b/src/components/create-vm-dialog/createVmDialog.scss
@@ -9,3 +9,10 @@
 .invalid-token-helper {
     color: var(--pf-c-form__helper-text--m-error--Color);
 }
+
+// Move position of icon so it doens't get covered by scrollbar.
+// Autoresize would also work, but in certain cases autoresize is buggy: https://github.com/patternfly/patternfly-react/issues/7834
+// Use this workaround until patternfly-react#7834 is fixed
+#offline-token {
+    background-position-x: right 1rem;
+}

--- a/src/components/create-vm-dialog/createVmDialogUtils.js
+++ b/src/components/create-vm-dialog/createVmDialogUtils.js
@@ -26,6 +26,7 @@ import autoDetectOSScript from 'raw-loader!./autoDetectOS.py';
 
 const ACCEPT_RELEASE_DATES_AFTER = getTodayYearShifted(-3);
 const ACCEPT_EOL_DATES_AFTER = getTodayYearShifted(-1);
+const RHSM_TOKEN = "rhsm-offline-token";
 
 export const URL_SOURCE = 'url';
 export const LOCAL_INSTALL_MEDIA_SOURCE = 'file';
@@ -152,4 +153,16 @@ export function isDownloadableOs(os) {
         !os.version.endsWith("unknown") &&
         // RHSM API supports only rhel versions >= 8: https://access.redhat.com/management/api/rhsm#/images/listImageDownloadsByVersionArch
         (os.version.localeCompare("8.0", undefined, { numeric: true, sensitivity: 'base' }) >= 0));
+}
+
+export function saveOfflineToken(offlineToken) {
+    return localStorage.setItem(RHSM_TOKEN, offlineToken);
+}
+
+export function loadOfflineToken(setToken) {
+    return setToken(localStorage.getItem(RHSM_TOKEN));
+}
+
+export function removeOfflineToken() {
+    return localStorage.removeItem(RHSM_TOKEN);
 }

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -72,7 +72,7 @@ import {
 } from '../libvirt-xml-update.js';
 import { storagePoolRefresh } from './storagePool.js';
 import { snapshotGetAll } from './snapshot.js';
-import { downloadRhelImage, getAccessToken, getRhelImageUrl } from './rhel-images.js';
+import { downloadRhelImage, getRhelImageUrl } from './rhel-images.js';
 import { call, Enum, timeout, resolveUiState } from './helpers.js';
 import { DOWNLOAD_AN_OS, LOCAL_INSTALL_MEDIA_SOURCE, needsRHToken } from '../components/create-vm-dialog/createVmDialogUtils.js';
 
@@ -267,7 +267,7 @@ export function domainCreate({
     userLogin,
     userPassword,
     vmName,
-    offlineToken,
+    accessToken,
     loggedUser
 }) {
     // shows dummy vm  until we get vm from virsh (cleans up inProgress)
@@ -304,20 +304,14 @@ export function domainCreate({
 
     const tryDownloadRhelImage = () => {
         if (sourceType == DOWNLOAD_AN_OS && needsRHToken(os)) {
-            let arch;
-            let accessToken;
             const options = { err: "message" };
             if (connectionName === "system")
                 options.superuser = "try";
 
             return cockpit.spawn(['uname', '-m'], options)
                     .then(out => {
-                        arch = out.trim();
+                        const arch = out.trim();
 
-                        return getAccessToken(offlineToken);
-                    })
-                    .then(out => {
-                        accessToken = out.trim();
                         return getRhelImageUrl(accessToken, osVersion, arch);
                     })
                     .then(out => {

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -756,6 +756,7 @@ vnc_password= "{vnc_passwd}"
                      check_script_finished=True,
                      connection="system",
                      offline_token=None,
+                     offline_token_autofilled=True,
                      pixel_test_tag=None):
 
             TestMachinesCreate.VmDialog.vmId += 1  # This variable is static - don't use self here
@@ -802,6 +803,7 @@ vnc_password= "{vnc_passwd}"
             self.connection = connection
             self.name_generated = name_generated
             self.offline_token = offline_token
+            self.offline_token_autofilled = offline_token_autofilled
 
             self.pixel_test_tag = pixel_test_tag
 
@@ -1126,7 +1128,10 @@ vnc_password= "{vnc_passwd}"
                 b.wait_attr("#os-select-group input", "value", self.expected_os_name)
 
             if self.sourceType == "os" and self.os_name in [TestMachinesCreate.TestCreateConfig.RHEL_8_1, TestMachinesCreate.TestCreateConfig.RHEL_8_2]:
-                b.set_input_text("#offline-token", self.offline_token)
+                if not self.offline_token_autofilled:
+                    b.set_input_text("#offline-token", self.offline_token)
+                b.wait_in_text("#offline-token", self.offline_token)
+                b.wait_in_text("#offline-token-helper", "Valid")
 
             if self.sourceType != 'disk_image':
                 if not self.expected_storage_size:
@@ -1690,7 +1695,8 @@ vnc_password= "{vnc_passwd}"
             b.click("#os-select-group > div button")
             b.click(f"#os-select li:contains('{dialog.os_name}') button")
             b.wait_attr("#os-select-group input", "value", dialog.os_name)
-            b.set_input_text("#offline-token", dialog.offline_token)
+            if not dialog.offline_token_autofilled:
+                b.set_input_text("#offline-token", dialog.offline_token)
 
             b.wait_visible("#token-helper-message")
             b.wait_in_text("#token-helper-message", error_msg)
@@ -1979,6 +1985,7 @@ vnc_password= "{vnc_passwd}"
                                                                           os_name=config.RHEL_8_1,
                                                                           os_short_id=config.RHEL_8_1_SHORTID,
                                                                           offline_token="invalid_token",
+                                                                          offline_token_autofilled=False,
                                                                           create_and_run=True),
                                               "Error",
                                               True)
@@ -1986,14 +1993,16 @@ vnc_password= "{vnc_passwd}"
         runner.checkDialogErrorTest(TestMachinesCreate.VmDialog(self, sourceType='os',
                                                                 os_name=config.RHEL_8_2,
                                                                 os_short_id=config.RHEL_8_2_SHORTID,
-                                                                offline_token="my_offline_token",
+                                                                offline_token="valid_token",
+                                                                offline_token_autofilled=False,
                                                                 create_and_run=True),
                                     ["No image available for RHEL 8.2"])
 
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='os',
                                                       os_name=config.RHEL_8_1,
                                                       os_short_id=config.RHEL_8_1_SHORTID,
-                                                      offline_token="my_offline_token",
+                                                      offline_token="valid_token",
+                                                      offline_token_autofilled=False,
                                                       create_and_run=False))
 
         m.execute("rm /var/lib/libvirt/images/rhel-8-1-boot.iso")
@@ -2001,20 +2010,30 @@ vnc_password= "{vnc_passwd}"
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='os',
                                                       os_name=config.RHEL_8_1,
                                                       os_short_id=config.RHEL_8_1_SHORTID,
-                                                      offline_token="my_offline_token",
+                                                      offline_token="valid_token",
+                                                      offline_token_autofilled=True,
                                                       create_and_run=True))
 
         # If run on different connection, the downloaded iso should be stored in ~/.local/share/libvirt/images/
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='os',
                                                       os_name=config.RHEL_8_1,
                                                       os_short_id=config.RHEL_8_1_SHORTID,
-                                                      offline_token="my_offline_token",
+                                                      offline_token="valid_token",
                                                       create_and_run=True,
                                                       connection="session"),
                           check_env_empty=False)
 
         # Check only RHEL >= 8 are available for download
         runner.checkRhelIsDownloadableTest(TestMachinesCreate.VmDialog(self))
+
+        # Change token saved at localStorage to imitate expiration of a token
+        b.call_js_func("localStorage.setItem", "rhsm-offline-token", "expired_token")
+        runner.checkDialogInvalidOfflineToken(TestMachinesCreate.VmDialog(self, sourceType='os',
+                                                                          os_name=config.RHEL_8_1,
+                                                                          os_short_id=config.RHEL_8_1_SHORTID,
+                                                                          offline_token_autofilled=True),
+                                              "expired",
+                                              False)
 
 
 if __name__ == '__main__':

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1191,6 +1191,7 @@ vnc_password= "{vnc_passwd}"
             return self
 
         def createAndExpectInlineValidationErrors(self, errors):
+
             b = self.browser
 
             if self.sourceType == 'disk_image':
@@ -1681,6 +1682,24 @@ vnc_password= "{vnc_passwd}"
             b.wait_in_text("#create-button-tooltip", "medium")
             b.mouse("#create-new-vm", "mouseleave")
 
+        def checkDialogInvalidOfflineToken(self, dialog, error_msg, create_disabled):
+            b = self.browser
+            dialog.open() \
+
+            b.select_from_dropdown("#source-type", dialog.sourceType)
+            b.click("#os-select-group > div button")
+            b.click(f"#os-select li:contains('{dialog.os_name}') button")
+            b.wait_attr("#os-select-group input", "value", dialog.os_name)
+            b.set_input_text("#offline-token", dialog.offline_token)
+
+            b.wait_visible("#token-helper-message")
+            b.wait_in_text("#token-helper-message", error_msg)
+            if create_disabled:
+                b.wait_visible(".pf-c-modal-box__footer button:contains(Create and run)[aria-disabled=true]")
+                b.wait_visible(".pf-c-modal-box__footer button:contains(Create and edit)[aria-disabled=true]")
+
+            dialog.cancel()
+
         def cancelDialogTest(self, dialog):
             dialog.open() \
                 .fill() \
@@ -1956,12 +1975,13 @@ vnc_password= "{vnc_passwd}"
 
         m.execute(f"qemu-img create {TestMachinesCreate.TestCreateConfig.VALID_DISK_IMAGE_PATH} 500M")
 
-        runner.checkDialogErrorTest(TestMachinesCreate.VmDialog(self, sourceType='os',
-                                                                os_name=config.RHEL_8_1,
-                                                                os_short_id=config.RHEL_8_1_SHORTID,
-                                                                offline_token="invalid_token",
-                                                                create_and_run=True),
-                                    ["404"])
+        runner.checkDialogInvalidOfflineToken(TestMachinesCreate.VmDialog(self, sourceType='os',
+                                                                          os_name=config.RHEL_8_1,
+                                                                          os_short_id=config.RHEL_8_1_SHORTID,
+                                                                          offline_token="invalid_token",
+                                                                          create_and_run=True),
+                                              "Error",
+                                              True)
 
         runner.checkDialogErrorTest(TestMachinesCreate.VmDialog(self, sourceType='os',
                                                                 os_name=config.RHEL_8_2,

--- a/test/files/mock-rhsm-rest
+++ b/test/files/mock-rhsm-rest
@@ -15,13 +15,13 @@ class handler(BaseHTTPRequestHandler):
     def do_POST(self):
         data = self.rfile.read(int(self.headers['Content-Length']))
         m = self.match("/auth/realms/redhat-external/protocol/openid-connect/token")
-        if m and data == b'grant_type=refresh_token&client_id=rhsm-api&refresh_token=my_offline_token':
+        if m and data == b'grant_type=refresh_token&client_id=rhsm-api&refresh_token=valid_token':
             self.send_response(200)
             self.end_headers()
             self.wfile.write(b'{ "access_token": "my_access_token" }\n')
             return
 
-        self.send_response(404)
+        self.send_response(400)
         self.end_headers()
 
     def do_GET(self):


### PR DESCRIPTION
- Check validity of offline token immediatelly after supplied by a user
- Add saving and loading offline tokens from localStorage

---
## Machines: Improvements of offline token management 

Offline token, which needs to be specified to download a RHEL OS, is now validated on the fly. 
![demo1](https://user-images.githubusercontent.com/42733240/191479932-0e050461-2c33-4247-b3a4-f09f24272b91.gif)

Valid tokens are then saved by Cockpit and re-used on the next occasion.
![demo2](https://user-images.githubusercontent.com/42733240/191479949-5b2c0254-3225-4ddc-b58e-a0a9c58107bf.gif)
