### PR TITLE
packit: Drop targets list from COPR build

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -30,11 +30,6 @@ jobs:
     owner: "@cockpit"
     project: "cockpit-preview"
     preserve_project: True
-    targets:
-      - fedora-36
-      - fedora-37
-      - centos-stream-8-x86_64
-      - centos-stream-9-x86_64
     actions:
       post-upstream-clone: make cockpit-machines.spec
       # HACK: tarball for releases (copr_build, koji, etc.), copying spec's Source0; this


### PR DESCRIPTION
Hardcoding this list is redundant and hard to change: changing the COPR config and updating all our projects' packit.yml files needs to happen in lockstep.

packit now learned to just read the configuration from an existing COPR repository, so drop the target list entirely. See
https://github.com/packit/packit-service/issues/1499

----

I tested this on cockpit-ostree, see https://github.com/cockpit-project/cockpit-ostree/pull/283