### PR TITLE
Bump cockpit repo to slightly before 284

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = 69aac32ebe3e23384a00321b9570f64f4ac07583 # 282.1
+COCKPIT_REPO_COMMIT = 736e2369118015ff1da352a790d1a92168439c7a # 284 minus "Disable file watching in FileAutoComplete"
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'

--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -67,7 +67,7 @@ class TestMachinesConsoles(VirtualMachinesCase):
         b.wait_in_text('.pf-c-expandable-section__content',
                        'Clicking "Launch remote viewer" will download')
 
-        b.assert_pixels("#vm-subVmTest1-consoles-page", "vm-details-console-external")
+        b.assert_pixels("#vm-subVmTest1-consoles-page", "vm-details-console-external", skip_layouts=["rtl"])
 
     def testInlineConsole(self, urlroot=""):
         b = self.browser
@@ -138,7 +138,7 @@ class TestMachinesConsoles(VirtualMachinesCase):
 
         b.click("button:contains(Expand)")
         b.assert_pixels("#vm-vmWithSerialConsole-consoles-page", "vm-details-console-serial",
-                        ignore=[".pf-c-console__vnc"])
+                        ignore=[".pf-c-console__vnc"], skip_layouts=["rtl"])
 
         # Add a second serial console
         m.execute("virsh destroy vmWithSerialConsole; virt-xml --add-device vmWithSerialConsole --console pty,target_type=virtio; virsh start vmWithSerialConsole")

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1280,7 +1280,7 @@ vnc_password= "{vnc_passwd}"
                 ignore = ["#memory-size-helper"]
                 if self.storage_pool != "NoStorage":
                     ignore += ["#storage-limit-helper"]
-                self.browser.assert_pixels("#create-vm-dialog", tag, ignore=ignore)
+                self.browser.assert_pixels("#create-vm-dialog", tag, ignore=ignore, skip_layouts=["rtl"])
             return self
 
         def checkNoCrashOnThePage(self):

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -548,7 +548,8 @@ class TestMachinesDisks(VirtualMachinesCase):
             if self.pixel_test_tag:
                 self.test_obj.browser.wait_visible(f"{prefix}-dialog-add[aria-disabled=false]")
                 self.test_obj.browser.assert_pixels(f"{prefix}-dialog-modal-window", self.pixel_test_tag,
-                                                    ignore=[self.pixel_test_ignore] if self.pixel_test_ignore else [])
+                                                    ignore=[self.pixel_test_ignore] if self.pixel_test_ignore else [],
+                                                    skip_layouts=["rtl"])
 
             if not self.skip_add:
                 self.add_disk()

--- a/test/check-machines-hostdevs
+++ b/test/check-machines-hostdevs
@@ -99,7 +99,7 @@ class TestMachinesHostDevs(VirtualMachinesCase):
             m.execute("test -d /sys/devices/pci0000\\:00/0000\\:00\\:0f.0/")
             b.wait_in_text("#vm-subVmTest1-hostdev-1-vendor", "Red Hat, Inc")
             b.wait_in_text("#vm-subVmTest1-hostdev-1-product", "Virtio network device")
-            b.assert_pixels("#vm-subVmTest1-hostdevs", "vm-details-hostdevs-card")
+            b.assert_pixels("#vm-subVmTest1-hostdevs", "vm-details-hostdevs-card", skip_layouts=["rtl"])
         except subprocess.CalledProcessError:
             pass
 
@@ -163,7 +163,7 @@ class TestMachinesHostDevs(VirtualMachinesCase):
                 b.click("button#vm-subVmTest1-hostdevs-add")
                 b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Add host device")
                 if connectionName != "session":
-                    b.assert_pixels(".pf-c-modal-box", "vm-hostdevs-add-dialog")
+                    b.assert_pixels(".pf-c-modal-box", "vm-hostdevs-add-dialog", skip_layouts=["rtl"])
 
             def fill(self):
                 b.click(f"input#{self.dev_type}")

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -401,7 +401,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         # virsh attach-disk does not create disks of type volume
         b.wait_visible(f"#vm-{name}-delete-modal-dialog .disk-source-volume:contains({secondDiskVolName})")
         b.wait_visible(f"#vm-{name}-delete-modal-dialog .disk-source-pool:contains({poolName})")
-        b.assert_pixels(f"#vm-{name}-delete-modal-dialog", "vm-delete-dialog")
+        b.assert_pixels(f"#vm-{name}-delete-modal-dialog", "vm-delete-dialog", skip_layouts=["rtl"])
         b.click(f"#vm-{name}-delete-modal-dialog button:contains(Delete)")
         b.wait_not_present(f"#vm-{name}-delete-modal-dialog")
 

--- a/test/check-machines-networks
+++ b/test/check-machines-networks
@@ -770,7 +770,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
         b.wait_visible("#network-test_network2-system-autostart-off")
         b.wait_in_text("#network-test_network2-system-ipv6-dhcp-host-0", "simon")
 
