### PR TITLE
test fixes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 194

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ print-vm:
 	@echo $(VM_IMAGE)
 
 codecheck: test/static-code
-	test/static-code
+	test/static-code --tap
 
 # convenience target to setup all the bits needed for the integration tests
 # without actually running them

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -471,7 +471,7 @@ vnc_password= "{vnc_passwd}"
             print(self.machine.execute("; ".join(cmd).format(target_iqn)))
             wait(lambda: "unit:0:0:0" in self.machine.execute("virsh pool-refresh iscsi-pool && virsh vol-list iscsi-pool"), delay=3)
 
-            self.addCleanup(self.machine.execute, "virsh pool-destroy iscsi-pool; virsh pool-delete iscsi-pool; virsh pool-undefine iscsi-pool")
+            self.addCleanup(self.machine.execute, "virsh pool-destroy iscsi-pool; virsh pool-undefine iscsi-pool")
 
             self.browser.reload()
             self.browser.enter_page('/machines')

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -296,23 +296,20 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                                            storage_pool="NoStorage",
                                                                            connection="session"))
 
-        self.machine.execute("virsh net-destroy default && virsh net-undefine default")
+        self.machine.execute("set -e; virsh net-destroy default; virsh net-undefine default")
 
         # Set up the PXE server configuration files
         cmds = [
+            "set -e",
             "mkdir -p /var/lib/libvirt/pxe-config",
             f"echo \"{PXE_SERVER_CFG}\" > /var/lib/libvirt/pxe-config/pxe.cfg",
             "chmod 666 /var/lib/libvirt/pxe-config/pxe.cfg"
         ]
-        self.machine.execute(" && ".join(cmds))
+        self.machine.execute("; ".join(cmds))
 
         # Define and start a NAT network with tftp server configuration
-        cmds = [
-            f"echo \"{NETWORK_XML_PXE}\" > /tmp/pxe-nat.xml",
-            "virsh net-define /tmp/pxe-nat.xml",
-            "virsh net-start pxe-nat"
-        ]
-        self.machine.execute(" && ".join(cmds))
+        self.machine.write("/tmp/pxe-nat.xml", NETWORK_XML_PXE)
+        self.machine.execute("set -e; virsh net-define /tmp/pxe-nat.xml; virsh net-start pxe-nat")
 
         # Add an extra network interface that should appear in the PXE source dropdown
         iface = "eth42"
@@ -384,7 +381,8 @@ class TestMachinesCreate(VirtualMachinesCase):
         wait(lambda: self.machine.execute(r"sed 's,\x1B\[[0-9;]*[a-zA-Z],,g' /tmp/serial.txt | grep 'Rebooting in 60'"), delay=3)
         self.goToMainPage()
 
-        self.machine.execute("virsh destroy pxe-guest && virsh undefine pxe-guest")
+        self.machine.execute("virsh destroy pxe-guest")
+        self.machine.execute("virsh undefine pxe-guest")
         runner.checkEnvIsEmpty()
 
         # Check that host network devices are appearing in the options for PXE boot sources
@@ -442,12 +440,13 @@ vnc_password= "{vnc_passwd}"
         dev = self.add_ram_disk(1)
         partition = dev.split('/')[2] + "1"
         cmds = [
+            "set -e",
             f"virsh pool-define-as poolDisk disk - - {dev} - {os.path.join(self.vm_tmpdir, 'poolDiskImages')}",
             "virsh pool-build poolDisk --overwrite",
             "virsh pool-start poolDisk",
             f"virsh vol-create-as poolDisk {partition} 1024"
         ]
-        self.machine.execute(" && ".join(cmds))
+        self.machine.execute("; ".join(cmds))
 
         self.login_and_go("/machines")
         self.browser.wait_in_text("body", "Virtual machines")
@@ -464,11 +463,12 @@ vnc_password= "{vnc_passwd}"
             target_iqn = "iqn.2019-09.cockpit.lan"
             self.prepareStorageDeviceOnISCSI(target_iqn)
             cmd = [
+                "set -e",
                 "virsh pool-define-as iscsi-pool --type iscsi --target /dev/disk/by-id --source-host 127.0.0.1 --source-dev {0}",
                 "ls -la /dev/disk/by-id",
                 "virsh pool-start iscsi-pool"
             ]
