### PR TITLE
spec: Work around spice bug in Fedora 38

### DIFF
--- a/packaging/cockpit-machines.spec.in
+++ b/packaging/cockpit-machines.spec.in
@@ -51,6 +51,10 @@ Recommends: qemu-block-curl
 Recommends: qemu-char-spice
 Recommends: qemu-device-usb-host
 Recommends: qemu-device-usb-redirect
+# HACK: https://bugzilla.redhat.com/show_bug.cgi?id=2170110
+%if 0%{?fedora} >= 38
+Requires: (qemu-audio-spice if qemu-char-spice)
+%endif
 %endif
 %endif
 Requires: libvirt-client


### PR DESCRIPTION
Until this is fixed, unbreak spice consoles by pulling in qemu-audio-spice if the other spice packages are installed. This has no additional dependencies and is just 20 kB, and splitting the packages is pointless anyway.

See https://bugzilla.redhat.com/show_bug.cgi?id=2170110

----

This should eventually fix [testExternalConsole](https://cockpit-logs.us-east-1.linodeobjects.com/pull-955-20230219-100124-53a496a0-fedora-38/log.html), which gets currently [naughtied](https://github.com/cockpit-project/bots/issues/4415). This should fail in the first run on fedora-38 as the qemu-audio-spice package does not exist on our fedora-38 image. I'll add it as the next step, but I want to make sure the dependency works as expected.

 - https://github.com/cockpit-project/bots/pull/4443