### PR TITLE
test: Increase timeout for initializing the page

### DIFF
--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -40,7 +40,7 @@ class TestMachinesConsoles(VirtualMachinesCase):
         self.createVm("subVmTest1", graphics="spice")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow("subVmTest1")
 
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")  # running or paused
@@ -78,7 +78,7 @@ class TestMachinesConsoles(VirtualMachinesCase):
             self.machine.write("/etc/cockpit/cockpit.conf", f"[WebService]\nUrlRoot={urlroot}")
 
         self.login_and_go("/machines", urlroot=urlroot)
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow("subVmTest1")
 
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")  # running or paused
@@ -106,7 +106,7 @@ class TestMachinesConsoles(VirtualMachinesCase):
         self.createVm(name, graphics='vnc', ptyconsole=True)
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow(name)
 
         self.goToVmPage(name)
@@ -179,7 +179,7 @@ class TestMachinesConsoles(VirtualMachinesCase):
         self.createVm(name, graphics="vnc", ptyconsole=True)
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         self.waitVmRow(name)
         self.goToVmPage(name)
@@ -216,7 +216,7 @@ class TestMachinesConsoles(VirtualMachinesCase):
         self.performAction(name, "delete")
         b.wait_visible(f"#vm-{name}-delete-modal-dialog")
         b.click(f"#vm-{name}-delete-modal-dialog button:contains(Delete)")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow(name, present=False)
 
         b.wait_not_present("#navbar-oops")

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -49,7 +49,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         self.add_veth(iface)
 
         self.login_and_go("/machines")
-        self.browser.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         # test create and import [VM] buttons show appropriate tooltips when hovered over
         runner.createAndImportTooltipsTest()
@@ -173,7 +173,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         runner = TestMachinesCreate.CreateVmRunner(self)
 
         self.login_and_go("/machines")
-        self.browser.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         runner.checkEnvIsEmpty()
 
@@ -225,7 +225,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         config = TestMachinesCreate.TestCreateConfig
 
         self.login_and_go("/machines")
-        self.browser.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         # try to CREATE few machines
         # --cloud-init user-data option exists since virt-install >= 3.0.0
@@ -253,7 +253,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         config = TestMachinesCreate.TestCreateConfig
 
         self.login_and_go("/machines")
