### PR TITLE
Disable Add disk button when file detection is in progress

### DIFF
--- a/src/components/vm/disks/diskAdd.jsx
+++ b/src/components/vm/disks/diskAdd.jsx
@@ -845,8 +845,8 @@ export class AddDiskModalBody extends React.Component {
                        <>
                            <Button id={`${idPrefix}-dialog-add`}
                                    variant='primary'
-                                   isLoading={this.state.addDiskInProgress}
-                                   isDisabled={this.state.addDiskInProgress || dialogLoading ||
+                                   isLoading={this.state.addDiskInProgress || this.state.verificationInProgress}
+                                   isDisabled={this.state.addDiskInProgress || this.state.verificationInProgress || dialogLoading ||
                                                (storagePools.length == 0 && this.state.mode != CUSTOM_PATH) ||
                                                (this.state.mode == CUSTOM_PATH && this.state.device === "disk" && this.state.customDiskVerificationFailed)}
                                    onClick={isMediaInsertion ? this.onInsertClicked : this.onAddClicked}>


### PR DESCRIPTION
This prevents a race condition where our test click on Add (disk) button before file detection is finished, resulting in the disk having an incorrect autodetected format.
Disabling the button while detection is in progress will make the test wait until it's finished.