### PR TITLE
Improve warning wording for attaching raw disks to more than one VM

### DIFF
--- a/src/components/vm/disks/diskAdd.jsx
+++ b/src/components/vm/disks/diskAdd.jsx
@@ -74,7 +74,7 @@ function getDiskUsageMessage(vms, storagePool, volumeName) {
 
     let message = cockpit.format(_("This volume is already used by $0."), vmsUsing);
     if (volume.format === "raw")
-        message += " " + _("Attaching it will make this disk shareable for every VM using it.");
+        message += " " + _("Adding this disk will change its access mode to shared.");
 
     return message;
 }


### PR DESCRIPTION
All hard disks are setup for exclusive access by default. When using raw disks, we can override the default behavior with the <shareable> libvirt flag. In cockpit-machines we add this flag automatically when the user tries to add to a VM a disk that is already used by a VM.

Technical note:
The shareable flag causes the SELinux/AppArmor policy to allow shared access, and tells the libvirt & QEMU lock managers to use shared locks.

Fixes #765