### PR TITLE
test: export TEST_BROWSER for the Firefox scenario

### DIFF
--- a/test/run
+++ b/test/run
@@ -2,8 +2,10 @@
 # This is the expected entry point for Cockpit CI; will be called without
 # arguments but with an appropriate $TEST_OS
 
-set -eu
+set -eux
 
+TEST_SCENARIO="${TEST_SCENARIO:-}"
+[ "${TEST_SCENARIO}" = "${TEST_SCENARIO##firefox}" ] || export TEST_BROWSER=firefox
 export RUN_TESTS_OPTIONS=--track-naughties
 
 make codecheck


### PR DESCRIPTION
To actually test on Firefox we need to export TEST_BROWSER also print out the run commands so we can verify firefox is started.