### PR TITLE
test: fix some possible race conditions

### DIFF
--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -146,16 +146,15 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # the shut off button beside the VM name
-        self.machine.execute(f"echo '' > {args['logfile']}")
         wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
         b.click("#vm-subVmTest1-system-shutdown-button")
         b.wait_in_text("#vm-subVmTest1-system-state", "Shut off")
         b.wait_visible("#vm-subVmTest1-system-run")
 
         # the shut off button in the extended operation list
+        self.machine.execute(f"echo '' > {args['logfile']}")
         b.click("#vm-subVmTest1-system-run")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
-        self.machine.execute(f"echo '' > {args['logfile']}")
         wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
         self.performAction("subVmTest1", "off")
 


### PR DESCRIPTION
If the VM boot process finishes too fast,  'wait' will be never successful. Thus, remove one 'log clear' which is not necessary, and change one 'log clear' before VM running