### PR TITLE
Reduce breakpoint width for device cards

### DIFF
--- a/src/components/vm/disks/vmDisksCard.jsx
+++ b/src/components/vm/disks/vmDisksCard.jsx
@@ -244,7 +244,7 @@ export const VmDisksCard = ({ vm, vms, disks, renderCapacity, supportedDiskBusTy
     return (
         <>
             <ListingTable variant='compact'
-                gridBreakPoint='grid-xl'
+                gridBreakPoint='grid-lg'
                 emptyCaption={_("No disks defined for this VM")}
                 aria-label={`VM ${vm.name} Disks`}
                 columns={columnTitles}

--- a/src/components/vm/filesystems/vmFilesystemsCard.jsx
+++ b/src/components/vm/filesystems/vmFilesystemsCard.jsx
@@ -86,7 +86,7 @@ export const VmFilesystemsCard = ({ connectionName, vmName, vmState, filesystems
     return (
         <>
             <ListingTable variant='compact'
-                          gridBreakPoint='grid-xl'
+                          gridBreakPoint='grid-lg'
                           emptyCaption={_("No directories shared between the host and this VM")}
                           columns={columnTitles}
                           rows={rows} />

--- a/src/components/vm/hostdevs/hostDevCard.jsx
+++ b/src/components/vm/hostdevs/hostDevCard.jsx
@@ -315,7 +315,7 @@ export const VmHostDevCard = ({ vm, nodeDevices, config }) => {
 
     return (
         <ListingTable aria-label={cockpit.format(_("VM $0 Host Devices"), vm.name)}
-                      gridBreakPoint='grid-xl'
+                      gridBreakPoint='grid-lg'
                       variant='compact'
                       emptyCaption={_("No host devices assigned to this VM")}
                       rows={rows}

--- a/src/components/vm/nics/vmNicsCard.jsx
+++ b/src/components/vm/nics/vmNicsCard.jsx
@@ -448,7 +448,7 @@ export class VmNetworkTab extends React.Component {
 
         return (
             <ListingTable aria-label={`VM ${vm.name} Network Interface Cards`}
-                          gridBreakPoint='grid-xl'
+                          gridBreakPoint='grid-lg'
                           variant='compact'
                           emptyCaption={_("No network interfaces defined for this VM")}
                           columns={columnTitles}

--- a/src/components/vm/snapshots/vmSnapshotsCard.jsx
+++ b/src/components/vm/snapshots/vmSnapshotsCard.jsx
@@ -204,7 +204,7 @@ export class VmSnapshotsCard extends React.Component {
 
         return (
             <ListingTable aria-label={`VM ${vm.name} Snapshots Cards`}
-                          gridBreakPoint='grid-xl'
+                          gridBreakPoint='grid-lg'
                           variant="compact"
                           emptyCaption={_("No snapshots defined for this VM")}
                           emptyCaptionDetail={_("Previously taken snapshots allow you to revert to an earlier state if something goes wrong")}

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -60,8 +60,12 @@ class TestMachinesNICs(VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-network-1-source", "default")
         b.wait_in_text("#vm-subVmTest1-network-1-ipv4-address", "192.168.122.")
         b.wait_in_text("#vm-subVmTest1-network-1-state", "up")
-
-        b.assert_pixels("#vm-subVmTest1-networks", "vm-details-nics-card", ignore=["#vm-subVmTest1-network-1-mac", "#vm-subVmTest1-network-1-ipv4-address"])
+        b.assert_pixels("#vm-subVmTest1-networks",
+                        "vm-details-nics-card",
+                        ignore=["#vm-subVmTest1-network-1-mac", "#vm-subVmTest1-network-1-ipv4-address"],
+                        # MAC and IP address values are not static, and their values affect the width of their columns and neighbouring columns
+                        # With medium layout this variable width of the columns makes pixel tests references of the table different each test run
+                        skip_layouts=["medium"])
 
         # Remove default interface
         self.deleteIface(1)


### PR DESCRIPTION
The breakpoint width was collapsing far too soon. Ideally, we'd want it at `md`, not `lg`, but there's a problem around the first few pixels. I think it's a side effect of PF's breakpoints being wonky (and us still not having a proper solution for that).

Meanwhile, `lg` is a big improvement over `xl` (which is what it's currently set at).