### PR TITLE
Use sentence case for form field labels

### DIFF
--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -873,7 +873,7 @@ const StorageRow = ({ connectionName, allowNoDisk, storageSize, storageSizeUnit,
 
             { storagePoolName === "NewVolume" &&
             <>
-                <FormGroup label={_("Storage Limit")} fieldId='storage-limit'
+                <FormGroup label={_("Storage limit")} fieldId='storage-limit'
                            id='storage-group'
                            validated={validationStateStorage}
                            helperText={helperTextNewVolume}


### PR DESCRIPTION
Following the guidelines from Patternfly:
https://www.patternfly.org/v4/ux-writing/capitalization/#capitalization-across-red-hat-uis