### PR TITLE
Don't start virtproxyd.socket

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -78,7 +78,6 @@ if [ "${PLATFORM_ID:-}" != "platform:el8" ]; then
     systemctl start virtinterfaced.socket
     systemctl start virtnetworkd.socket
     systemctl start virtnodedevd.socket
-    systemctl start virtproxyd.socket
     systemctl start virtstoraged.socket
 fi
 


### PR DESCRIPTION
    Unit virtproxyd.socket not found started to show up on fedora-rawhide.
    Let's see if we actually need it for our CI.
