### PR TITLE
Fix undefined dialogs at console page

### DIFF
--- a/src/components/vm/consoles/consoles.jsx
+++ b/src/components/vm/consoles/consoles.jsx
@@ -36,7 +36,7 @@ const _ = cockpit.gettext;
 
 const VmNotRunning = () => {
     return (
-        <div>
+        <div id="vm-not-running-message">
             {_("Please start the virtual machine to access its console.")}
         </div>
     );

--- a/src/components/vm/vmDetailsPage.jsx
+++ b/src/components/vm/vmDetailsPage.jsx
@@ -102,27 +102,29 @@ export const VmDetailsPage = ({
 
     if (cockpit.location.path[1] == "console") {
         return (
-            <Page groupProps={{ sticky: 'top' }}
-                  id={"vm-" + vm.name + "-consoles-page"}
-                  isBreadcrumbGrouped
-                  breadcrumb={
-                      <Breadcrumb className='machines-listing-breadcrumb'>
-                          <BreadcrumbItem to='#'>
-                              {_("Virtual machines")}
-                          </BreadcrumbItem>
-                          <BreadcrumbItem to={'#' + cockpit.format("vm?name=$0&connection=$1", encodeURIComponent(vm.name), vm.connectionName)}>
-                              {vm.name}
-                          </BreadcrumbItem>
-                          <BreadcrumbItem isActive>
-                              {_("Console")}
-                          </BreadcrumbItem>
-                      </Breadcrumb>}>
-                {vmActionsPageSection}
-                <PageSection variant={PageSectionVariants.light}>
-                    <Consoles vm={vm} config={config}
-                        onAddErrorNotification={onAddErrorNotification} />
-                </PageSection>
-            </Page>
+            <WithDialogs>
+                <Page groupProps={{ sticky: 'top' }}
+                      id={"vm-" + vm.name + "-consoles-page"}
+                      isBreadcrumbGrouped
+                      breadcrumb={
+                          <Breadcrumb className='machines-listing-breadcrumb'>
+                              <BreadcrumbItem to='#'>
+                                  {_("Virtual machines")}
+                              </BreadcrumbItem>
+                              <BreadcrumbItem to={'#' + cockpit.format("vm?name=$0&connection=$1", encodeURIComponent(vm.name), vm.connectionName)}>
+                                  {vm.name}
+                              </BreadcrumbItem>
+                              <BreadcrumbItem isActive>
+                                  {_("Console")}
+                              </BreadcrumbItem>
+                          </Breadcrumb>}>
+                    {vmActionsPageSection}
+                    <PageSection variant={PageSectionVariants.light}>
+                        <Consoles vm={vm} config={config}
+                            onAddErrorNotification={onAddErrorNotification} />
+                    </PageSection>
+                </Page>
+            </WithDialogs>
         );
     }
 

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -55,7 +55,7 @@ EXCLUDES="$EXCLUDES
           TestMachinesConsoles.testInlineConsole
           TestMachinesConsoles.testInlineConsoleWithUrlRoot
           TestMachinesConsoles.testSerialConsole
-          TestMachinesConsoles.testSwitchConsoleFromSerialToGraphical
+          TestMachinesConsoles.testBasic
 
           TestMachinesDisks.testAddDiskAdditionalOptions
           TestMachinesDisks.testAddDiskCustomPath

--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -187,6 +187,11 @@ class TestMachinesConsoles(VirtualMachinesCase):
         # Go to the expanded console view
         b.click("button:contains(Expand)")
 
+        # Test message is present if VM is not running
+        self.performAction(name, "forceOff", checkExpectedState=False)
+
+        b.wait_in_text("#vm-not-running-message", "start the virtual machine")
+
         # Test deleting VM from console page will not trigger any error
         self.performAction(name, "delete")
         b.wait_visible(f"#vm-{name}-delete-modal-dialog")

--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -152,9 +152,9 @@ class TestMachinesConsoles(VirtualMachinesCase):
         self.allow_journal_messages(".* couldn't shutdown fd: Transport endpoint is not connected")
         self.allow_journal_messages("127.0.0.1:5900: couldn't read: Connection refused")
 
-    def testSwitchConsoleFromSerialToGraphical(self):
+    def testBasic(self):
         b = self.browser
-        name = "vmForSwitching"
+        name = "subVmTest1"
 
         self.createVm(name, graphics="vnc", ptyconsole=True)
 
@@ -165,6 +165,7 @@ class TestMachinesConsoles(VirtualMachinesCase):
         self.goToVmPage(name)
         b.wait_in_text(f"#vm-{name}-system-state", "Running")
 
+        # test switching console from serial to graphical
         b.wait_visible(f"#vm-{name}-consoles")
         b.wait_visible(".pf-c-console__vnc canvas")
 
@@ -175,6 +176,23 @@ class TestMachinesConsoles(VirtualMachinesCase):
 
         b.wait_not_present(".pf-c-console__vnc canvas")
         b.wait_visible(f"#{name}-terminal")
+
+        # Go back to Vnc console
+        b.click("#pf-c-console__type-selector")
+        b.wait_visible("#pf-c-console__type-selector + .pf-c-select__menu")
+        b.click("#VncConsole button")
+        b.wait_not_present("#pf-c-console__type-selector + .pf-c-select__menu")
+        b.wait_visible(".pf-c-console__vnc canvas")
+
+        # Go to the expanded console view
+        b.click("button:contains(Expand)")
+
+        # Test deleting VM from console page will not trigger any error
+        self.performAction(name, "delete")
+        b.wait_visible(f"#vm-{name}-delete-modal-dialog")
+        b.click(f"#vm-{name}-delete-modal-dialog button:contains(Delete)")
+        b.wait_in_text("body", "Virtual machines")
+        self.waitVmRow(name, present=False)
 
         b.wait_not_present("#navbar-oops")
 


### PR DESCRIPTION
Without WithDialogs, trying to delete VM from console page would cause
a runtime error: "Uncaught TypeError: Dialogs is undefined".

Also, since I'm already re-writing test for console page, 
I added a test which checks console page with shut-off VM.
