### PR TITLE
Drop unrequired @use import

### DIFF
--- a/src/components/vm/hostdevs/hostDevAdd.scss
+++ b/src/components/vm/hostdevs/hostDevAdd.scss
@@ -1,5 +1,3 @@
-@use "_global-variables.scss";
-
 .pf-c-table.vm-device-table {
   /* Set overflow with a limiter on the list, so it scrolls instead of the dialog */
   max-height: min(50vh, 50rem);


### PR DESCRIPTION
The global variables are not required any variables in this file.

Follow up from https://github.com/cockpit-project/cockpit-machines/pull/770#discussion_r926308798

After this change the table headers are still aligned, that's why we remove the padding.
![image](https://user-images.githubusercontent.com/67428/182564918-18e35a89-7c89-408a-a8fe-aa1cbc8fa5dd.png)