### PR TITLE
Bump pkg/lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = 736e2369118015ff1da352a790d1a92168439c7a # 284 minus "Disable file watching in FileAutoComplete"
+COCKPIT_REPO_COMMIT = 1a84ad594cee44509677aae69c8eb0a263d3a1f6 # 284-62-g1a84ad594
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "react-dom": "17.0.2",
     "redux": "4.1.2",
     "redux-thunk": "2.4.2",
-    "throttle-debounce": "3.0.1"
+    "throttle-debounce": "3.0.1",
+    "xterm": "5.1.0",
+    "xterm-addon-canvas": "0.3.0"
   }
 }


### PR DESCRIPTION
- Ignore xterm-addon-canvas missing import from pkg/lib as this is not used

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=2032197 Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1999945