### PR TITLE
Transient domains should not be redefined when editing their network devices

### DIFF
--- a/src/components/vm/nics/vmNicsCard.jsx
+++ b/src/components/vm/nics/vmNicsCard.jsx
@@ -387,7 +387,7 @@ export class VmNetworkTab extends React.Component {
                         errorMessage: cockpit.format(_("Network interface $0 could not be removed"), network.mac),
                         actionDescription: cockpit.format(_("Network interface $0 will be removed from $1"), network.mac, vm.name),
                         actionName: _("Remove"),
-                        deleteHandler: () => domainDetachIface({ connectionName: vm.connectionName, index: network.index, vmName: vm.name, live: vm.state === 'running', persistent: nicPersistent }),
+                        deleteHandler: () => domainDetachIface({ connectionName: vm.connectionName, index: network.index, vmName: vm.name, live: vm.state === 'running', persistent: vm.persistent && nicPersistent }),
                     };
                     const deleteNICAction = (
                         <DeleteResourceButton objectId={`${id}-iface-${networkId}`}

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -176,6 +176,16 @@ class TestMachinesNICs(VirtualMachinesCase):
         b.wait_text("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:5f")
         b.wait_text("#vm-subVmTest1-network-2-model", "e1000e")
 
+        # Test for bugzilla #2030948
+        b.click("#vm-subVmTest1-system-run")
+        m.execute("virsh undefine subVmTest1")
+        b.click(".machines-listing-breadcrumb li a:contains(Virtual machines)")
+        b.wait_visible("tr[data-row-id=vm-subVmTest1-system][data-vm-transient=true]")
+        self.goToVmPage("subVmTest1")
+        self.deleteIface(1)
+        self.performAction("subVmTest1", "forceOff", checkExpectedState=False)
+        self.waitVmRow("subVmTest1", "system", False)
+
     def testNICAdd(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=2030948