### PR TITLE
Use initial password for password fields in VM create dialog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = 1e5f74b9f5e486fca7aa87670983254a2288f37a # 275 + test/common/{net,storage}lib.py
+COCKPIT_REPO_COMMIT = 47642abc13e3d93e73cea5acca2c08237afb8142 # 275 + test/common/{net,storage}lib.py + PasswordFormFields
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'

--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -595,7 +595,7 @@ const UsersConfigurationRow = ({
 
     return (
         <>
-            <PasswordFormFields password={rootPassword}
+            <PasswordFormFields initial_password={rootPassword}
                                 password_label={_("Root password")}
                                 password_strength={root_pwd_strength}
                                 idPrefix="create-vm-dialog-root-password"
@@ -615,7 +615,7 @@ const UsersConfigurationRow = ({
                                value={userLogin || ''}
                                onChange={value => onValueChanged('userLogin', value)} />
                 </FormGroup>
-                <PasswordFormFields password={userPassword}
+                <PasswordFormFields initial_password={userPassword}
                                     password_label={_("User password")}
                                     password_strength={user_pwd_strength}
                                     idPrefix="create-vm-dialog-user-password"

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -164,6 +164,10 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                                          create_and_run=True),
                                              {"create-vm-dialog-user-login": "User login must not be empty when user password is set"})
 
+        # Check swithing from "os" to "cloud" source type doesn't reset passwords
+        # https://bugzilla.redhat.com/show_bug.cgi?id=2109986
+        runner.checkPasswordsAreNotResetTest(TestMachinesCreate.VmDialog(self))
+
     def testCreateNameGeneration(self):
         config = TestMachinesCreate.TestCreateConfig
         runner = TestMachinesCreate.CreateVmRunner(self)
@@ -909,6 +913,30 @@ vnc_password= "{vnc_passwd}"
 
             return self
 
+        def checkPasswordsAreNotReset(self):
+            b = self.browser
+
+            b.select_from_dropdown("#source-type", "os")
+            b.set_input_text("#os-select-group input", "Fedora")
+            b.click(f"#os-select li button:contains('{TestMachinesCreate.TestCreateConfig.FEDORA_28}')")
+            b.wait_attr_contains("#os-select-group input", "value", TestMachinesCreate.TestCreateConfig.FEDORA_28)
+            b.wait_not_present("#navbar-oops")
+
+            b.click("#pf-tab-1-automation")
+            b.set_input_text("#create-vm-dialog-user-password-pw1", "foobaruser")
+            b.set_input_text("#create-vm-dialog-root-password-pw1", "foobarroot")
+
+            b.click("#pf-tab-0-details-tab")
+            b.select_from_dropdown("#source-type", "cloud")
+
+            b.click("#pf-tab-1-automation")
+
+            # Check swithing from "os" to "cloud" sourcetype did not reset passwords
+            b.wait_attr("#create-vm-dialog-user-password-pw1", "value", "foobaruser")
+            b.wait_attr("#create-vm-dialog-root-password-pw1", "value", "foobarroot")
+
+            return self
+
         def checkOsFiltered(self, present=False):
             b = self.browser
 
@@ -1607,6 +1635,11 @@ vnc_password= "{vnc_passwd}"
 
         def checkOsInputTest(self, dialog):
             dialog.open().checkOsInput().cancel(True)
+
+            self._assertScriptFinished().checkEnvIsEmpty()
+
+        def checkPasswordsAreNotResetTest(self, dialog):
+            dialog.open().checkPasswordsAreNotReset().cancel(True)
 
             self._assertScriptFinished().checkEnvIsEmpty()
 


### PR DESCRIPTION
Password fields are different component instances when you switch
between Cloud base image and Download OS. This causes a bug:
When user sets user/root password, and then changes Installation type,
it will reset the passwords, since a different component instance of the
password field rendered. This is however not ideal behaviour.
Using the initial password value would fix this.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2109986