### PR TITLE
Use id instead of shortId to workaround osinfo-db issue

### DIFF
--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -470,7 +470,7 @@ class OSRow extends React.Component {
                     onToggle={isOpen => this.setState({ isOpen })}
                     isOpen={this.state.isOpen}
                     menuAppendTo="parent">
-                    {this.state.osEntries.map(os => (<SelectOption key={os.shortId}
+                    {this.state.osEntries.map(os => (<SelectOption key={os.id}
                                                                   value={this.createValue(os)} />))}
                 </PFSelect>
             </FormGroup>


### PR DESCRIPTION
https://gitlab.com/libosinfo/osinfo-db/-/commit/61c86b242bf3bb8be18f8970670bad3dbadee952

This can be reverted once the above fix is released.