### PR TITLE
Limit disk source column to 25% of the whole 'Disks' table width

### DIFF
--- a/src/components/vm/disks/vmDisksCard.jsx
+++ b/src/components/vm/disks/vmDisksCard.jsx
@@ -218,7 +218,7 @@ export const VmDisksCard = ({ vm, vms, disks, renderCapacity, supportedDiskBusTy
             columns.push({ title: access });
         }
 
-        columns.push({ title: <DiskSourceCell diskSource={disk.source} idPrefix={idPrefixRow} /> });
+        columns.push({ title: <DiskSourceCell diskSource={disk.source} idPrefix={idPrefixRow} />, props: { width: 25 } });
 
         if (renderAdditional) {
             columns.push({


### PR DESCRIPTION
The disk source text is sometimes expressed as file path, making that column take too much space compared to the rest.

Fixes #813