-            print(self.machine.execute("&& ".join(cmd).format(target_iqn)))
+            print(self.machine.execute("; ".join(cmd).format(target_iqn)))
             wait(lambda: "unit:0:0:0" in self.machine.execute("virsh pool-refresh iscsi-pool && virsh vol-list iscsi-pool"), delay=3)
 
             self.addCleanup(self.machine.execute, "virsh pool-destroy iscsi-pool; virsh pool-delete iscsi-pool; virsh pool-undefine iscsi-pool")
@@ -526,11 +526,8 @@ vnc_password= "{vnc_passwd}"
 
         # define again the default storage pool for system connection
         # we need so that the UI will know the remaining available space when we use that pool's path
-        cmds = [
-            "virsh pool-define-as default --type dir --target /var/lib/libvirt/images",
-            "virsh pool-start default"
-        ]
-        self.machine.execute(" && ".join(cmds))
+        self.machine.execute("virsh pool-define-as default --type dir --target /var/lib/libvirt/images")
+        self.machine.execute("virsh pool-start default")
 
         self.browser.reload()
         self.browser.enter_page('/machines')
@@ -543,13 +540,14 @@ vnc_password= "{vnc_passwd}"
                                                       create_and_run=False,
                                                       connection='session'))
         cmds = [
+            "set -e",
             "mkdir -p '/var/lib/libvirt/pools/tmp pool'; chmod a+rwx '/var/lib/libvirt/pools/tmp pool'",
             "virsh pool-define-as 'tmp pool' --type dir --target '/var/lib/libvirt/pools/tmp pool'",
             "virsh pool-start 'tmp pool'",
             "qemu-img create -f qcow2 '/var/lib/libvirt/pools/tmp pool/vmTmpDestination.qcow2' 128M",
             "virsh pool-refresh 'tmp pool'"
         ]
-        self.machine.execute(" && ".join(cmds))
+        self.machine.execute("; ".join(cmds))
 
         self.browser.reload()
         self.browser.enter_page('/machines')
@@ -598,7 +596,7 @@ vnc_password= "{vnc_passwd}"
         # This is applicable for all tests that we want to really successfully run a nested VM.
         # in order to allow the rest of the tests to run faster with QEMU KVM
         # Stop pmcd service if available which is invoking pmdakvm and is keeping KVM module used
-        self.machine.execute("(systemctl stop pmcd || true) && modprobe -r kvm_intel && modprobe -r kvm_amd && modprobe -r kvm")
+        self.machine.execute("systemctl stop pmcd; modprobe -r kvm_intel kvm_amd kvm")
 
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='disk_image',
                                                       location=config.VALID_DISK_IMAGE_PATH,
@@ -1267,11 +1265,8 @@ vnc_password= "{vnc_passwd}"
 
             # define default storage pool for system connection
             # we need so that the UI will know the remaining available space when we use that pool's path
-            cmds = [
-                "virsh pool-define-as default --type dir --target /var/lib/libvirt/images",
-                "virsh pool-start default"
-            ]
-            self.machine.execute(" && ".join(cmds))
+            self.machine.execute("virsh pool-define-as default --type dir --target /var/lib/libvirt/images")
+            self.machine.execute("virsh pool-start default")
 
         def _fakeOsDBInfoFedora(self):
             # Fake the osinfo-db data in order that it will allow spawn the installation - of course we don't expect it to succeed -

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -536,7 +536,7 @@ class TestMachinesDisks(VirtualMachinesCase):
             m.execute(f"virsh pool-define-as iscsi-pool --type iscsi --target /dev/disk/by-id --source-host 127.0.0.1 --source-dev {target_iqn} && virsh pool-start iscsi-pool")
             wait(lambda: "unit:0:0:0" in self.machine.execute("virsh pool-refresh iscsi-pool && virsh vol-list iscsi-pool"), delay=3)
 
