### PR TITLE
Offer downloading RHEL OS only for RHEL >= 8

### DIFF
--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -71,6 +71,7 @@ import {
     filterReleaseEolDates,
     getOSStringRepresentation,
     needsRHToken,
+    isDownloadableOs,
 } from "./createVmDialogUtils.js";
 import { domainCreate } from '../../libvirtApi/domain.js';
 import { storagePoolRefresh } from '../../libvirtApi/storagePool.js';
@@ -368,7 +369,7 @@ const SourceRow = ({ connectionName, source, sourceType, networks, nodeDevices, 
                 </FormGroup>
                 : <>
                     <OSRow os={os}
-                         osInfoList={osInfoList.filter(os => os.treeInstallable || (needsRHToken(os.shortId) && !os.version.endsWith("unknown")))}
+                         osInfoList={osInfoList.filter(isDownloadableOs)}
                          onValueChanged={onValueChanged}
                          isLoading={false}
                          validationFailed={validationFailed} />

--- a/src/components/create-vm-dialog/createVmDialogUtils.js
+++ b/src/components/create-vm-dialog/createVmDialogUtils.js
@@ -145,3 +145,11 @@ export function correctSpecialCases(os) {
 export function needsRHToken(osName) {
     return osName.startsWith("rhel");
 }
+
+export function isDownloadableOs(os) {
+    return os.treeInstallable ||
+        (needsRHToken(os.shortId) &&
+        !os.version.endsWith("unknown") &&
+        // RHSM API supports only rhel versions >= 8: https://access.redhat.com/management/api/rhsm#/images/listImageDownloadsByVersionArch
+        (os.version.localeCompare("8.0", undefined, { numeric: true, sensitivity: 'base' }) >= 0));
+}

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -695,8 +695,10 @@ vnc_password= "{vnc_passwd}"
         FEDORA_29 = 'Fedora 29'
         FEDORA_29_SHORTID = 'fedora29'
 
-        RHEL_5_0 = 'Red Hat Enterprise Linux 5.0 (Tikanga)'
-        RHEL_5_0_SHORTID = 'rhel5.0'
+        RHEL_8_1 = 'Red Hat Enterprise Linux 8.1 (Ootpa)'
+        RHEL_8_1_SHORTID = 'rhel8.test'
+        RHEL_7_1 = 'Red Hat Enterprise Linux 7.1'
+        RHEL_7_1_SHORTID = 'rhel7.test'
 
         CENTOS_7 = 'CentOS 7'
 
@@ -907,6 +909,18 @@ vnc_password= "{vnc_passwd}"
             else:
                 b.wait_visible(f"#os-select li button:contains({self.os_search_name})")
 
+        def checkRhelIsDownloadable(self):
+            b = self.browser
+
+            b.select_from_dropdown("#source-type", "os")
+            b.set_input_text("#os-select-group input", "Red Hat")
+
+            # Check only RHEL >= 8 is shown
+            b.wait_visible(f"#os-select li button:contains('{TestMachinesCreate.TestCreateConfig.RHEL_8_1}')")
+            b.wait_not_present(f"#os-select li button:contains('{TestMachinesCreate.TestCreateConfig.RHEL_7_1}')")
+
+            return self
+
         def checkOsSorted(self, sorted_list):
             b = self.browser
 
@@ -1065,7 +1079,7 @@ vnc_password= "{vnc_passwd}"
             if self.expected_os_name:
                 b.wait_attr("#os-select-group input", "value", self.expected_os_name)
 
-            if self.sourceType == "os" and self.os_name == TestMachinesCreate.TestCreateConfig.RHEL_5_0:
+            if self.sourceType == "os" and self.os_name == TestMachinesCreate.TestCreateConfig.RHEL_8_1:
                 b.set_input_text("#offline-token", self.offline_token)
 
             if self.sourceType != 'disk_image':
@@ -1295,16 +1309,25 @@ vnc_password= "{vnc_passwd}"
             self.test_obj.addCleanup(self.machine.execute, "umount /usr/share/osinfo/os/fedoraproject.org/fedora-29.xml || true")
 
         def _fakeOsDBInfoRhel(self):
-            # Fake rhel image
-            rhel_5_0_xml = self.machine.execute("cat /usr/share/osinfo/os/redhat.com/rhel-5.0.xml")
-            root = ET.fromstring(rhel_5_0_xml)
+            # Fake rhel 8 image
+            rhel_8_1_xml = self.machine.execute("cat /usr/share/osinfo/os/redhat.com/rhel-8.1.xml")
+            root = ET.fromstring(rhel_8_1_xml)
             root.find('os').find('resources').find('minimum').find('ram').text = '134217728'
             root.find('os').find('resources').find('minimum').find('storage').text = '134217728'
-            root.find('os').find('eol-date').text = '9999-12-31'
-            new_rhel_5_0_xml = ET.tostring(root)
-            self.machine.execute(f"echo '{str(new_rhel_5_0_xml, 'utf-8')}' > {self.test_obj.vm_tmpdir}/rhel-5.0.xml")
-            self.machine.execute(f"mount -o bind  {self.test_obj.vm_tmpdir}/rhel-5.0.xml /usr/share/osinfo/os/redhat.com/rhel-5.0.xml")
-            self.test_obj.addCleanup(self.machine.execute, "umount /usr/share/osinfo/os/redhat.com/rhel-5.0.xml || true")
+            new_rhel_8_1_xml = ET.tostring(root)
+            self.machine.execute(f"echo '{str(new_rhel_8_1_xml, 'utf-8')}' > {self.test_obj.vm_tmpdir}/rhel-8.1.xml")
+            self.machine.execute(f"mount -o bind  {self.test_obj.vm_tmpdir}/rhel-8.1.xml /usr/share/osinfo/os/redhat.com/rhel-8.1.xml")
+            self.test_obj.addCleanup(self.machine.execute, "umount /usr/share/osinfo/os/redhat.com/rhel-8.1.xml || true")
+
+            # Fake rhel 7 image
+            rhel_7_1_xml = self.machine.execute("cat /usr/share/osinfo/os/redhat.com/rhel-7.1.xml")
+            root = ET.fromstring(rhel_7_1_xml)
+            root.find('os').find('resources').find('minimum').find('ram').text = '134217728'
+            root.find('os').find('resources').find('minimum').find('storage').text = '134217728'
+            new_rhel_7_1_xml = ET.tostring(root)
+            self.machine.execute(f"echo '{str(new_rhel_7_1_xml, 'utf-8')}' > {self.test_obj.vm_tmpdir}/rhel-7.1.xml")
+            self.machine.execute(f"mount -o bind  {self.test_obj.vm_tmpdir}/rhel-7.1.xml /usr/share/osinfo/os/redhat.com/rhel-7.1.xml")
+            self.test_obj.addCleanup(self.machine.execute, "umount /usr/share/osinfo/os/redhat.com/rhel-7.1.xml || true")
 
         def _fakeFedoraTree(self):
             server = self.test_obj.setup_mock_server("mock-range-server.py", ["archive.fedoraproject.org"])
@@ -1351,7 +1374,7 @@ vnc_password= "{vnc_passwd}"
 
             final_state = "Running" if dialog.create_and_run else "Shut off"
             # Test dowloading RHEL image shows the progress of the download
-            if dialog.os_name == TestMachinesCreate.TestCreateConfig.RHEL_5_0:
+            if dialog.os_name == TestMachinesCreate.TestCreateConfig.RHEL_8_1:
                 # Check download percantage is shown as a whole number 0-100 followed by '%'
                 if dialog.create_and_run:
                     b.wait_in_text(f"#vm-{dialog.name}-{dialog.connection}-state", "Downloading")
@@ -1471,10 +1494,7 @@ vnc_password= "{vnc_passwd}"
 
             # check bus type
             if dialog.storage_pool != "NoStorage":
-                if dialog.os_name == TestMachinesCreate.TestCreateConfig.RHEL_5_0:
-                    b.wait_in_text(f"#vm-{name}-disks-hda-bus", "ide")
-                else:
-                    b.wait_in_text(f"#vm-{name}-disks-vda-bus", "virtio")
+                b.wait_in_text(f"#vm-{name}-disks-vda-bus", "virtio")
             # check memory
             # adjust to how cockpit_format_bytes() formats sizes > 1024 MiB -- this depends on how much RAM
             # the host has (less or more than 1 GiB), and thus needs to be dynamic
@@ -1486,7 +1506,7 @@ vnc_password= "{vnc_passwd}"
 
             # check disks
             # Test disk got imported/created
-            if dialog.sourceType == 'disk_image' or (dialog.os_name == TestMachinesCreate.TestCreateConfig.RHEL_5_0):
+            if dialog.sourceType == 'disk_image' or (dialog.os_name == TestMachinesCreate.TestCreateConfig.RHEL_8_1):
                 b.wait_visible(".disks-card table tbody > tr:first-child")
                 if b.is_present(f"#vm-{name}-disks-vda-device"):
                     b.wait_in_text(f"#vm-{name}-disks-vda-source-file", dialog.location)
@@ -1622,6 +1642,11 @@ vnc_password= "{vnc_passwd}"
                 .cancel(True)
             self._assertScriptFinished() \
                 .checkEnvIsEmpty()
+
+        def checkRhelIsDownloadableTest(self, dialog):
+            dialog.open() \
+                .checkRhelIsDownloadable() \
+                .cancel(True)
 
         def checkSortedOsTest(self, dialog, sorted_list):
             dialog.open() \
@@ -1872,34 +1897,37 @@ vnc_password= "{vnc_passwd}"
         m.execute(f"qemu-img create {TestMachinesCreate.TestCreateConfig.VALID_DISK_IMAGE_PATH} 500M")
 
         runner.checkDialogErrorTest(TestMachinesCreate.VmDialog(self, sourceType='os',
-                                                                os_name=config.RHEL_5_0,
-                                                                os_short_id=config.RHEL_5_0_SHORTID,
+                                                                os_name=config.RHEL_8_1,
+                                                                os_short_id=config.RHEL_8_1_SHORTID,
                                                                 offline_token="invalid_token",
                                                                 create_and_run=True),
                                     ["404"])
 
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='os',
-                                                      os_name=config.RHEL_5_0,
-                                                      os_short_id=config.RHEL_5_0_SHORTID,
+                                                      os_name=config.RHEL_8_1,
+                                                      os_short_id=config.RHEL_8_1_SHORTID,
                                                       offline_token="my_offline_token",
                                                       create_and_run=False))
 
-        m.execute("rm /var/lib/libvirt/images/rhel-5-0-boot.iso")
+        m.execute("rm /var/lib/libvirt/images/rhel-8-1-boot.iso")
 
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='os',
-                                                      os_name=config.RHEL_5_0,
-                                                      os_short_id=config.RHEL_5_0_SHORTID,
+                                                      os_name=config.RHEL_8_1,
+                                                      os_short_id=config.RHEL_8_1_SHORTID,
                                                       offline_token="my_offline_token",
                                                       create_and_run=True))
 
         # If run on different connection, the downloaded iso should be stored in ~/.local/share/libvirt/images/
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='os',
-                                                      os_name=config.RHEL_5_0,
-                                                      os_short_id=config.RHEL_5_0_SHORTID,
+                                                      os_name=config.RHEL_8_1,
+                                                      os_short_id=config.RHEL_8_1_SHORTID,
                                                       offline_token="my_offline_token",
                                                       create_and_run=True,
                                                       connection="session"),
                           check_env_empty=False)
+
+        # Check only RHEL >= 8 are available for download
+        runner.checkRhelIsDownloadableTest(TestMachinesCreate.VmDialog(self))
 
 
 if __name__ == '__main__':

--- a/test/files/mock-rhsm-rest
+++ b/test/files/mock-rhsm-rest
@@ -32,7 +32,7 @@ class handler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.end_headers()
             self.wfile.write(b'{ "body": [\
-                {"imageName": "RHEL 5.0 Boot ISO", "filename": "rhel-5-0-boot.iso",\
+                {"imageName": "RHEL 8.1 Boot ISO", "filename": "rhel-8-1-boot.iso",\
                 "downloadHref": "https://api.access.redhat.com/management/v1/images/my_image_checksum/download"}\
             ] }\n')
             return


### PR DESCRIPTION
RHSM listImageDownloadsByVersionArch API[1] only works for RHEL images
with a version >= 8. Therefore, we should only provide 'Download OS'
option for images with that version

[1] https://access.redhat.com/management/api/rhsm#/images/listImageDownloadsByVersionArch

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2118236