### PR TITLE
Fix resolution issues with VNC console

### DIFF
--- a/src/components/vm/consoles/consoles.css
+++ b/src/components/vm/consoles/consoles.css
@@ -6,6 +6,10 @@
     height: auto !important;
 }
 
+#vnc-display-container {
+    min-height: 480px;
+}
+
 /* Hide send key button - there is not way to do that from the JS
  * https://github.com/patternfly/patternfly-react/issues/3689
  */

--- a/src/components/vm/consoles/consoles.css
+++ b/src/components/vm/consoles/consoles.css
@@ -6,8 +6,12 @@
     height: auto !important;
 }
 
-#vnc-display-container {
+#vnc-display-container-minimized {
     min-height: 480px;
+}
+
+#vnc-display-container-expanded {
+    min-height: 68vh;
 }
 
 /* Hide send key button - there is not way to do that from the JS

--- a/src/components/vm/consoles/consoles.jsx
+++ b/src/components/vm/consoles/consoles.jsx
@@ -93,7 +93,7 @@ class Consoles extends React.Component {
     }
 
     render () {
-        const { vm, onAddErrorNotification } = this.props;
+        const { vm, onAddErrorNotification, isExpanded } = this.props;
         const { serial } = this.state;
         const spice = vm.displays && vm.displays.find(display => display.type == 'spice');
         const vnc = vm.displays && vm.displays.find(display => display.type == 'vnc');
@@ -123,7 +123,8 @@ class Consoles extends React.Component {
                      vmId={vm.id}
                      connectionName={vm.connectionName}
                      consoleDetail={vnc}
-                     onAddErrorNotification={onAddErrorNotification} />}
+                     onAddErrorNotification={onAddErrorNotification}
+                     isExpanded={isExpanded} />}
                 {(vnc || spice) &&
                 <DesktopConsole type="DesktopViewer"
                                 onDesktopConsole={onDesktopConsole}

--- a/src/components/vm/consoles/vnc.jsx
+++ b/src/components/vm/consoles/vnc.jsx
@@ -111,7 +111,7 @@ class Vnc extends React.Component {
     }
 
     render() {
-        const { consoleDetail, connectionName, vmName, vmId, onAddErrorNotification } = this.props;
+        const { consoleDetail, connectionName, vmName, vmId, onAddErrorNotification, isExpanded } = this.props;
         const { path, isActionOpen } = this.state;
         if (!consoleDetail || !path) {
             // postpone rendering until consoleDetail is known and channel ready
@@ -169,7 +169,7 @@ class Vnc extends React.Component {
                         textConnecting={_("Connecting")}
                         textDisconnected={_("Disconnected")}
                         textDisconnect={_("Disconnect")}
-                        consoleContainerId="vnc-display-container"
+                        consoleContainerId={isExpanded ? "vnc-display-container-expanded" : "vnc-display-container-minimized"}
             />
         );
     }

--- a/src/components/vm/consoles/vnc.jsx
+++ b/src/components/vm/consoles/vnc.jsx
@@ -169,6 +169,7 @@ class Vnc extends React.Component {
                         textConnecting={_("Connecting")}
                         textDisconnected={_("Disconnected")}
                         textDisconnect={_("Disconnect")}
+                        consoleContainerId="vnc-display-container"
             />
         );
     }

--- a/src/components/vm/consoles/vnc.jsx
+++ b/src/components/vm/consoles/vnc.jsx
@@ -170,6 +170,7 @@ class Vnc extends React.Component {
                         textDisconnected={_("Disconnected")}
                         textDisconnect={_("Disconnect")}
                         consoleContainerId={isExpanded ? "vnc-display-container-expanded" : "vnc-display-container-minimized"}
+                        resizeSession={!isExpanded}
             />
         );
     }

--- a/src/components/vm/vmDetailsPage.jsx
+++ b/src/components/vm/vmDetailsPage.jsx
@@ -121,7 +121,8 @@ export const VmDetailsPage = ({
                     {vmActionsPageSection}
                     <PageSection variant={PageSectionVariants.light}>
                         <Consoles vm={vm} config={config}
-                            onAddErrorNotification={onAddErrorNotification} />
+                            onAddErrorNotification={onAddErrorNotification}
+                            isExpanded />
                     </PageSection>
                 </Page>
             </WithDialogs>


### PR DESCRIPTION
### Use minimum height for VNC console

Sometimes when machine is booted up, VNC console is resized to the
small screen resolution of bootloader. Once the VM is booted, the
resolution is retained. This resolution is however too small for any
meaningfull interaction (e.g. it doesn't even allow you to click on
"Settings" at GNOME since the panel is cropped off)

**Before**
![Screenshot from 2022-12-20 02-18-40](https://user-images.githubusercontent.com/42733240/208682058-b92ca360-9598-425f-8f18-87deb7e8bcc4.png)

**After**
![Screenshot from 2022-12-20 02-19-05](https://user-images.githubusercontent.com/42733240/208682025-f22e0844-6bb6-44ae-a4f0-8f34df23c578.png)


### Add minimal height for expanded VNC

Expanding VNC console sometimes affects only the width of the console,
not its height. One would expect that expanded VNC console should try to
stretch to the whole available height of the screen.

**Before**
![Screenshot from 2022-12-20 13-15-38](https://user-images.githubusercontent.com/42733240/208682113-5fa26cfa-7d3f-4cef-a5a1-f5376e2c7beb.png)

**After**
![Screenshot from 2022-12-20 13-43-20](https://user-images.githubusercontent.com/42733240/208682146-30330fe6-ecf8-4925-8f77-db72618733fd.png)


### Don't force session resize when in expanded VNC dialog

When the resizeSession is turned on, it will automatically resize the VM
resolution based on the container element in which VNC is located. This
is however counter-productive, as it will in effect prevent user from
setting resolution inside the VM and always resize the back to the
container element.

**Before**
(Resolution change is not successful and always scales back to the previous value)

[Screencast from 2022-12-20 14-30-36.webm](https://user-images.githubusercontent.com/42733240/208682524-318c38ad-34c6-4faa-b88c-19ba23fc0a16.webm)


**After**

[Screencast from 2022-12-20 14-31-44.webm](https://user-images.githubusercontent.com/42733240/208682259-9f893f59-3efe-4bb2-9710-64225cdc16d1.webm)