-            self.addCleanup(self.machine.execute, "virsh pool-destroy iscsi-pool; virsh pool-delete iscsi-pool; virsh pool-undefine iscsi-pool")
+            self.addCleanup(self.machine.execute, "virsh pool-destroy iscsi-pool; virsh pool-undefine iscsi-pool")
 
         args = self.createVm("subVmTest1")
 

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -42,7 +42,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         self.machine.execute(f"useradd{' -G ' + user_group if user_group else '' } {user_name} && echo '{user_name}:foobar' | chpasswd")
         # user libvirtd instance tends to SIGABRT with "Failed to find user record for uid .." on shutdown during cleanup
         # so make sure that there are no leftover user processes that bleed into the next test
-        self.addCleanup(self.machine.execute, "pkill -u {0}; while pgrep -u {0}; do sleep 0.5; done".format(user_name))
+        self.addCleanup(self.machine.execute, f"pkill -u {user_name} || true; while pgrep -u {user_name}; do sleep 0.5; done")
         # HACK: ...but it still tends to crash during shutdown (without known stack trace)
         self.allow_journal_messages('Process .*libvirtd.* of user 10.* dumped core.*')
 
@@ -324,7 +324,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         m.execute("useradd nonadmin; echo nonadmin:foobar | chpasswd")
         # user libvirtd instance tends to SIGABRT with "Failed to find user record for uid .." on shutdown during cleanup
         # so make sure that there are no leftover user processes that bleed into the next test
-        self.addCleanup(self.machine.execute, "pkill -u nonadmin; while pgrep -u nonadmin; do sleep 0.5; done")
+        self.addCleanup(self.machine.execute, "pkill -u nonadmin || true; while pgrep -u nonadmin; do sleep 0.5; done")
         self.login_and_go("/machines", user="nonadmin", superuser=False)
         b.wait_in_text("body", "Virtual machines")
         b.wait_in_text("#virtual-machines-listing .pf-c-empty-state", "No VM is running")

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -324,7 +324,7 @@ class VirtualMachinesCase(MachineCase, VirtualMachinesCaseHelpers, StorageHelper
 
         # user libvirtd instance tends to SIGABRT with "Failed to find user record for uid .." on shutdown during cleanup
         # so make sure that there are no leftover user processes that bleed into the next test
-        self.addCleanup(self.machine.execute, '''pkill -u admin; while [ -n "$(pgrep -au admin | grep -v 'systemd --user')" ]; do sleep 0.5; done''')
+        self.addCleanup(self.machine.execute, '''pkill -u admin || true; while [ -n "$(pgrep -au admin | grep -v 'systemd --user')" ]; do sleep 0.5; done''')
 
         # FIXME: report downstream; AppArmor noisily denies some operations, but they are not required for us
         self.allow_journal_messages(r'.* type=1400 .* apparmor="DENIED" operation="capable" profile="\S*libvirtd.* capname="sys_rawio".*')


### PR DESCRIPTION
Running `a && b` is wrong for our intent here, as it will silently
succeed if `a` fails, and never run `b`. This can often cause follow-up
failures which are harder to investigate.

Use `set -e` where appropriate. In some cases, run the commands separately so
that we will know which one failed exactly.

----

This was triggered by [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-787-20220805-100642-0c85102c-ubuntu-2204/log.html#75), which happens fairly often. The [log](https://cockpit-logs.us-east-1.linodeobjects.com/pull-787-20220805-100642-0c85102c-ubuntu-2204/TestMachinesCreate-testCreatePXE-ubuntu-2204-127.0.0.2-2701-FAIL.log.gz) and the [screenshot](https://cockpit-logs.us-east-1.linodeobjects.com/pull-787-20220805-100642-0c85102c-ubuntu-2204/TestMachinesCreate-testCreatePXE-ubuntu-2204-127.0.0.2-2701-FAIL.png) both confirm that the destroy actually worked, but the undefine either failed, never ran, or did not generate a libvirt-dbus event, or the UI was missing it. Let's find out!