### PR TITLE
packaging: Use GitHub API in debian/watch

### DIFF
--- a/packaging/debian/watch
+++ b/packaging/debian/watch
@@ -1,2 +1,5 @@
 version=4
-https://github.com/cockpit-project/cockpit-machines/releases/ .*/cockpit-machines-([\d\.]+)\.tar\.xz
+opts="searchmode=plain, \
+filenamemangle=s/.+\/@PACKAGE@-@ANY_VERSION@.tar.gz/@PACKAGE@-$1\.tar\.xz/" \
+https://api.github.com/repos/cockpit-project/@PACKAGE@/releases \
+https://github.com/cockpit-project/@PACKAGE@/releases/download/\d[\.\d]*/@PACKAGE@-@ANY_VERSION@.tar.xz


### PR DESCRIPTION
The /releases page has become JavaScript-y recently and thus unreadable by machines. Scan the API instead and construct a download URL.

---

Exactly the same as in https://github.com/cockpit-project/cockpit-podman/pull/1163 and https://github.com/cockpit-project/cockpit/pull/18048