### PR TITLE
test: Wait for a correct dialog to be closed

### DIFF
--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -461,12 +461,13 @@ class TestMachinesSettings(VirtualMachinesCase):
 
         # Change CPU model setting
         b.click("#vm-subVmTest1-cpu-model button")
+        b.wait_visible("#machines-cpu-type-modal")
         cpu_model = "host-model"
         if m.image in distrosWithDefaultHostModel:
             cpu_model = "host-passthrough"
         b.select_from_dropdown("#cpu-model-select-group select", cpu_model)
         b.click("#cpu-config-dialog-apply")
-        b.wait_not_present("#machines-vcpu-modal-dialog")
+        b.wait_not_present("#machines-cpu-type-modal")
         b.wait_visible("#cpu-tooltip")
 
         # Change vCPUs setting


### PR DESCRIPTION
The testMultipleSettings was using incorrect selector to check that the dialog is closed. This caused that test would continue while the dialog is still open, resulting in a race condition in the image-refresh[1].

[1] https://github.com/cockpit-project/bots/pull/3893