### PR TITLE
packit: Drop Fedora 35, add Fedora 37

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -73,7 +73,7 @@ css or other issues:
 # Running tests locally
 
 Run `make vm` to build an RPM and install it into a standard Cockpit test VM.
-This will be `fedora-35` by default. You can set `$TEST_OS` to use a different
+This will be `fedora-36` by default. You can set `$TEST_OS` to use a different
 image, for example
 
     TEST_OS=centos-8-stream make vm

--- a/packit.yaml
+++ b/packit.yaml
@@ -19,9 +19,9 @@ jobs:
   - job: tests
     trigger: pull_request
     targets:
-      - fedora-35
       - fedora-36
-      - fedora-rawhide
+      - fedora-37
+      - fedora-development
       - centos-stream-8
       - centos-stream-9
 
@@ -31,9 +31,8 @@ jobs:
     project: "cockpit-preview"
     preserve_project: True
     targets:
-      - fedora-35
       - fedora-36
-      - fedora-development
+      - fedora-37
       - centos-stream-8-x86_64
       - centos-stream-9-x86_64
     actions:
@@ -48,19 +47,19 @@ jobs:
     trigger: release
     dist_git_branches:
       - fedora-development
-      - fedora-35
       - fedora-36
+      - fedora-37
 
   - job: koji_build
     trigger: commit
     dist_git_branches:
       - fedora-development
-      - fedora-35
       - fedora-36
+      - fedora-37
 
   - job: bodhi_update
     trigger: commit
     dist_git_branches:
       # rawhide updates are created automatically
-      - fedora-35
       - fedora-36
+      - fedora-37


### PR DESCRIPTION
As usual, keep supporting the two most recent branched versions.

Also drop Rawhide from our cockpit-preview COPR build: We directly
upload new releases to Rawhide anyway, so this is redundant.

Rename "fedora-rawhide" to "fedora-development" in tests job for
consistency.

---

This PR also adjusts tests on our infra for fedora-37. I already found [at least one SELinux regression](https://bugzilla.redhat.com/show_bug.cgi?id=2083900), so we'll have to add some naughties first.

 - https://github.com/cockpit-project/bots/pull/3797
 - https://github.com/cockpit-project/bots/pull/3798
 - https://github.com/cockpit-project/bots/pull/3801