-        self.browser.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         # try to CREATE few machines
         runner.createDownloadAnOSTest(TestMachinesCreate.VmDialog(self, sourceType='os',
@@ -307,7 +307,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         self.login_and_go("/machines")
 
         b = self.browser
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         # test PXE Source
         # check that the pxe booting is not available on session connection
@@ -337,7 +337,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         # We don't handle events for networks yet, so reload the page to refresh the state
         b.reload()
         b.enter_page('/machines')
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         # Create with immediate starting
         runner.createTest(TestMachinesCreate.VmDialog(self, name='pxe-guest', sourceType='pxe',
@@ -428,7 +428,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         self.restore_file("/etc/libvirt/qemu.conf")
 
         self.login_and_go("/machines")
-        self.browser.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         vnc_listen = "192.168.2.6"
         vnc_passwd = "mypass"
@@ -467,7 +467,7 @@ vnc_password= "{vnc_passwd}"
         self.machine.execute("; ".join(cmds))
 
         self.login_and_go("/machines")
-        self.browser.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         # Test create VM with disk of type "block"
         # Check choosing existing volume as destination storage
@@ -492,7 +492,7 @@ vnc_password= "{vnc_passwd}"
 
             self.browser.reload()
             self.browser.enter_page('/machines')
-            self.browser.wait_in_text("body", "Virtual machines")
+            self.waitPageInit()
 
             # Check choosing existing volume as destination storage
             runner.createThenInstallTest(TestMachinesCreate.VmDialog(self, sourceType='file',
@@ -527,7 +527,7 @@ vnc_password= "{vnc_passwd}"
         self.machine.execute("virsh pool-destroy default; virsh pool-undefine default")
 
         self.login_and_go("/machines")
-        self.browser.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         # Check that when there is no storage pool defined a VM can still be created
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='file',
@@ -548,7 +548,7 @@ vnc_password= "{vnc_passwd}"
 
         self.browser.reload()
         self.browser.enter_page('/machines')
-        self.browser.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='file',
                                                       location=config.NOVELL_MOCKUP_ISO_PATH,
@@ -567,7 +567,7 @@ vnc_password= "{vnc_passwd}"
 
         self.browser.reload()
         self.browser.enter_page('/machines')
-        self.browser.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         # Check choosing existing volume as destination storage
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='file',
@@ -597,7 +597,7 @@ vnc_password= "{vnc_passwd}"
         config = TestMachinesCreate.TestCreateConfig
 
         self.login_and_go("/machines")
-        self.browser.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='disk_image',
                                                       location=config.VALID_DISK_IMAGE_PATH,
@@ -625,7 +625,7 @@ vnc_password= "{vnc_passwd}"
         config = TestMachinesCreate.TestCreateConfig
 
         self.login_and_go("/machines")
-        self.browser.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         runner.checkEnvIsEmpty()
 
@@ -686,7 +686,7 @@ vnc_password= "{vnc_passwd}"
 
     def testDisabledCreate(self):
         self.login_and_go("/machines")
-        self.browser.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.browser.wait_visible("#create-new-vm:not(:disabled)")
         self.browser.wait_attr("#create-new-vm", "testdata", None)
 
@@ -1796,7 +1796,7 @@ vnc_password= "{vnc_passwd}"
         m = self.machine
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         dialog = TestMachinesCreate.VmDialog(self, sourceType='file',
                                              name="VmNotInstalled",
@@ -1945,7 +1945,7 @@ vnc_password= "{vnc_passwd}"
         b = self.browser
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         dialog = TestMachinesCreate.VmDialog(self, sourceType='file',
                                              name="VmNotInstalledBios",
@@ -1986,7 +1986,7 @@ vnc_password= "{vnc_passwd}"
         m = self.machine
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         m.execute(f"qemu-img create {TestMachinesCreate.TestCreateConfig.VALID_DISK_IMAGE_PATH} 500M")
 

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -106,7 +106,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         m.execute(f"virsh attach-disk --domain subVmTest1 --source {p1}/mydisk3 --target vdg --targetbus virtio --subdriver qcow2 --persistent")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow("subVmTest1")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
@@ -231,7 +231,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         self.createVm("subVmTest2")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow("subVmTest1")
 
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
@@ -765,7 +765,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
@@ -821,7 +821,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
@@ -879,7 +879,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
@@ -961,7 +961,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         self.createVm("subVmTest1")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
@@ -1070,7 +1070,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         # Make sure that trying to inspect the Disks tab will just show the fields that are available when a pool is inactive
         b.reload()
         b.enter_page('/machines')
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         # Check that usage information can't be fetched since the pool is inactive
         b.wait_not_present("#vm-subVmTest1-disks-vdd-used")
 
@@ -1090,7 +1090,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         m.execute("touch /var/lib/libvirt/empty.img")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
@@ -1220,7 +1220,6 @@ class TestMachinesDisks(VirtualMachinesCase):
         b.wait_visible(f"{prefix}-bus-type[data-value=ide]")
 
     def testAddDiskAdditionalOptions(self):
-        b = self.browser
         m = self.machine
 
         used_targets = ['vda']
@@ -1233,7 +1232,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         self.createVm("subVmTest1", running=False)
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         self.goToVmPage("subVmTest1")
 
@@ -1394,7 +1393,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         m.execute(f"virsh attach-disk --domain subVmTest1 --source {vde_path} --target vde --targetbus virtio --persistent")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow("subVmTest1")
 
         # Wait for the login prompt before we try detaching disks - we need the OS to be fully responsive
@@ -1452,7 +1451,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         # Need to refresh when attaching disk for shutoff VM
         b.reload()
         b.enter_page('/machines')
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         b.wait_visible("#vm-subVmTest1-disks-sda-device")
         b.wait_visible("#vm-subVmTest1-disks-vdf-device")
 
@@ -1516,7 +1515,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         m.execute("virsh start subVmTest1")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")

--- a/test/check-machines-hostdevs
+++ b/test/check-machines-hostdevs
@@ -47,7 +47,7 @@ class TestMachinesHostDevs(VirtualMachinesCase):
         self.createVm("subVmTest1")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow("subVmTest1")
 
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
@@ -127,7 +127,7 @@ class TestMachinesHostDevs(VirtualMachinesCase):
         self.addCleanup(self.run_admin, "rm -rf /tmp/vmdir/", connectionName)
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         self.createVm("subVmTest1", running=False, connection=connectionName)
 
@@ -267,7 +267,7 @@ class TestMachinesHostDevs(VirtualMachinesCase):
         self.addCleanup(self.run_admin, "rm -rf /tmp/vmdir/", connectionName)
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.createVm("subVmTest1", running=False, connection=connectionName)
         self.goToVmPage("subVmTest1", connectionName)
 

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -86,7 +86,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
             with b.wait_timeout(20):
                 b.wait_in_text("#virtual-machines-listing .pf-c-empty-state", "No VM is running")
                 return
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow("subVmTest1")
 
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
@@ -250,7 +250,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         self.addCleanup(self.run_admin, "rm -rf /tmp/vmdir/", connectionName)
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         self.createVm("subVmTest1", running=False, connection=connectionName)
 
@@ -270,7 +270,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
 
         self.login_and_go("/machines")
 
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         self.performAction("old", "rename")
 
@@ -329,7 +329,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         # Check initial state
         self.createVm("subVmTest1")
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow("subVmTest1")
 
         # Check that empty state screen appears for privileged users when both the service and the socket are not running
@@ -349,7 +349,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         # so make sure that there are no leftover user processes that bleed into the next test
         self.addCleanup(self.machine.execute, "pkill -u nonadmin || true; while pgrep -u nonadmin; do sleep 0.5; done")
         self.login_and_go("/machines", user="nonadmin", superuser=False)
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         b.wait_in_text("#virtual-machines-listing .pf-c-empty-state", "No VM is running")
 
     def testDelete(self):
@@ -362,7 +362,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         args = self.createVm(name, graphics='vnc')
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow(name)
 
         m.execute(f"test -f {img2}")

--- a/test/check-machines-networks
+++ b/test/check-machines-networks
@@ -54,7 +54,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
         connectionName = m.execute("virsh uri | head -1 | cut -d/ -f4").strip()
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         b.wait_in_text("#card-pf-networks .card-pf-title-link", "1 Network")
 
@@ -130,7 +130,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
         m = self.machine
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         # Click on Networks card
         b.wait_in_text("#card-pf-networks .pf-c-card__header button", "Network")
@@ -510,7 +510,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
 
         # Create a second bridge to LAN NIC, virbr0 does not make sense but let's use it for test purposes
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow("subVmTest1")
 
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
@@ -573,7 +573,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
         # We don't get events for shut off VMs so reload the page
         b.reload()
         b.enter_page('/machines')
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         self.goToMainPage()
 
@@ -708,7 +708,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
         connectionName = m.execute("virsh uri | head -1 | cut -d/ -f4").strip()
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         # Click on Networks card
         b.wait_in_text("#card-pf-networks .pf-c-card__header button", "Network")
@@ -755,7 +755,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
         connectionName = m.execute("virsh uri | head -1 | cut -d/ -f4").strip()
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         # Click on Networks card
         b.click(".pf-c-card .pf-c-card__header button:contains(Network)")
@@ -884,7 +884,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
         self.createVm("subVmTest1", running=False)
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         # Click on Networks card
         b.click(".pf-c-card .pf-c-card__header button:contains(Network)")

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -46,7 +46,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         self.createVm("subVmTest1")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow("subVmTest1")
 
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
@@ -96,7 +96,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         self.createVm("subVmTest1")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         self.waitVmRow("subVmTest1")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
@@ -137,7 +137,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         args = self.createVm("subVmTest1")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow("subVmTest1")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
@@ -157,7 +157,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         # Refresh for getting new added NIC
         b.reload()
         b.enter_page('/machines')
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         # Check NIC MAC addresses
         b.wait_text("#vm-subVmTest1-network-1-mac", "52:54:00:4b:73:6f")
         b.wait_text("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:4f")
@@ -199,7 +199,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         args = self.createVm("subVmTest1")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         self.goToVmPage("subVmTest1")
         self.deleteIface(1)  # Remove default vNIC
@@ -463,7 +463,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         self.createVm("subVmTest1", running=False)
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         self.goToVmPage("subVmTest1")
 

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -47,7 +47,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         self.createVm("subVmTest1")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow("subVmTest1")
 
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
@@ -167,7 +167,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         m = self.machine
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         def checkAutostart(vm_name, running):
             self.createVm(vm_name, running=running)
@@ -213,7 +213,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         self.createVm("subVmTest1")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow("subVmTest1")
 
         self.goToVmPage("subVmTest1")
@@ -270,7 +270,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         m.execute("touch /var/lib/libvirt/images/phonycdrom; virsh attach-disk subVmTest1 /var/lib/libvirt/images/phonycdrom sdb --type cdrom --config")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow("subVmTest1")
 
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
@@ -379,7 +379,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         args = self.createVm("subVmTest1", memory=256)
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow("subVmTest1")
 
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
@@ -440,7 +440,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         args = self.createVm("subVmTest1")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow("subVmTest1")
 
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
@@ -591,7 +591,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         args = self.createVm("subVmTest1", running=False)
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.goToVmPage("subVmTest1")
 
         b.wait_in_text("#vm-subVmTest1-watchdog-state", "none")

--- a/test/check-machines-snapshots
+++ b/test/check-machines-snapshots
@@ -53,7 +53,7 @@ class TestMachinesSnapshots(VirtualMachinesCase):
         self.createVm("subVmTest1")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow("subVmTest1")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
@@ -115,7 +115,7 @@ class TestMachinesSnapshots(VirtualMachinesCase):
         self.createVm("subVmTest1")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         if m.image in distrosWithoutSnapshot:
             b.wait_not_present("#vm-subVmTest1-snapshots")
@@ -269,7 +269,7 @@ class TestMachinesSnapshots(VirtualMachinesCase):
         m.execute("virsh snapshot-current --domain subVmTest1 --snapshotname snapshotA")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow("subVmTest1")
         self.goToVmPage("subVmTest1")
         if m.image in distrosWithoutSnapshot:

--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -49,7 +49,7 @@ class TestMachinesStoragePools(VirtualMachinesCase):
         self.createVm("subVmTest1")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
         self.waitVmRow("subVmTest1")
 
         b.wait_in_text("#card-pf-storage-pools .card-pf-title-link", "1 Storage pool")
@@ -216,7 +216,7 @@ class TestMachinesStoragePools(VirtualMachinesCase):
         m.execute("systemctl restart nfs-server")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         # Click on Storage pools card
         b.wait_in_text("#card-pf-storage-pools .pf-c-card__header button", "Storage pools")
@@ -513,7 +513,7 @@ class TestMachinesStoragePools(VirtualMachinesCase):
             virsh pool-start disk-pool""")
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         # Click on Storage pools card
         b.wait_in_text("#card-pf-storage-pools .pf-c-card__header button", "Storage pools")
@@ -728,7 +728,7 @@ class TestMachinesStoragePools(VirtualMachinesCase):
             self.prepareStorageDeviceOnISCSI(target_iqn)
 
         self.login_and_go("/machines")
-        b.wait_in_text("body", "Virtual machines")
+        self.waitPageInit()
 
         b.wait_in_text("#card-pf-storage-pools .pf-c-card__header button", "Storage pools")
         b.click(".pf-c-card .pf-c-card__header button:contains(Storage pools)")

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -26,7 +26,8 @@ class VirtualMachinesCaseHelpers:
     created_pool = False
 
     def waitPageInit(self):
-        self.browser.wait_in_text("body", "Virtual machines")
+        with self.browser.wait_timeout(30):
+            self.browser.wait_in_text("body", "Virtual machines")
 
     def performAction(self, vmName, action, checkExpectedState=True, connectionName="system"):
         b = self.browser

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -25,6 +25,9 @@ distrosWithMonolithicDaemon = ["rhel-8-6", "rhel-8-7", "rhel-8-8", "ubuntu-stabl
 class VirtualMachinesCaseHelpers:
     created_pool = False
 
+    def waitPageInit(self):
+        self.browser.wait_in_text("body", "Virtual machines")
+
     def performAction(self, vmName, action, checkExpectedState=True, connectionName="system"):
         b = self.browser
         b.click("#vm-{0}-{1}-action-kebab button".format(vmName, connectionName))


### PR DESCRIPTION
Loading the state occasionally times out with the default 15s on our CI, especially in the more complex scenarios with migration or storage pools.

----

Example: https://cockpit-logs.us-east-1.linodeobjects.com/pull-934-20230202-211253-32d31f47-fedora-37/log.html#77