-        b.assert_pixels("#app", "networks-page")
+        b.assert_pixels("#app", "networks-page", skip_layouts=["rtl"])
 
         # activate network
         b.wait_visible(f"#activate-network-test_network2-{connectionName}")

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -65,7 +65,7 @@ class TestMachinesNICs(VirtualMachinesCase):
                         ignore=["#vm-subVmTest1-network-1-mac", "#vm-subVmTest1-network-1-ipv4-address"],
                         # MAC and IP address values are not static, and their values affect the width of their columns and neighbouring columns
                         # With medium layout this variable width of the columns makes pixel tests references of the table different each test run
-                        skip_layouts=["medium"])
+                        skip_layouts=["medium", "rtl"])
 
         # Remove default interface
         self.deleteIface(1)
@@ -473,7 +473,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         dialog.open()
         b.wait_in_text("#vm-subVmTest1-network-1-edit-dialog-source", "eth42")
         b.wait_val("#vm-subVmTest1-network-1-edit-dialog-mac", "52:54:00:f0:eb:63")
-        b.assert_pixels("#vm-subVmTest1-network-1-edit-dialog-modal-window", "vm-edit-nic-modal")
+        b.assert_pixels("#vm-subVmTest1-network-1-edit-dialog-modal-window", "vm-edit-nic-modal", skip_layouts=["rtl"])
         dialog.cancel()
 
         # Changing the NIC configuration for a shut off VM should not display any warning
@@ -569,7 +569,7 @@ class TestMachinesNICs(VirtualMachinesCase):
 
         def assert_pixels(self):
             if self.pixel_test_tag:
-                self.browser.assert_pixels("#vm-subVmTest1-add-iface-dialog", self.pixel_test_tag)
+                self.browser.assert_pixels("#vm-subVmTest1-add-iface-dialog", self.pixel_test_tag, skip_layouts=["rtl"])
 
         def cancel(self):
             self.browser.click(".pf-c-modal-box__footer button:contains(Cancel)")

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -506,7 +506,7 @@ class TestMachinesSettings(VirtualMachinesCase):
             b.wait_visible("#vm-subVmTest1-watchdog-modal")
 
             if pixel_test_tag:
-                b.assert_pixels("#vm-subVmTest1-watchdog-modal", pixel_test_tag)
+                b.assert_pixels("#vm-subVmTest1-watchdog-modal", pixel_test_tag, skip_layouts=["rtl"])
 
             b.click(f"#{action}")
 

--- a/test/check-machines-snapshots
+++ b/test/check-machines-snapshots
@@ -104,7 +104,8 @@ class TestMachinesSnapshots(VirtualMachinesCase):
             ignore=[
                 "tr:nth-child(1) .snap-creation-time",
                 "tr:nth-child(2) .snap-creation-time",
-            ]
+            ],
+            skip_layouts=["rtl"]
         )
 
     def testSnapshotCreate(self):
@@ -160,7 +161,7 @@ class TestMachinesSnapshots(VirtualMachinesCase):
 
             def assert_pixels(self):
                 if self.name == 'test_snap_1':
-                    b.assert_pixels("#vm-subVmTest1-create-snapshot-modal", "create-snapshot-dialog" + ("" if not self.xfail else "-error"))
+                    b.assert_pixels("#vm-subVmTest1-create-snapshot-modal", "create-snapshot-dialog" + ("" if not self.xfail else "-error"), skip_layouts=["rtl"])
 
             def cancel(self):
                 b.click(".pf-c-modal-box__footer button:contains(Cancel)")

--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -102,7 +102,8 @@ class TestMachinesStoragePools(VirtualMachinesCase):
                 # HACK: the font rendering of middle columns is jittery, even after sleep()
                 [f"td:nth-child({n})" for n in range(2, 6)] +
                 [f"th:nth-child({n})" for n in range(2, 6)]
-            )
+            ),
+            skip_layouts=["rtl"]
         )
 
         # Check basic pool properties


### PR DESCRIPTION
This picks the fix for the "ugly zero" font fix from tabular numbers.
Adjust pixel tests accordingly.

Disable the "RTL" pixel scenario, as it's still causing unstable
reference images, and we don't yet know what exactly to do with that in
Cockpit.  Unfortunately we can't use test/browser-layouts.json as we
already have the "dark" scenario, want to retain it, but it does not 
work on Firefox.  This gets computed dynamically in testlib, but a
static browser-layouts.json prevents this. Thus, explicitly skip the 
"rtl" scenario everywhere for now.

Don't update to full 284 yet, as [1] breaks testStoragePoolsCreate. This
works interactively, but not in the tests. This is not trivial to work
around, so do this in a separate commit that isn't blocking the release.

[1] https://github.com/cockpit-project/cockpit/commit/a3fad8f6e71037539

----

[pixel test review](https://github.com/cockpit-project/pixel-test-reference/compare/27c3efa8dc7fa03e184569c9464c04aab6b56f6d..7355d3b47607fb21ccc911d0e6e32bddddf57857)