### PR TITLE
Attach watchdog device only to offline XML if hotplug fails

### DIFF
--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -980,7 +980,7 @@ export function domainSetVCPUSettings ({
     ], opts);
 }
 
-export function domainSetWatchdog({ connectionName, vmName, permanent, hotplug, action, isWatchdogAttached }) {
+export function domainSetWatchdog({ connectionName, vmName, defineOffline, hotplug, action, isWatchdogAttached }) {
     const args = ['virt-xml', '-c', `qemu:///${connectionName}`, vmName, isWatchdogAttached ? '--edit' : '--add-device', '--watchdog', `action=${action}`];
     const options = { err: "message" };
 
@@ -991,7 +991,7 @@ export function domainSetWatchdog({ connectionName, vmName, permanent, hotplug, 
     // Editing existing watchdog device on running VM (live XML config) is not possible, in such situation we only change offline XML config
     if (hotplug && !isWatchdogAttached) {
         args.push("--update");
-        if (!permanent)
+        if (!defineOffline)
             args.push("--no-define");
     }
 

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -644,6 +644,31 @@ class TestMachinesSettings(VirtualMachinesCase):
         # Check rebooting machine will not unexpectedly affect watchdog configuration
         setWatchdogActionLive(action="poweroff", reboot_machine=True)
 
+        # Older libvirt in rhel-8-9 and centos-8-stream doesn't support target.hotplug=off
+        if not m.image.startswith("rhel-8") and m.image != "centos-8-stream":
+            # Disable hotplugging for subVmTest1
+            m.execute("virsh destroy subVmTest1")
+            m.execute("virt-xml subVmTest1 --edit model=pci-root --controller target.hotplug=off")
+            # Cleanup watchdog configuration
+            m.execute("virt-xml subVmTest1 --remove-device --watchdog 1")
+            m.execute("virsh start subVmTest1")
+
+            # Test hotplug will fail and warning is shown
+            openWatchDogDialog()
+            b.wait_not_present("#watchdog-dialog-apply-next-boot")
+            b.click("#reset")
+            b.click("#watchdog-dialog-apply")
+            b.wait_in_text("#vm-subVmTest1-watchdog-modal .pf-m-warning", "Could not dynamically add watchdog")
+            b.wait_visible("#watchdog-dialog-apply:disabled")
+            # Apply coldplug
+            closeWatchDogDialog("#watchdog-dialog-apply-next-boot")
+            # Watchdog requires fresh boot
+            b.wait_visible("#watchdog-tooltip")
+
+            # Destroy and start a VM so libvirt reloads updated XML
+            m.execute("virsh destroy subVmTest1; virsh start subVmTest1")
+            b.wait_not_present("#watchdog-tooltip")
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -499,6 +499,14 @@ class TestMachinesSettings(VirtualMachinesCase):
             "inject-nmi": "Inject a non-maskable interrupt",
         }
 
+        def openWatchDogDialog():
+            b.click("#vm-subVmTest1-watchdog-button")
+            b.wait_visible("#vm-subVmTest1-watchdog-modal")
+
+        def closeWatchDogDialog(selector):
+            b.click(selector)
+            b.wait_not_present("#vm-subVmTest1-watchdog-modal")
+
         def setWatchdogAction(action, machine_has_no_watchdog=False, pixel_test_tag=None, reboot_machine=False):
             # If no watchdog action is set, we are attaching a new watchdog device. If watchdog already is set, we are editing an exiting watchdog device
             if machine_has_no_watchdog:
@@ -506,8 +514,7 @@ class TestMachinesSettings(VirtualMachinesCase):
             else:
                 b.wait_in_text("#vm-subVmTest1-watchdog-button", "edit")
 
-            b.click("#vm-subVmTest1-watchdog-button")
-            b.wait_visible("#vm-subVmTest1-watchdog-modal")
+            openWatchDogDialog()
 
             if pixel_test_tag:
                 b.assert_pixels("#vm-subVmTest1-watchdog-modal", pixel_test_tag, skip_layouts=["rtl"])
@@ -519,8 +526,7 @@ class TestMachinesSettings(VirtualMachinesCase):
             else:
                 b.wait_in_text("#watchdog-dialog-apply", "Save")
 
-            b.click("#watchdog-dialog-apply")
-            b.wait_not_present("#vm-subVmTest1-watchdog-modal")
+            closeWatchDogDialog("#watchdog-dialog-apply")
 
             b.wait_in_text("#vm-subVmTest1-watchdog-state", action_strings[action])
 
@@ -528,8 +534,7 @@ class TestMachinesSettings(VirtualMachinesCase):
             self.assertEqual(virsh_output, f'action="{action}"')
 
         def setWatchdogActionLive(action, previous_action=None, reboot_machine=False):
-            b.click("#vm-subVmTest1-watchdog-button")
-            b.wait_visible("#vm-subVmTest1-watchdog-modal")
+            openWatchDogDialog()
 
             b.click(f"#{action}")
             if previous_action:
@@ -539,8 +544,7 @@ class TestMachinesSettings(VirtualMachinesCase):
                 # When attaching adding a new watchdog, no message should be present
                 b.wait_not_present("#vm-subVmTest1-watchdog-modal #vm-subVmTest1-idle-message")
 
-            b.click("#watchdog-dialog-apply")
-            b.wait_not_present("#vm-subVmTest1-watchdog-modal")
+            closeWatchDogDialog("#watchdog-dialog-apply")
 
             if previous_action:
                 # When editing an exiting watchdog, tooltip should be present on overview card warning user that changes will take effect after reboot
@@ -603,14 +607,6 @@ class TestMachinesSettings(VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-watchdog-state", "none")
 
         # General checks for watchdog
-        def openWatchDogDialog():
-            b.click("#vm-subVmTest1-watchdog-button")
-            b.wait_visible("#vm-subVmTest1-watchdog-modal")
-
-        def closeWatchDogDialog(selector):
-            b.click(selector)
-            b.wait_not_present("#vm-subVmTest1-watchdog-modal")
-
         # Cancel
         openWatchDogDialog()
         closeWatchDogDialog("#watchdog-dialog-apply + button")


### PR DESCRIPTION
In some cases, hotplug of watchdog device to a running VM might fail since there are no more available PCI slots. This is normal behaviour and not really a bug on libvirt side.
However, if hotplug fails, instead of just failing altogether, we can at least try to attach the watchdog to an offline VM. Additionally, we should let user know that operation only succeeded for offline VM state, and hotplug failed, since they might have expected a hotplug to succeed.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2173584

# Offer to apply watchdog changes on next boot if hotplug fails

In some cases, adding a watchdog to a running VM might fail. When that happens, the user can choose to apply a watchdog on next boot.

![234253257-d6bc8d91-7b66-4ef7-b9df-79d554f92b0b](https://user-images.githubusercontent.com/42733240/235896020-7e209f2a-4c7d-4140-90ce-8ab184e8da6e.png)

