### PR TITLE
Show appropriate error message if RHEL image is not available

### DIFF
--- a/src/scripts/rhsm/get_rhel_image_url.py
+++ b/src/scripts/rhsm/get_rhel_image_url.py
@@ -16,6 +16,12 @@ except urllib.error.URLError as error:
 if "error" in ret_obj:
     sys.exit(ret_obj["error"])
 
+# If certain version of RHEL is not available for download through RHSM API (e.g. it's not released yet),
+# RHSM just returns an empty object: { body: [] }.
+# Show appropriate error message in such situation
+if len(ret_obj["body"]) == 0:
+    sys.exit(f"No image available for RHEL {args['rhelVersion']} ({args['arch']}).")
+
 for downloadable_content in ret_obj["body"]:
     if downloadable_content["filename"].endswith("boot.iso"):
         download_url = downloadable_content["downloadHref"]

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -696,9 +696,11 @@ vnc_password= "{vnc_passwd}"
         FEDORA_29_SHORTID = 'fedora29'
 
         RHEL_8_1 = 'Red Hat Enterprise Linux 8.1 (Ootpa)'
-        RHEL_8_1_SHORTID = 'rhel8.test'
+        RHEL_8_1_SHORTID = 'rhel8.1'
+        RHEL_8_2 = 'Red Hat Enterprise Linux 8.2 (Ootpa)'
+        RHEL_8_2_SHORTID = 'rhel8.2'
         RHEL_7_1 = 'Red Hat Enterprise Linux 7.1'
-        RHEL_7_1_SHORTID = 'rhel7.test'
+        RHEL_7_1_SHORTID = 'rhel7.1'
 
         CENTOS_7 = 'CentOS 7'
 
@@ -1079,7 +1081,7 @@ vnc_password= "{vnc_passwd}"
             if self.expected_os_name:
                 b.wait_attr("#os-select-group input", "value", self.expected_os_name)
 
-            if self.sourceType == "os" and self.os_name == TestMachinesCreate.TestCreateConfig.RHEL_8_1:
+            if self.sourceType == "os" and self.os_name in [TestMachinesCreate.TestCreateConfig.RHEL_8_1, TestMachinesCreate.TestCreateConfig.RHEL_8_2]:
                 b.set_input_text("#offline-token", self.offline_token)
 
             if self.sourceType != 'disk_image':
@@ -1309,7 +1311,7 @@ vnc_password= "{vnc_passwd}"
             self.test_obj.addCleanup(self.machine.execute, "umount /usr/share/osinfo/os/fedoraproject.org/fedora-29.xml || true")
 
         def _fakeOsDBInfoRhel(self):
-            # Fake rhel 8 image
+            # Fake rhel 8 images
             rhel_8_1_xml = self.machine.execute("cat /usr/share/osinfo/os/redhat.com/rhel-8.1.xml")
             root = ET.fromstring(rhel_8_1_xml)
             root.find('os').find('resources').find('minimum').find('ram').text = '134217728'
@@ -1318,6 +1320,15 @@ vnc_password= "{vnc_passwd}"
             self.machine.execute(f"echo '{str(new_rhel_8_1_xml, 'utf-8')}' > {self.test_obj.vm_tmpdir}/rhel-8.1.xml")
             self.machine.execute(f"mount -o bind  {self.test_obj.vm_tmpdir}/rhel-8.1.xml /usr/share/osinfo/os/redhat.com/rhel-8.1.xml")
             self.test_obj.addCleanup(self.machine.execute, "umount /usr/share/osinfo/os/redhat.com/rhel-8.1.xml || true")
+
+            rhel_8_2_xml = self.machine.execute("cat /usr/share/osinfo/os/redhat.com/rhel-8.2.xml")
+            root = ET.fromstring(rhel_8_2_xml)
+            root.find('os').find('resources').find('minimum').find('ram').text = '134217728'
+            root.find('os').find('resources').find('minimum').find('storage').text = '134217728'
+            new_rhel_8_2_xml = ET.tostring(root)
+            self.machine.execute(f"echo '{str(new_rhel_8_2_xml, 'utf-8')}' > {self.test_obj.vm_tmpdir}/rhel-8.2.xml")
+            self.machine.execute(f"mount -o bind  {self.test_obj.vm_tmpdir}/rhel-8.2.xml /usr/share/osinfo/os/redhat.com/rhel-8.2.xml")
+            self.test_obj.addCleanup(self.machine.execute, "umount /usr/share/osinfo/os/redhat.com/rhel-8.2.xml || true")
 
             # Fake rhel 7 image
             rhel_7_1_xml = self.machine.execute("cat /usr/share/osinfo/os/redhat.com/rhel-7.1.xml")
@@ -1902,6 +1913,13 @@ vnc_password= "{vnc_passwd}"
                                                                 offline_token="invalid_token",
                                                                 create_and_run=True),
                                     ["404"])
+
+        runner.checkDialogErrorTest(TestMachinesCreate.VmDialog(self, sourceType='os',
+                                                                os_name=config.RHEL_8_2,
+                                                                os_short_id=config.RHEL_8_2_SHORTID,
+                                                                offline_token="my_offline_token",
+                                                                create_and_run=True),
+                                    ["No image available for RHEL 8.2"])
 
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='os',
                                                       os_name=config.RHEL_8_1,

--- a/test/files/mock-rhsm-rest
+++ b/test/files/mock-rhsm-rest
@@ -26,7 +26,7 @@ class handler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         authorization = self.headers['Authorization']
-        m = self.match("/management/v1/images/rhel/.*/.*")
+        m = self.match("/management/v1/images/rhel/8.1/.*")
 
         if m and authorization == 'Bearer my_access_token':
             self.send_response(200)
@@ -35,6 +35,13 @@ class handler(BaseHTTPRequestHandler):
                 {"imageName": "RHEL 8.1 Boot ISO", "filename": "rhel-8-1-boot.iso",\
                 "downloadHref": "https://api.access.redhat.com/management/v1/images/my_image_checksum/download"}\
             ] }\n')
+            return
+
+        m = self.match("/management/v1/images/rhel/.*/.*")
+        if m and authorization == 'Bearer my_access_token':
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'{ "body": [] }\n')
             return
 
         m = self.match("/management/v1/images/my_image_checksum/download")


### PR DESCRIPTION
If certain version of RHEL is not available for download through RHSM
API (e.g. it's not released yet), RHSM just returns an empty object:
{ body: [] }.
Show appropriate error message in such situation

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2119682