### PR TITLE
Stop showing the 'loading' page only after all resources are loaded

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -79,7 +79,7 @@ export const App = () => {
                     return Promise.allSettled(connectionNames.map(conn => {
                         return getLibvirtVersion({ connectionName: conn })
                                 .then(() => {
-                                    getApiData({ connectionName: conn })
+                                    return getApiData({ connectionName: conn })
                                             .then(promises => {
                                                 const errorMsgs = [];
                                                 promises.forEach(promise => {


### PR DESCRIPTION
The getApiData promise was not returned previously, thus was not part of the promise chain, which resulted in the app thinking that it's ready to show the resources before they were present.