### PR TITLE
Check offline token only when the source type is 'Download an OS'

### DIFF
--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -222,7 +222,7 @@ function validateParams(vmParams) {
             validationFailed.source = _("Installation source must not be empty");
     }
 
-    if (vmParams.os && needsRHToken(vmParams.os.shortId) && isEmpty(vmParams.offlineToken))
+    if (vmParams.sourceType == DOWNLOAD_AN_OS && vmParams.os && needsRHToken(vmParams.os.shortId) && isEmpty(vmParams.offlineToken))
         validationFailed.offlineToken = _("Offline token must not be empty");
 
     if (vmParams.memorySize === 0) {

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1995,6 +1995,17 @@ vnc_password= "{vnc_passwd}"
                                               "Error",
                                               True)
 
+        # Check create buttons do not get disabled when RHEL is selected for sourceType != 'os' (Download an OS)
+        dialog = TestMachinesCreate.VmDialog(self, sourceType='url',
+                                             location=config.VALID_URL,
+                                             os_name=config.RHEL_8_1,
+                                             os_short_id=config.RHEL_8_1_SHORTID) \
+            .open() \
+            .fill()
+        b.wait_visible(".pf-c-modal-box__footer button:contains(Create and run)[aria-disabled=false]")
+        b.wait_visible(".pf-c-modal-box__footer button:contains(Create and edit)[aria-disabled=false]")
+        dialog.cancel()
+
         runner.checkDialogErrorTest(TestMachinesCreate.VmDialog(self, sourceType='os',
                                                                 os_name=config.RHEL_8_2,
                                                                 os_short_id=config.RHEL_8_2_SHORTID,


### PR DESCRIPTION
For now, all source type will check offline token when OS is RHEL, that will cause 'Create and run'/'Create and edit' button disabled unexpectedly, add a filter to check offline token only when the source type is 'Download an OS'