### PR TITLE
Allow creating a VM without immediatelly starting with Cloud base image

### DIFF
--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -1320,18 +1320,17 @@ class CreateVmModal extends React.Component {
                     key="secondary-button"
                     id="create-and-edit"
                     isLoading={this.state.createMode === EDIT}
-                    isAriaDisabled={
+                    isAriaDisabled={!!(
                         this.state.createMode === EDIT ||
                         Object.getOwnPropertyNames(validationFailed).length > 0 ||
-                        this.state.sourceType === CLOUD_IMAGE ||
-                        unattendedInstallation ||
+                        (this.state.sourceType === DOWNLOAD_AN_OS && unattendedInstallation) ||
                         downloadingRhelDisabled
-                    }
+                    )}
                     onClick={() => this.onCreateClicked(false)}>
                 {this.props.mode == 'create' ? _("Create and edit") : _("Import and edit")}
             </Button>
         );
-        if (unattendedInstallation || this.state.sourceType === CLOUD_IMAGE) {
+        if (unattendedInstallation) {
             createAndEdit = (
                 <Tooltip id='create-and-edit-disabled-tooltip'
                          content={_("Setting the user passwords for unattended installation requires starting the VM when creating it")}>

--- a/src/libvirt-xml-parse.js
+++ b/src/libvirt-xml-parse.js
@@ -250,12 +250,18 @@ export function parseDomainDumpxml(connectionName, domXml, objPath) {
     const installSourceType = parseDumpxmlMachinesMetadataElement(metadataElem, 'install_source_type');
     const installSource = parseDumpxmlMachinesMetadataElement(metadataElem, 'install_source');
     const osVariant = parseDumpxmlMachinesMetadataElement(metadataElem, 'os_variant');
+    const rootPassword = parseDumpxmlMachinesMetadataElement(metadataElem, 'root_password');
+    const userLogin = parseDumpxmlMachinesMetadataElement(metadataElem, 'user_login');
+    const userPassword = parseDumpxmlMachinesMetadataElement(metadataElem, 'user_password');
 
     const metadata = {
         hasInstallPhase,
         installSourceType,
         installSource,
         osVariant,
+        rootPassword,
+        userLogin,
+        userPassword,
     };
 
     return {

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -730,6 +730,9 @@ export function domainInstall({ vm }) {
         os: vm.metadata.osVariant,
         source: vm.metadata.installSource,
         sourceType: vm.metadata.installSourceType,
+        rootPassword: vm.metadata.rootPassword,
+        userLogin: vm.metadata.userLogin,
+        userPassword: vm.metadata.userPassword,
         type: "install",
         vmName: vm.name,
     });

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -248,6 +248,17 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                                     root_password="dogsaremybestfr13nds",
                                                                     create_and_run=True))
 
+        # Create and Edit + Install
+        runner.createCloudBaseImageTest(TestMachinesCreate.VmDialog(self, sourceType='cloud',
+                                                                    storage_size=10, storage_size_unit='MiB',
+                                                                    location=config.VALID_DISK_IMAGE_PATH,
+                                                                    os_name=config.FEDORA_28,
+                                                                    os_short_id=config.FEDORA_28_SHORTID,
+                                                                    user_password="catsaremybestfr13nds",
+                                                                    user_login="foo",
+                                                                    root_password="dogsaremybestfr13nds",
+                                                                    create_and_run=False))
+
         # Test using a cloud image without setting the cloud init options
         # https://bugzilla.redhat.com/show_bug.cgi?id=1978206
         runner.createCloudBaseImageTest(TestMachinesCreate.VmDialog(self, sourceType='cloud',
@@ -806,7 +817,7 @@ vnc_password= "{vnc_passwd}"
             self.root_password = root_password
             self.user_password = user_password
             self.user_login = user_login
-            self.create_and_run = create_and_run or is_unattended or sourceType == "cloud"
+            self.create_and_run = create_and_run or is_unattended
             self.storage_pool = storage_pool
             self.storage_volume = storage_volume
             self.delete = delete
@@ -1007,6 +1018,10 @@ vnc_password= "{vnc_passwd}"
 
             if self.create_and_run:
                 self.goToVmPage(self.name)
+            else:
+                # Install the VM
+                self.browser.click(f"#vm-{self.name}-system-install")
+
             self.browser.wait_text(f"#vm-{self.name}-disks-vda-bus", "virtio")
             # A cloud-init NoCloud ISO file is generated, and attached to the VM as a CDROM device.
             self.browser.wait_text(f"#vm-{self.name}-disks-sda-device", "cdrom")
@@ -1168,13 +1183,6 @@ vnc_password= "{vnc_passwd}"
             else:
                 b.wait_val("#memory-size", self.expected_memory_size)
 
-            if self.sourceType == "cloud":
-                b.wait_visible("#create-and-edit[aria-disabled=true]")
-                b.mouse("#create-and-edit", "mouseenter")
-                b.wait_visible("#create-and-edit-disabled-tooltip")
-            else:
-                b.wait_visible("#create-and-run[aria-disabled=false]")
-
             if (self.connection):
                 b.set_checked(f"#connectionName-{self.connection}", True)
 
@@ -1190,6 +1198,13 @@ vnc_password= "{vnc_passwd}"
                     b.set_input_text("#user-login", self.user_login)
                 if self.root_password:
                     b.set_input_text("#create-vm-dialog-root-password-pw1", self.root_password)
+
+                if self.is_unattended:
+                    b.wait_visible("#create-and-edit[aria-disabled=true]")
+                    b.mouse("#create-and-edit", "mouseenter")
+                    b.wait_visible("#create-and-edit-disabled-tooltip")
+                else:
+                    b.wait_visible("#create-and-run[aria-disabled=false]")
 
             return self
 


### PR DESCRIPTION
The reason why we didn't allow creation of VM without immediatelly
starting it when when root password and login password were supplied
was that we didn't want to store sensitive information anywhere on
the system.
Ever since #932 was merged, this is no longer the issue

Fixes #880 

# Machines: Create a cloud image VM without immediately starting it

A cloud base image VM can now be created without immediately starting it by clicking "Create and edit", which was disabled until now. This allows users to configure additional VM properties (e.g. bootloader, boot order, disks, networking, etc.) before the VM is installed.

![Screenshot from 2023-03-21 14-07-46](https://user-images.githubusercontent.com/42733240/226617157-1edca5b0-ae5b-4d6f-81bf-faa0243eeb7b.png)
![Screenshot from 2023-03-21 14-07-58](https://user-images.githubusercontent.com/42733240/226617152-21e85fbf-fd7c-4b1d-a67d-c03c5a68f310.png)
