### PR TITLE
Use viewport options for VNC console

### DIFF
--- a/src/components/vm/consoles/consoles.css
+++ b/src/components/vm/consoles/consoles.css
@@ -1,17 +1,27 @@
 @import "@patternfly/react-styles/css/components/Consoles/SerialConsole.css";
 
-/* Make the VNC canvas scale down to available width */
-.pf-c-console__vnc canvas {
-    max-width: 100%;
-    height: auto !important;
+.pf-c-console,
+.pf-c-console__vnc,
+.pf-c-console__vnc > div,
+.pf-c-console__vnc > div > div {
+    width: 100%;
+    height: 100%;
 }
 
-#vnc-display-container-minimized {
-    min-height: 480px;
+.pf-c-console__actions {
+    max-width: 25ch;
 }
 
-#vnc-display-container-expanded {
-    min-height: 68vh;
+.pf-c-console {
+     /* auto minimum width, causing problem */
+     grid-template-columns: 1fr;
+     grid-template-rows: min-content 1fr;
+}
+
+.consoles-page-expanded .pf-c-page__main {
+    .actions-pagesection {
+        padding-bottom: 0;
+    }
 }
 
 /* Hide send key button - there is not way to do that from the JS
@@ -19,9 +29,4 @@
  */
 #pf-c-console__send-shortcut {
     display: none;
-}
-
-/* Add spacing between action buttons */
-.pf-c-console__actions-vnc {
-    gap: var(--pf-global--spacer--sm);
 }

--- a/src/components/vm/consoles/vnc.jsx
+++ b/src/components/vm/consoles/vnc.jsx
@@ -169,7 +169,8 @@ class Vnc extends React.Component {
                         textDisconnected={_("Disconnected")}
                         textDisconnect={_("Disconnect")}
                         consoleContainerId={isExpanded ? "vnc-display-container-expanded" : "vnc-display-container-minimized"}
-                        resizeSession={!isExpanded}
+                        resizeSession
+                        scaleViewport
             />
         );
     }

--- a/src/components/vm/vmDetailsPage.jsx
+++ b/src/components/vm/vmDetailsPage.jsx
@@ -105,6 +105,7 @@ export const VmDetailsPage = ({
             <WithDialogs>
                 <Page groupProps={{ sticky: 'top' }}
                       id={"vm-" + vm.name + "-consoles-page"}
+                      className="consoles-page-expanded"
                       isBreadcrumbGrouped
                       breadcrumb={
                           <Breadcrumb className='machines-listing-breadcrumb'>


### PR DESCRIPTION
There is an issue where if virtual machine system's resolution is set to something larger than VNC console element rendered in the browser, the view will be scaled down, but there will be an offset for mouse clicks:

[false.webm](https://user-images.githubusercontent.com/42733240/209139339-e08ce7fa-3fcb-45f5-a89b-e7a5e0ed103d.webm)


This should fix it:

[true-(2).webm](https://user-images.githubusercontent.com/42733240/209139322-ebb84f0a-7810-44f0-960f-df9d8bc0a1bc.webm)


Fixes https://github.com/cockpit-project/cockpit-machines/issues/29
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1913548
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2030836