### PR TITLE
Change the default source mode of direct attachment NIC to bridge

### DIFF
--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -157,7 +157,7 @@ export function domainAttachHostDevices({ connectionName, vmName, live, devices 
 
 export function domainAttachIface({ connectionName, vmName, mac, permanent, hotplug, sourceType, source, model }) {
     const macArg = mac ? "mac=" + mac + "," : "";
-    const args = ['virt-xml', '-c', `qemu:///${connectionName}`, vmName, '--add-device', '--network', `${macArg}type=${sourceType},source=${source},model=${model}`];
+    const args = ['virt-xml', '-c', `qemu:///${connectionName}`, vmName, '--add-device', '--network', `${macArg}type=${sourceType},source=${source},source.mode=bridge,model=${model}`];
     const options = { err: "message" };
 
     if (connectionName === "system")


### PR DESCRIPTION
As description in this Bugzilla, VEPA mode needs switch supplement. Also, for MacVTap NIC, it seems that virt-manager use bridge mode by default, and virt-manager seems that doesn't support mode options for MacVTap unless editing the XML. So changing default mode of "Direct attachment" NIC to bridge.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2095967