### PR TITLE
Limit use of primary buttons; switch to secondary

### DIFF
--- a/src/components/common/deleteResource.jsx
+++ b/src/components/common/deleteResource.jsx
@@ -103,8 +103,14 @@ DeleteResourceModal.propTypes = {
     deleteHandler: PropTypes.func.isRequired
 };
 
-export const DeleteResourceButton = ({ objectId, disabled, overlayText, actionName, dialogProps, isLink, isInline, className, isDropdownItem }) => {
+export const DeleteResourceButton = ({ objectId, disabled, overlayText, actionName, dialogProps, isLink, isInline, isSecondary, className, isDropdownItem }) => {
     const Dialogs = useDialogs();
+
+    let variant = "danger";
+    if (isSecondary)
+        variant = "secondary";
+    if (isLink)
+        variant = "link";
 
     const button = (isDropdownItem
         ? <DropdownItem className={className ? `pf-m-danger ${className}` : "pf-m-danger"}
@@ -116,8 +122,8 @@ export const DeleteResourceButton = ({ objectId, disabled, overlayText, actionNa
         </DropdownItem>
         : <Button id={`delete-${objectId}`}
                   className={className}
-                  variant={isLink ? 'link' : 'danger'}
-                  isDanger={isLink}
+                  variant={variant}
+                  isDanger={isLink || isSecondary}
                   isInline={isInline}
                   onClick={() => Dialogs.show(<DeleteResourceModal {...dialogProps} />)}
                   isDisabled={disabled}>

--- a/src/components/vm/filesystems/vmFilesystemsCard.jsx
+++ b/src/components/vm/filesystems/vmFilesystemsCard.jsx
@@ -68,7 +68,8 @@ export const VmFilesystemsCard = ({ connectionName, vmName, vmState, filesystems
                                           actionName: _("Remove"),
                                           deleteHandler: () => domainDeleteFilesystem({ connectionName, vmName, target: filesystemTarget }),
                                       }}
-                                      overlayText={_("Deleting shared directories is possible only when the guest is shut off")} />
+                                      overlayText={_("Deleting shared directories is possible only when the guest is shut off")}
+                                      isSecondary />
             </div>
         );
         const columns = [

--- a/src/components/vm/hostdevs/hostDevCard.jsx
+++ b/src/components/vm/hostdevs/hostDevCard.jsx
@@ -268,7 +268,8 @@ export const VmHostDevCard = ({ vm, nodeDevices, config }) => {
                                                           .then(() => nodeDeviceGetAll({ connectionName: vm.connectionName }))
                                                           .then(() => domainGet({ connectionName: vm.connectionName, id: vm.id }));
                                               }
-                                          }} />
+                                          }}
+                                          isSecondary />
                 );
 
                 return ["usb", "pci"].includes(hostdev.type)

--- a/src/components/vm/nics/vmNicsCard.jsx
+++ b/src/components/vm/nics/vmNicsCard.jsx
@@ -394,7 +394,8 @@ export class VmNetworkTab extends React.Component {
                                               disabled={vm.state != 'shut off' && vm.state != 'running'}
                                               dialogProps={deleteDialogProps}
                                               actionName={_("Remove")}
-                                              overlayText={_("The VM needs to be running or shut off to detach this device")} />
+                                              overlayText={_("The VM needs to be running or shut off to detach this device")}
+                                              isSecondary />
                     );
 
                     return (

--- a/src/components/vm/snapshots/vmSnapshotsCard.jsx
+++ b/src/components/vm/snapshots/vmSnapshotsCard.jsx
@@ -177,7 +177,8 @@ export class VmSnapshotsCard extends React.Component {
 
                         return (
                             <DeleteResourceButton objectId={`${id}-snapshot-${snapId}`}
-                                                  dialogProps={deleteDialogProps} />
+                                                  dialogProps={deleteDialogProps}
+                                                  isSecondary />
                         );
                     };
 


### PR DESCRIPTION
As stated @ https://www.patternfly.org/v4/components/button/design-guidelines#primary-button:

> A primary button is the most prominent button on a page, used for the most important call to action on a page. Try to limit primary buttons to one per page.

These were basically glowing at you in dark mode, where they are even more prominent visually.