### PR TITLE
Ship npm integration test dependencies in dist tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,19 +119,28 @@ devel-uninstall:
 print-version:
 	@echo "$(VERSION)"
 
+# required for running integration tests; commander and ws are deps of chrome-remote-interface
+TEST_NPMS = \
+	node_modules/chrome-remote-interface \
+	node_modules/commander \
+	node_modules/sizzle \
+	node_modules/ws \
+	$(NULL)
+
 dist: $(TARFILE)
 	@ls -1 $(TARFILE)
 
 # when building a distribution tarball, call webpack with a 'production' environment
-# we don't ship node_modules for license and compactness reasons; we ship a
-# pre-built dist/ (so it's not necessary) and ship package-lock.json (so that
-# node_modules/ can be reconstructed if necessary)
+# we don't ship most node_modules for license and compactness reasons, only the ones necessary for running tests
+# we ship a pre-built dist/ (so it's not necessary) and ship package-lock.json (so that node_modules/ can be reconstructed if necessary)
 $(TARFILE): export NODE_ENV=production
 $(TARFILE): $(WEBPACK_TEST) $(SPEC) packaging/arch/PKGBUILD packaging/debian/changelog
 	if type appstream-util >/dev/null 2>&1; then appstream-util validate-relax --nonet *.metainfo.xml; fi
 	tar --xz $(TAR_ARGS) -cf $(TARFILE) --transform 's,^,$(RPM_NAME)/,' \
-		--exclude '*.in' --exclude test/reference --exclude node_modules \
-		$$(git ls-files) $(COCKPIT_REPO_FILES) $(NODE_MODULES_TEST) $(SPEC) packaging/arch/PKGBUILD packaging/debian/changelog dist/
+		--exclude '*.in' --exclude test/reference \
+		$$(git ls-files | grep -v node_modules) \
+		$(COCKPIT_REPO_FILES) $(NODE_MODULES_TEST) $(SPEC) $(TEST_NPMS) \
+		packaging/arch/PKGBUILD packaging/debian/changelog dist/
 
 # convenience target for developers
 rpm: $(TARFILE) $(SPEC)

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -9,7 +9,7 @@ require:
   - git-core
   - libvirt-python3
   - make
-  - npm
+  - nodejs
   - python3
   - python3-yaml
   # required by tests

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -3,21 +3,12 @@ set -eux
 
 # tests need cockpit's bots/ libraries and test infrastructure
 cd $SOURCE
-git init
 rm -f bots  # common local case: existing bots symlink
 make bots
 
-# support running from clean git tree
-if [ ! -d node_modules/chrome-remote-interface ]; then
-    # copy package.json temporarily otherwise npm might try to install the dependencies from it
-    mv package.json .package.json
-    npm install chrome-remote-interface sizzle
-    mv .package.json package.json
-fi
-
 # disable detection of affected tests; testing takes too long as there is no parallelization,
 # and TF machines are slow and brittle
-mv .git dot-git
+[ ! -e .git ] || mv .git dot-git
 
 . /usr/lib/os-release
 export TEST_OS="${ID}-${VERSION_ID/./-}"


### PR DESCRIPTION
This avoids having to run `npm`, and thus a potentially brittle internet
access, during FMF test runs. It also avoids the npm test dependency,
which tends to be uninstallable in Rawhide.

We have successfully used this approach in cockpit for a long time.

----

This avoids [this failure](https://artifacts.dev.testing-farm.io/2d44eeb8-bb89-42a8-bd9d-6764c37bed60/), which has been going on for a week [bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2110750). This already hit us in the past.