### PR TITLE
fmf: Run storage and network tests in separate test plans

### DIFF
--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -1,6 +1,0 @@
-summary:
-    Run all tests
-discover:
-    how: fmf
-execute:
-    how: tmt

--- a/plans/basic.fmf
+++ b/plans/basic.fmf
@@ -1,0 +1,7 @@
+summary:
+    Run basic tests (creation and lifetime)
+discover:
+    how: fmf
+    test: /test/browser/basic
+execute:
+    how: tmt

--- a/plans/network.fmf
+++ b/plans/network.fmf
@@ -1,0 +1,7 @@
+summary:
+    Run network related tests
+discover:
+    how: fmf
+    test: /test/browser/network
+execute:
+    how: tmt

--- a/plans/storage.fmf
+++ b/plans/storage.fmf
@@ -1,0 +1,7 @@
+summary:
+    Run storage related tests
+discover:
+    how: fmf
+    test: /test/browser/storage
+execute:
+    how: tmt

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -eux
 
+# like "basic", passed on to run-test.sh
+PLAN="$1"
+
 TESTS="$(realpath $(dirname "$0"))"
 if [ -d source ]; then
     # path for standard-test-source
@@ -80,7 +83,7 @@ if [ "$ID" = fedora ] && [ "$VERSION_ID" -ge "36" ]; then
 fi
 
 # Run tests as unprivileged user
-su - -c "env TEST_BROWSER=firefox SOURCE=$SOURCE LOGS=$LOGS $TESTS/run-test.sh" runtest
+su - -c "env TEST_BROWSER=firefox SOURCE=$SOURCE LOGS=$LOGS $TESTS/run-test.sh $PLAN" runtest
 
 RC=$(cat $LOGS/exitcode)
 exit ${RC:-1}

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -1,22 +1,64 @@
-summary:
-    Run browser integration tests on the host
-require:
-  - cockpit-system
-  - cockpit-ws
-  # build/test infra dependencies
-  - virt-install
-  - bzip2
-  - git-core
-  - libvirt-python3
-  - make
-  - nodejs
-  - python3
-  - python3-yaml
-  # required by tests
-  - dbus-tools
-  - firewalld
-  - libvirt-daemon-driver-storage-iscsi
-  - libvirt-daemon-driver-storage-logical
-  - targetcli
-test: ./browser.sh
-duration: 60m
+/basic:
+  summary: Run browser integration for basic functionality
+  require:
+    - cockpit-system
+    - cockpit-ws
+    # build/test infra dependencies
+    - virt-install
+    - bzip2
+    - git-core
+    - libvirt-python3
+    - make
+    - nodejs
+    - python3
+    - python3-yaml
+    # required by tests
+    - dbus-tools
+    - firewalld
+    - libvirt-daemon-driver-storage-iscsi
+    - targetcli
+  test: ./browser.sh basic
+  duration: 60m
+
+/network:
+  summary: Run browser integration for network functionality
+  require:
+    - cockpit-system
+    - cockpit-ws
+    # build/test infra dependencies
+    - virt-install
+    - bzip2
+    - git-core
+    - libvirt-python3
+    - make
+    - nodejs
+    - python3
+    - python3-yaml
+    # required by tests
+    - dbus-tools
+    - firewalld
+  test: ./browser.sh network
+  duration: 60m
+
+/storage:
+  summary: Run browser integration for storage functionality
+  require:
+    - cockpit-system
+    - cockpit-ws
+    # build/test infra dependencies
+    - virt-install
+    - bzip2
+    - git-core
+    - libvirt-python3
+    - make
+    - nodejs
+    - python3
+    - python3-yaml
+    # required by tests
+    - dbus-tools
+    - firewalld
+    - libvirt-daemon-driver-storage-iscsi
+    - libvirt-daemon-driver-storage-logical
+    - targetcli
+  test: ./browser.sh storage
+  duration: 60m


### PR DESCRIPTION
On the Testing Farm we can run up to 5 parallel test plans. So split the tests into three plans "basic", "network", and "storage".

This mitigates the utterly slow Fedora Rawhide tests due to a kernel bug [1], and also should generally speed up results.

We previously skipped all TestMachinesConsoles tests, so drop that whole block and just not run TestConsoles in any plan. Once that is reconsidered, let's re-evaluate why the tests fail.

Similarly, TestMachinesMigration cannot be run in TMT, so drop the "skip all tests" block and just don't run it in any plan.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2139658

----

This should fix the [rawhide timeouts](https://artifacts.dev.testing-farm.io/88a56cd5-c943-4d7c-b34e-dfecd9797b49/), and also speed up results on the sane Fedora releases. Same approach as in https://github.com/cockpit-project/cockpit/pull/17873