### PR TITLE
VSOCK interface

### DIFF
--- a/src/components/common/overviewCard.css
+++ b/src/components/common/overviewCard.css
@@ -1,3 +1,8 @@
 .overview-tab.pf-l-flex {
     gap: var(--pf-global--spacer--lg);
 }
+
+.overview-icon svg {
+    color: var(--pf-c-description-list__term-icon--Color);
+    font-size: var(--pf-c-description-list__term--FontSize);
+}

--- a/src/components/vm/overview/firmware.jsx
+++ b/src/components/vm/overview/firmware.jsx
@@ -28,7 +28,7 @@ import { useDialogs, DialogsContext } from 'dialogs.jsx';
 
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
 import { domainSetOSFirmware, domainCanInstall } from "../../../libvirtApi/domain.js";
-import { supportsUefiXml, labelForFirmwarePath } from './helpers.js';
+import { supportsUefiXml, labelForFirmwarePath } from './helpers.jsx';
 
 const _ = cockpit.gettext;
 

--- a/src/components/vm/overview/helpers.js
+++ b/src/components/vm/overview/helpers.js
@@ -17,6 +17,12 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
+import cockpit from 'cockpit';
+
+const _ = cockpit.gettext;
+
+export const WATCHDOG_INFO_MESSAGE = _("Watchdogs act when systems stop responding. To use this virtual watchdog device, the guest system also needs to have an additional driver and a running watchdog service.");
+
 export function labelForFirmwarePath(path, guest_arch) {
     /* Copied from virt-manager code:
      * Mapping of UEFI binary names to their associated architectures.

--- a/src/components/vm/overview/helpers.jsx
+++ b/src/components/vm/overview/helpers.jsx
@@ -16,12 +16,33 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
-
+import React from 'react';
 import cockpit from 'cockpit';
+
+import { CodeBlock, CodeBlockCode } from "@patternfly/react-core/dist/esm/components/CodeBlock";
+import { FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
 
 const _ = cockpit.gettext;
 
 export const WATCHDOG_INFO_MESSAGE = _("Watchdogs act when systems stop responding. To use this virtual watchdog device, the guest system also needs to have an additional driver and a running watchdog service.");
+export const VSOCK_INFO_MESSAGE = _("Virtual socket support enables communication between the host and guest over a socket. It still requires special vsock-aware software to communicate over the socket.");
+export const SOCAT_EXAMPLE_HEADER = _("An example of vsock-aware software is socat");
+export const SOCAT_EXAMPLE = (
+    <>
+        <FlexItem>
+            {_("On the host")}
+            <CodeBlock>
+                <CodeBlockCode>socat VSOCK-LISTEN:1234 VSOCK-CONNECT:[vsock_identifier]:1234</CodeBlockCode>
+            </CodeBlock>
+        </FlexItem>
+        <FlexItem>
+            {_("Inside the VM")}
+            <CodeBlock>
+                <CodeBlockCode>nc --vsock -l 1234</CodeBlockCode>
+            </CodeBlock>
+        </FlexItem>
+    </>
+);
 
 export function labelForFirmwarePath(path, guest_arch) {
     /* Copied from virt-manager code:

--- a/src/components/vm/overview/vmOverviewCard.jsx
+++ b/src/components/vm/overview/vmOverviewCard.jsx
@@ -20,10 +20,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cockpit from 'cockpit';
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Icon } from "@patternfly/react-core/dist/esm/components/Icon";
 import { Text, TextVariants } from "@patternfly/react-core/dist/esm/components/Text";
 import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip";
 import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from "@patternfly/react-core/dist/esm/components/DescriptionList";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
+import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
 import { Switch } from "@patternfly/react-core/dist/esm/components/Switch";
 import { DialogsContext } from 'dialogs.jsx';
 import { HelpIcon } from '@patternfly/react-icons';
@@ -41,10 +43,16 @@ import { BootOrderLink } from './bootOrder.jsx';
 import { FirmwareLink } from './firmware.jsx';
 import { WatchdogLink } from './watchdog.jsx';
 import { needsShutdownCpuModel, NeedsShutdownTooltip, needsShutdownVcpu } from '../../common/needsShutdown.jsx';
+import { VsockLink } from './vsock.jsx';
 import { StateIcon } from '../../common/stateIcon.jsx';
 import { domainChangeAutostart, domainGet } from '../../../libvirtApi/domain.js';
 import store from '../../../store.js';
-import { WATCHDOG_INFO_MESSAGE } from './helpers.js';
+import {
+    SOCAT_EXAMPLE,
+    SOCAT_EXAMPLE_HEADER,
+    VSOCK_INFO_MESSAGE,
+    WATCHDOG_INFO_MESSAGE,
+} from './helpers.jsx';
 
 import '../../common/overviewCard.css';
 
@@ -92,7 +100,7 @@ class VmOverviewCard extends React.Component {
     }
 
     render() {
-        const { vm, nodeDevices, libvirtVersion } = this.props;
+        const { vm, vms, nodeDevices, libvirtVersion } = this.props;
         const idPrefix = vmId(vm.name);
 
         const autostart = (
@@ -216,6 +224,38 @@ class VmOverviewCard extends React.Component {
                                 <WatchdogLink vm={vm} idPrefix={idPrefix} />
                             </DescriptionListDescription>
                         </DescriptionListGroup>
+
+                        <DescriptionListGroup>
+                            <Flex spaceItems={{ default: 'spaceItemsXs' }} alignItems={{ default: 'alignItemsCenter' }}>
+                                <FlexItem>
+                                    <DescriptionListTerm>
+                                        {_("Vsock")}
+                                    </DescriptionListTerm>
+                                </FlexItem>
+                                <FlexItem>
+                                    <Popover alertSeverityVariant="info"
+                                        position="right"
+                                        headerContent={_("vsock requires special software")}
+                                        bodyContent={VSOCK_INFO_MESSAGE}
+                                        footerContent={
+                                            <Flex direction={{ default: 'column' }}>
+                                                <FlexItem>{SOCAT_EXAMPLE_HEADER}</FlexItem>
+                                                {SOCAT_EXAMPLE}
+                                            </Flex>
+                                        }
+                                        hasAutoWidth>
+                                        <button onClick={e => e.preventDefault()} className="pf-c-form__group-label-help">
+                                            <Icon className="overview-icon" status="info">
+                                                <HelpIcon noVerticalAlign />
+                                            </Icon>
+                                        </button>
+                                    </Popover>
+                                </FlexItem>
+                            </Flex>
+                            <DescriptionListDescription id={`${idPrefix}-vsock`}>
+                                <VsockLink vm={vm} vms={vms} idPrefix={idPrefix} infoMessage={VSOCK_INFO_MESSAGE} socatMessage={SOCAT_EXAMPLE} />
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>
                     </DescriptionList>
                 </FlexItem>
                 <FlexItem>
@@ -246,6 +286,7 @@ class VmOverviewCard extends React.Component {
 
 VmOverviewCard.propTypes = {
     vm: PropTypes.object.isRequired,
+    vms: PropTypes.array.isRequired,
     config: PropTypes.object.isRequired,
     libvirtVersion: PropTypes.number.isRequired,
     nodeDevices: PropTypes.array.isRequired,

--- a/src/components/vm/overview/vmOverviewCard.jsx
+++ b/src/components/vm/overview/vmOverviewCard.jsx
@@ -26,6 +26,7 @@ import { DescriptionList, DescriptionListDescription, DescriptionListGroup, Desc
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
 import { Switch } from "@patternfly/react-core/dist/esm/components/Switch";
 import { DialogsContext } from 'dialogs.jsx';
+import { HelpIcon } from '@patternfly/react-icons';
 
 import { CPUModal } from './cpuModal.jsx';
 import MemoryModal from './memoryModal.jsx';
@@ -43,6 +44,7 @@ import { needsShutdownCpuModel, NeedsShutdownTooltip, needsShutdownVcpu } from '
 import { StateIcon } from '../../common/stateIcon.jsx';
 import { domainChangeAutostart, domainGet } from '../../../libvirtApi/domain.js';
 import store from '../../../store.js';
+import { WATCHDOG_INFO_MESSAGE } from './helpers.js';
 
 import '../../common/overviewCard.css';
 
@@ -192,7 +194,24 @@ class VmOverviewCard extends React.Component {
                         </DescriptionListGroup>}
 
                         <DescriptionListGroup>
-                            <DescriptionListTerm>{_("Watchdog")}</DescriptionListTerm>
+                            <Flex spaceItems={{ default: 'spaceItemsXs' }} alignItems={{ default: 'alignItemsCenter' }}>
+                                <FlexItem>
+                                    <DescriptionListTerm>
+                                        {_("Watchdog")}
+                                    </DescriptionListTerm>
+                                </FlexItem>
+                                <FlexItem>
+                                    <Popover alertSeverityVariant="info"
+                                        position="right"
+                                        bodyContent={WATCHDOG_INFO_MESSAGE}>
+                                        <button onClick={e => e.preventDefault()} className="pf-c-form__group-label-help">
+                                            <Icon className="overview-icon" status="info">
+                                                <HelpIcon noVerticalAlign />
+                                            </Icon>
+                                        </button>
+                                    </Popover>
+                                </FlexItem>
+                            </Flex>
                             <DescriptionListDescription id={`${idPrefix}-watchdog`}>
                                 <WatchdogLink vm={vm} idPrefix={idPrefix} />
                             </DescriptionListDescription>

--- a/src/components/vm/overview/vsock.jsx
+++ b/src/components/vm/overview/vsock.jsx
@@ -1,0 +1,279 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import cockpit from 'cockpit';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
+import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
+import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
+import { NumberInput } from "@patternfly/react-core/dist/esm/components/NumberInput";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
+import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
+import { HelpIcon } from '@patternfly/react-icons';
+import { useDialogs } from 'dialogs.jsx';
+import { fmt_to_fragments } from 'utils.jsx';
+
+import { ModalError } from 'cockpit-components-inline-notification.jsx';
+import { FormHelper } from "cockpit-components-form-helper.jsx";
+import { domainRemoveVsock, domainSetVsock } from "../../../libvirtApi/domain.js";
+import { NeedsShutdownAlert, NeedsShutdownTooltip } from "../../common/needsShutdown.jsx";
+import {
+    SOCAT_EXAMPLE,
+    SOCAT_EXAMPLE_HEADER,
+    VSOCK_INFO_MESSAGE,
+} from './helpers.jsx';
+
+import "./vsock.scss";
+
+const _ = cockpit.gettext;
+
+const ASSIGN_AUTOMATICALLY = _("Assign automatically");
+// There  are  several  reserved  addresses:
+// VMADDR_CID_ANY  (-1U)  means  any  address  for  binding;
+// VMADDR_CID_HYPERVISOR (0) is reserved for services built into the hypervisor;
+// VMADDR_CID_LOCAL (1) is the well-known address for local communication (loopback);
+// VMADDR_CID_HOST (2) is the well-known address of the host.
+const MIN_VSOCK_CID = 3;
+
+function getVsockUsageMessage(vmName, connectionName, vms, auto, address) {
+    if (auto)
+        return;
+
+    const vmsUsingCIDAddress = vms
+            .filter(vm => !(vmName === vm.name && connectionName === vm.connectionName) && vm.vsock.cid.auto === "no" && vm.vsock.cid.address === String(address))
+            .map(vm => vm.name);
+    if (vmsUsingCIDAddress.length === 0)
+        return;
+
+    const vmsUsingCIDAddressString = vmsUsingCIDAddress.join(", ");
+
+    return (
+        <span>
+            {fmt_to_fragments(_("Identifier in use by $0. VMs with an identical identifier cannot run at the same time."), <b>{vmsUsingCIDAddressString}</b>)}
+        </span>
+    );
+}
+
+function getNextAvailableVsockCID(vmName, connectionName, vms) {
+    let availableAddress = MIN_VSOCK_CID;
+
+    const vmsCIDAddresses = vms.filter(vm => !(vmName === vm.name && connectionName === vm.connectionName) && vm.vsock.cid.auto === "no")
+            .map(vm => Number(vm.vsock.cid.address))
+            .sort();
+
+    for (let i = 0; i < vmsCIDAddresses.length; i++) {
+        const addressInUse = vmsCIDAddresses[i];
+        if (availableAddress === addressInUse) {
+            availableAddress++;
+            i = 0;
+        }
+    }
+
+    return availableAddress;
+}
+
+export const VsockModal = ({ vm, vms, vmVsockNormalized, isVsockAttached, idPrefix }) => {
+    const [dialogError, setDialogError] = useState();
+    const [auto, setAuto] = useState(vm.vsock.cid.auto ? vmVsockNormalized.auto : true);
+    const [address, _setAddress] = useState(vmVsockNormalized.address || getNextAvailableVsockCID(vm.name, vm.connectionName, vms));
+    const [actionInProgress, setActionInProgress] = useState(undefined);
+
+    const setAddress = (value) => {
+        // Allow empty string
+        if (value === "") {
+            _setAddress(value);
+            return;
+        }
+
+        _setAddress(parseInt(value));
+    };
+
+    const onBlur = (value) => {
+        if (value < MIN_VSOCK_CID)
+            value = MIN_VSOCK_CID;
+
+        _setAddress(value);
+    };
+
+    const Dialogs = useDialogs();
+
+    const save = () => {
+        setActionInProgress("save");
+        return domainSetVsock({
+            connectionName: vm.connectionName,
+            vmName: vm.name,
+            hotplug: vm.state === "running",
+            permanent: vm.persistent,
+            auto: auto ? "yes" : "no",
+            address,
+            isVsockAttached,
+        })
+                .then(Dialogs.close, exc => setDialogError({ text: _("Failed to configure vsock"), detail: exc.message }))
+                .finally(() => setActionInProgress(undefined));
+    };
+
+    const detach = () => {
+        setActionInProgress("detach");
+        return domainRemoveVsock({
+            connectionName: vm.connectionName,
+            vmName: vm.name,
+            hotplug: vm.state === "running",
+            permanent: vm.persistent,
+        })
+                .then(Dialogs.close, exc => setDialogError({ text: _("Failed to detach vsock"), detail: exc.message }))
+                .finally(() => setActionInProgress(undefined));
+    };
+
+    const showWarning = () => {
+        if (isVsockAttached && vm.persistent && vm.state === "running" &&
+            (vmVsockNormalized.auto !== auto ||
+            // If automatic generation is set, then adress in live XML is prefilled with a value libvirt chooses,
+            // and it's expected that live XML will contain different address than inactiveXML
+            (!auto && vmVsockNormalized.address !== address)))
+            return <NeedsShutdownAlert idPrefix={idPrefix} />;
+    };
+
+    const vsockUsage = getVsockUsageMessage(vm.name, vm.connectionName, vms, auto, address);
+
+    const body = (
+        <Form onSubmit={e => e.preventDefault()} isHorizontal>
+            <FormGroup fieldId="vsock-cid"
+                       label={_("Custom identifier")}
+                       isInline>
+                <Flex alignItems={{ default: 'alignItemsCenter' }} spaceItems={{ default: 'spaceItemsSm' }}>
+                    <Checkbox id='vsock-cid-generate'
+                              isChecked={!auto}
+                              onChange={() => setAuto(!auto)} />
+                    <NumberInput value={!auto ? address : ""}
+                        onMinus={() => setAddress(address - 1)}
+                        onChange={event => setAddress(event.target.value)}
+                        onPlus={() => setAddress(address + 1)}
+                        onBlur={event => onBlur(event.target.value)}
+                        min={MIN_VSOCK_CID}
+                        isDisabled={auto}
+                        inputName="vsock-context-identifier"
+                        id="vsock-context-identifier"
+                        inputAriaLabel="vsock context identifier"
+                        allowEmptyInput
+                        widthChars={4} />
+                </Flex>
+                <FormHelper fieldId="vsock-cid-usage"
+                    variant="warning"
+                    helperTextInvalid={vsockUsage}
+                    helperText={vsockUsage} />
+            </FormGroup>
+        </Form>
+    );
+
+    return (
+        <Modal id={`${idPrefix}-vsock-modal`}
+               position="top"
+               variant="small"
+               onClose={Dialogs.close}
+               title={isVsockAttached ? _("Edit vsock interface") : _("Add vsock interface")}
+               description={<>
+                   {VSOCK_INFO_MESSAGE}
+                   <Popover alertSeverityVariant="info"
+                       position="bottom"
+                       headerContent={SOCAT_EXAMPLE_HEADER}
+                       bodyContent={
+                           <Flex direction={{ default: 'column' }}>
+                               {SOCAT_EXAMPLE}
+                           </Flex>
+                       }
+                       hasAutoWidth>
+                       <Button variant="plain" className="pf-u-px-sm pf-u-py-0" aria-label={_("more info")}>
+                           <HelpIcon noVerticalAlign />
+                       </Button>
+                   </Popover>
+               </>}
+               isOpen
+               footer={
+                   <>
+                       <Button variant='primary'
+                               id="vsock-dialog-apply"
+                               onClick={save}
+                               isLoading={actionInProgress == "save"}
+                               isDisabled={actionInProgress}>
+                           {isVsockAttached ? _("Save") : _("Add")}
+                       </Button>
+                       {isVsockAttached &&
+                       <Button variant='secondary'
+                               id="vsock-dialog-detach"
+                               onClick={detach}
+                               isLoading={actionInProgress == "detach"}
+                               isDisabled={actionInProgress}>
+                           {_("Remove")}
+                       </Button>}
+                       <Button variant='link' onClick={Dialogs.close}>
+                           {_("Cancel")}
+                       </Button>
+                   </>
+               }>
+            {showWarning()}
+            {dialogError && <ModalError dialogError={dialogError.text} dialogErrorDetail={dialogError.detail} />}
+            {body}
+        </Modal>
+    );
+};
+
+VsockModal.propTypes = {
+    vm: PropTypes.object.isRequired,
+    vmVsockNormalized: PropTypes.object.isRequired,
+    vms: PropTypes.array.isRequired,
+    isVsockAttached: PropTypes.bool.isRequired,
+    idPrefix: PropTypes.string.isRequired,
+};
+
+export const VsockLink = ({ vm, vms, idPrefix }) => {
+    const Dialogs = useDialogs();
+    const isVsockAttached = Object.keys(vm.vsock.cid).length > 0;
+    const vmVsockNormalized = {
+        auto: vm.vsock.cid.auto && vm.vsock.cid.auto === "yes",
+        address: vm.vsock.cid.address && Number(vm.vsock.cid.address),
+    };
+    const vsockActionChanged = vm.persistent && vm.state === "running" &&
+                               (vm.inactiveXML.vsock.cid.auto !== vm.vsock.cid.auto ||
+                               // If automatic generation is set, then adress in live XML is prefilled with a value libvirt chooses,
+                               // and it's expected that live XML will contain different address than inactiveXML
+                               (!vmVsockNormalized.auto && vm.inactiveXML.vsock.cid.address !== vm.vsock.cid.address));
+    let vsockAddress = _("none");
+    if (vmVsockNormalized.auto && vm.state !== "running") {
+        vsockAddress = ASSIGN_AUTOMATICALLY.toLowerCase(); // small hack so translators don't have to translate both uppercase and lowercase string
+    } else if (vmVsockNormalized.address) {
+        vsockAddress = vmVsockNormalized.address;
+    }
+
+    function open() {
+        Dialogs.show(<VsockModal vm={vm} vms={vms} vmVsockNormalized={vmVsockNormalized} isVsockAttached={isVsockAttached} idPrefix={idPrefix} />);
+    }
+
+    return (
+        <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+            <FlexItem id={`${idPrefix}-vsock-address`}>
+                {vsockAddress}
+            </FlexItem>
+            { vsockActionChanged && <NeedsShutdownTooltip iconId="vsock-tooltip" tooltipId="tip-vsock" /> }
+            <Button variant="link" isInline id={`${idPrefix}-vsock-button`} onClick={open}>
+                {isVsockAttached ? _("edit") : _("add")}
+            </Button>
+        </Flex>
+    );
+};

--- a/src/components/vm/overview/vsock.scss
+++ b/src/components/vm/overview/vsock.scss
@@ -1,0 +1,6 @@
+.ct-input-group-spacer-sm.pf-l-flex {
+    // Limit width for select entries and inputs in the input groups otherwise they take up the whole space
+    > .pf-c-select, .pf-c-form-control:not(.pf-c-select__toggle-typeahead) {
+      max-width: 8ch;
+    }
+}

--- a/src/components/vm/overview/watchdog.jsx
+++ b/src/components/vm/overview/watchdog.jsx
@@ -32,7 +32,7 @@ import { ModalError } from 'cockpit-components-inline-notification.jsx';
 import { domainRemoveWatchdog, domainSetWatchdog } from "../../../libvirtApi/domain.js";
 import { rephraseUI } from "../../../helpers.js";
 import { NeedsShutdownAlert, NeedsShutdownTooltip, needsShutdownWatchdog } from "../../common/needsShutdown.jsx";
-import { WATCHDOG_INFO_MESSAGE } from './helpers.js';
+import { WATCHDOG_INFO_MESSAGE } from './helpers.jsx';
 
 const _ = cockpit.gettext;
 

--- a/src/components/vm/overview/watchdog.jsx
+++ b/src/components/vm/overview/watchdog.jsx
@@ -32,6 +32,7 @@ import { ModalError } from 'cockpit-components-inline-notification.jsx';
 import { domainRemoveWatchdog, domainSetWatchdog } from "../../../libvirtApi/domain.js";
 import { rephraseUI } from "../../../helpers.js";
 import { NeedsShutdownAlert, NeedsShutdownTooltip, needsShutdownWatchdog } from "../../common/needsShutdown.jsx";
+import { WATCHDOG_INFO_MESSAGE } from './helpers.js';
 
 const _ = cockpit.gettext;
 
@@ -145,7 +146,7 @@ export const WatchdogModal = ({ vm, isWatchdogAttached, idPrefix }) => {
                variant="small"
                onClose={Dialogs.close}
                title={isWatchdogAttached ? _("Edit watchdog device type") : _("Add watchdog device type")}
-               description={_("Watchdogs act when systems stop responding. To use this virtual watchdog device, the guest system also needs to have an additional driver and a running watchdog service.")}
+               description={WATCHDOG_INFO_MESSAGE}
                isOpen
                footer={
                    <>

--- a/src/components/vm/vmDetailsPage.jsx
+++ b/src/components/vm/vmDetailsPage.jsx
@@ -109,7 +109,9 @@ export const VmDetailsPage = ({
         {
             id: `${vmId(vm.name)}-overview`,
             title: _("Overview"),
-            body: <VmOverviewCard vm={vm} config={config}
+            body: <VmOverviewCard vm={vm}
+                                  vms={vms}
+                                  config={config}
                                   loaderElems={vm.capabilities.loaderElems}
                                   maxVcpu={vm.capabilities.maxVcpu}
                                   cpuModels={vm.capabilities.cpuModels}

--- a/src/libvirt-xml-parse.js
+++ b/src/libvirt-xml-parse.js
@@ -245,6 +245,7 @@ export function parseDomainDumpxml(connectionName, domXml, objPath) {
     const hostDevices = parseDumpxmlForHostDevices(devicesElem);
     const filesystems = parseDumpxmlForFilesystems(devicesElem);
     const watchdog = parseDumpxmlForWatchdog(devicesElem);
+    const vsock = parseDumpxmlForVsock(devicesElem);
 
     const hasInstallPhase = parseDumpxmlMachinesMetadataElement(metadataElem, 'has_install_phase') === 'true';
     const installSourceType = parseDumpxmlMachinesMetadataElement(metadataElem, 'install_source_type');
@@ -286,6 +287,7 @@ export function parseDomainDumpxml(connectionName, domXml, objPath) {
         hostDevices,
         filesystems,
         watchdog,
+        vsock,
         metadata,
     };
 }
@@ -460,6 +462,23 @@ export function parseDumpxmlForWatchdog(devicesElem) {
     } else {
         return {};
     }
+}
+
+export function parseDumpxmlForVsock(devicesElem) {
+    const vsockElem = getSingleOptionalElem(devicesElem, 'vsock');
+    const cid = {};
+
+    if (vsockElem) {
+        const cidElem = getSingleOptionalElem(devicesElem, 'cid');
+
+        if (cidElem) {
+            // https://libvirt.org/formatdomain.html#vsock
+            cid.auto = cidElem.getAttribute('auto');
+            cid.address = cidElem.getAttribute('address');
+        }
+    }
+
+    return { cid };
 }
 
 export function parseDumpxmlForFilesystems(devicesElem) {

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -583,6 +583,23 @@ export function domainDetachIface({ connectionName, index, vmName, live, persist
     return cockpit.spawn(args, options);
 }
 
+export function domainRemoveVsock({ connectionName, vmName, permanent, hotplug }) {
+    const args = ['virt-xml', '-c', `qemu:///${connectionName}`, vmName, '--remove-device', '--vsock', '1'];
+
+    const options = { err: "message" };
+
+    if (connectionName === "system")
+        options.superuser = "try";
+
+    if (hotplug) {
+        args.push("--update");
+        if (!permanent)
+            args.push("--no-define");
+    }
+
+    return cockpit.spawn(args, options);
+}
+
 export function domainRemoveWatchdog({ connectionName, vmName, permanent, hotplug, model }) {
     const args = ['virt-xml', '-c', `qemu:///${connectionName}`, vmName, '--remove-device', '--watchdog', `model=${model}`];
     const options = { err: "message" };
@@ -978,6 +995,25 @@ export function domainSetVCPUSettings ({
     return cockpit.spawn([
         'virt-xml', '-c', `qemu:///${connectionName}`, '--vcpu', `${max},vcpu.current=${count},sockets=${sockets},cores=${cores},threads=${threads}`, name, '--edit'
     ], opts);
+}
+
+export function domainSetVsock({ connectionName, vmName, permanent, hotplug, auto, address, isVsockAttached }) {
+    const cidAddressStr = address ? `,cid.address=${address}` : "";
+    const args = ['virt-xml', '-c', `qemu:///${connectionName}`, vmName, isVsockAttached ? '--edit' : '--add-device', '--vsock', `cid.auto=${auto}${cidAddressStr}`];
+    const options = { err: "message" };
+
+    if (connectionName === "system")
+        options.superuser = "try";
+
+    // Only attaching new vsock device to running VM works
+    // Editing existing vsock device on running VM (live XML config) is not possible, in such situation we only change offline XML config
+    if (hotplug && !isVsockAttached) {
+        args.push("--update");
+        if (!permanent)
+            args.push("--no-define");
+    }
+
+    return cockpit.spawn(args, options);
 }
 
 export function domainSetWatchdog({ connectionName, vmName, defineOffline, hotplug, action, isWatchdogAttached }) {

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -19,6 +19,7 @@
 
 import os
 import sys
+import subprocess
 
 # import Cockpit's machinery for test VMs and its browser test API
 TEST_DIR = os.path.dirname(__file__)
@@ -673,6 +674,166 @@ class TestMachinesSettings(VirtualMachinesCase):
             # Destroy and start a VM so libvirt reloads updated XML
             m.execute("virsh destroy subVmTest1; virsh start subVmTest1")
             b.wait_not_present("#watchdog-tooltip")
+
+    def testVsock(self):
+        b = self.browser
+        m = self.machine
+
+        default_libvirt_vsock_address = "3"  # When we don't specify address, libvit will choose lowest available (3 in case of clean VM)
+
+        def setVsock(auto, address=None, machine_has_no_vsock=False, pixel_test_tag=None, reboot_machine=False):
+            # If no vsock configured, we are attaching a new vsock device. If vsock already is set, we are editing an exiting vsock device
+            if machine_has_no_vsock:
+                b.wait_in_text("#vm-subVmTest1-vsock-button", "add")
+            else:
+                b.wait_in_text("#vm-subVmTest1-vsock-button", "edit")
+
+            b.click("#vm-subVmTest1-vsock-button")
+            b.wait_visible("#vm-subVmTest1-vsock-modal")
+
+            if pixel_test_tag:
+                b.assert_pixels("#vm-subVmTest1-vsock-modal", pixel_test_tag)
+
+            b.set_checked("#vsock-cid-generate", not auto)
+            if not auto:
+                b.set_input_text("#vsock-context-identifier input", address)
+
+            if machine_has_no_vsock:
+                b.wait_in_text("#vsock-dialog-apply", "Add")
+            else:
+                b.wait_in_text("#vsock-dialog-apply", "Save")
+
+            b.click("#vsock-dialog-apply")
+            b.wait_not_present("#vm-subVmTest1-vsock-modal")
+
+            b.wait_in_text("#vm-subVmTest1-vsock-address", "assign automatically" if auto else address)
+
+            virsh_output_auto = m.execute("virsh dumpxml subVmTest1 | xmllint --xpath '/domain/devices/vsock/cid/@auto' -").strip()
+            virsh_output_address = m.execute("virsh dumpxml subVmTest1 | xmllint --xpath '/domain/devices/vsock/cid/@address' -").strip()
+            self.assertEqual(virsh_output_auto, 'auto="yes"' if auto else 'auto="no"')
+            if not auto:
+                self.assertEqual(virsh_output_address, f'address="{address}"')
+
+        def setVsockLive(new_auto, new_address=None, previous_address=None, previous_auto=None, reboot_machine=False):
+            b.click("#vm-subVmTest1-vsock-button")
+            b.wait_visible("#vm-subVmTest1-vsock-modal")
+
+            b.set_checked("#vsock-cid-generate", not new_auto)
+            if not new_auto:
+                b.set_input_text("#vsock-context-identifier input", new_address)
+
+            if previous_address or previous_auto:
+                # When editing an exiting vsock, message warning user that changes will take effect after reboot should be present
+                b.wait_visible("#vm-subVmTest1-vsock-modal #vm-subVmTest1-idle-message")
+            else:
+                # When attaching adding a new vsock, no message should be present
+                b.wait_not_present("#vm-subVmTest1-vsock-modal #vm-subVmTest1-idle-message")
+
+            b.click("#vsock-dialog-apply")
+            b.wait_not_present("#vm-subVmTest1-vsock-modal")
+
+            if previous_address or previous_auto:
+                # When editing an exiting vsock, tooltip should be present on overview card warning user that changes will take effect after reboot
+                b.wait_visible("#vsock-tooltip")
+            else:
+                # When attaching adding a new vsock, no tooltip should be present
+                b.wait_not_present("#vsock-tooltip")
+
+            # Libvirt doesn't support editing vsock device on RUNNING vm, so a live VM config will persist the previously configured vsock action until reboot
+            # On the other hand, libvirt does support attaching a vsock to a RUNNING VM
+            # So in summary:
+            # - if no previous vsock is configured on a VM, we are attaching a new vsock device and live VM config will get updated
+            # - if vsock action is configured on a VM, and we are editing an editing vsock device, the live VM config will persist the old setting until VM is rebooted
+            virsh_output_auto = m.execute("virsh dumpxml subVmTest1 | xmllint --xpath '/domain/devices/vsock/cid/@auto' -").strip()
+            if previous_auto is not None:  # Editing exiting vsock
+                expected_auto = "yes" if previous_auto else "no"
+            else:  # Attaching new vsock
+                expected_auto = "yes" if new_auto else "no"
+            self.assertEqual(virsh_output_auto, f'auto="{expected_auto}"')
+
+            if previous_address is not None:
+                expected_address = previous_address  # Editing exiting vsock, old vsock is still present in live XML
+            else:
+                if new_address is not None:
+                    expected_address = new_address   # Attaching new vsock, new vsock is already present in live VM
+                else:
+                    expected_address = default_libvirt_vsock_address  # When we don't specify address, libvit will choose
+            b.wait_in_text("#vm-subVmTest1-vsock-address", expected_address)
+            virsh_output_address = m.execute("virsh dumpxml subVmTest1 | xmllint --xpath '/domain/devices/vsock/cid/@address' -").strip()
+            self.assertEqual(virsh_output_address, f'address="{expected_address}"')
+
+            # Offline VM config will always have newly configured vsock, no matter if we are attaching a new vsock device or editing an existing one
+            expected_auto_offline = "yes" if new_auto else "no"
+            virsh_output_offline_auto = m.execute("virsh dumpxml subVmTest1 --inactive | xmllint --xpath '/domain/devices/vsock/cid/@auto' -").strip()
+            self.assertEqual(virsh_output_offline_auto, f'auto="{expected_auto_offline}"')
+
+            expected_address_offline = new_address
+            virsh_output_offline_address = m.execute("virsh dumpxml subVmTest1 --inactive | xmllint --xpath '/domain/devices/vsock/cid/@address' -").strip()
+            if expected_address_offline:
+                self.assertEqual(virsh_output_offline_address, f'address="{expected_address_offline}"')
+
+            if reboot_machine:
+                # Check that after rebooting machine, live VM config will have new vsock condiguration
+                self.performAction("subVmTest1", "forceOff")
+                b.click("#vm-subVmTest1-system-run")
+                b.wait_in_text("#vm-subVmTest1-system-state", "Running")
+
+                expected_after_reboot_auto = "yes" if new_auto else "no"
+                virsh_output_auto = m.execute("virsh dumpxml subVmTest1 | xmllint --xpath '/domain/devices/vsock/cid/@auto' -").strip()
+                self.assertEqual(virsh_output_auto, f'auto="{expected_after_reboot_auto}"')
+
+                expected_after_reboot_address = new_address if new_address else default_libvirt_vsock_address
+                b.wait_in_text("#vm-subVmTest1-vsock-address", expected_after_reboot_address)
+                virsh_output_address = m.execute("virsh dumpxml subVmTest1 | xmllint --xpath '/domain/devices/vsock/cid/@address' -").strip()
+                self.assertEqual(virsh_output_address, f'address="{expected_after_reboot_address}"')
+
+        def removeVsockDevice(live=True):
+            b.click("#vm-subVmTest1-vsock-button")
+            b.wait_visible("#vm-subVmTest1-vsock-modal")
+
+            b.click("#vsock-dialog-detach")
+            b.wait_not_present("#vm-subVmTest1-vsock-modal")
+
+            b.wait_in_text("#vm-subVmTest1-vsock-address", "none")
+            # check no vsock is present in VM's xml (also xmllint is expected to return non-zero code)
+            virsh_output = m.execute("virsh dumpxml subVmTest1 | xmllint --xpath '/domain/devices/vsock' - 2>&1 || true").strip()
+            self.assertEqual(virsh_output, 'XPath set is empty')
+
+            if live:
+                # check no vsock is present in VM's xml (also xmllint is expected to return non-zero code)
+                virsh_output = m.execute("virsh dumpxml subVmTest1 --inactive | xmllint --xpath '/domain/devices/vsock' - 2>&1 || true").strip()
+                self.assertEqual(virsh_output, 'XPath set is empty')
+
+        self.createVm("subVmTest1", running=False)
+
+        self.login_and_go("/machines")
+        self.waitPageInit()
+        self.goToVmPage("subVmTest1")
+
+        b.wait_in_text("#vm-subVmTest1-vsock-address", "none")
+
+        # The whole UI is based around expectation that libvirt allows maximum 1 vsock per VM
+        # Have a canary here which will let us know once this is no longer true
+        m.execute("virt-xml subVmTest1 --add-device --vsock cid.auto=yes")
+        # Attaching second vsock is expected to fail
+        self.assertRaises(subprocess.CalledProcessError, m.execute, "virt-xml subVmTest1 --add-device --vsock cid.auto=no,cid.address=8")
+        m.execute("virt-xml subVmTest1 --remove-device --vsock 1")
+
+        # Test configuring vsock for shutoff VM
+        setVsock(auto=True, machine_has_no_vsock=True)
+        setVsock(auto=False, address="5", pixel_test_tag="vsock")
+        removeVsockDevice()
+
+        # Because of bug in debian-testing, hotplug of vsock device fails
+        # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1033872
+        if m.image not in ["debian-testing", "debian-stable"]:
+            b.click("#vm-subVmTest1-system-run")
+            b.wait_in_text("#vm-subVmTest1-system-state", "Running")
+
+            # Test configuring vsock for running VM
+            setVsockLive(new_auto=False, new_address="5")
+            setVsockLive(new_auto=True, previous_auto=False, previous_address="5", reboot_machine=True)
+            setVsockLive(new_auto=False, new_address="4", previous_auto=True, previous_address=default_libvirt_vsock_address)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#  Vsock device support

Virtual socket support enables communication between the host and guest over a socket. Cockpit Machines now has support for setting up such a device.

![Screenshot from 2023-05-16 12-43-49](https://github.com/cockpit-project/cockpit-machines/assets/42733240/ec6d026f-be16-4dd7-ad46-daaea92b2834)

The user can choose to configure a custom identifier, or let have it assigned automatically upon a VM's boot. The identifier is used by the host to uniquely identify vsock of a specific guest.

![Screenshot from 2023-05-16 12-44-02](https://github.com/cockpit-project/cockpit-machines/assets/42733240/81496599-4c33-42dd-8785-8a9dd913af06)

Please note that vsock still requires special vsock-aware software (e.g. socat) to communicate over the socket.