### PR TITLE
fmf: Factorize and merge plan files

### DIFF
--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -1,0 +1,19 @@
+discover:
+    how: fmf
+execute:
+    how: tmt
+
+/basic:
+    summary: Run basic tests (creation and lifetime)
+    discover+:
+        test: /test/browser/basic
+
+/network:
+    summary: Run network related tests
+    discover+:
+        test: /test/browser/network
+
+/storage:
+    summary: Run storage related tests
+    discover+:
+        test: /test/browser/storage

--- a/plans/basic.fmf
+++ b/plans/basic.fmf
@@ -1,7 +1,0 @@
-summary:
-    Run basic tests (creation and lifetime)
-discover:
-    how: fmf
-    test: /test/browser/basic
-execute:
-    how: tmt

--- a/plans/network.fmf
+++ b/plans/network.fmf
@@ -1,7 +1,0 @@
-summary:
-    Run network related tests
-discover:
-    how: fmf
-    test: /test/browser/network
-execute:
-    how: tmt

--- a/plans/storage.fmf
+++ b/plans/storage.fmf
@@ -1,7 +1,0 @@
-summary:
-    Run storage related tests
-discover:
-    how: fmf
-    test: /test/browser/storage
-execute:
-    how: tmt


### PR DESCRIPTION
FMF plans can inherit common properties [1]. Go back to a single plans/all.fmf (like it was until commit cf0fec7e71), put the common properties at the top, and enumerate the three plans with their specific properties.

This will make it easier to keep the Fedora downstream dist-git in sync.

[1] https://tmt.readthedocs.io/en/latest/examples.html#inherit-plans