### PR TITLE
Invoke ./build.js directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,10 +88,10 @@ packaging/debian/changelog: packaging/debian/changelog.in
 	sed 's/VERSION/$(VERSION)/' $< > $@
 
 $(DIST_TEST): $(COCKPIT_REPO_STAMP) $(shell find src/ -type f) package.json build.js
-	$(MAKE) package-lock.json && NODE_ENV=$(NODE_ENV) node build.js
+	$(MAKE) package-lock.json && NODE_ENV=$(NODE_ENV) ./build.js
 
 watch:
-	NODE_ENV=$(NODE_ENV) ESBUILD_WATCH=true node build.js
+	NODE_ENV=$(NODE_ENV) ESBUILD_WATCH=true ./build.js
 
 clean:
 	rm -rf dist/

--- a/build.js
+++ b/build.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import fs from 'fs';
 import path from 'path';
 

--- a/build.js
+++ b/build.js
@@ -4,7 +4,6 @@ import path from 'path';
 
 import copy from 'esbuild-plugin-copy';
 import esbuild from "esbuild";
-import { sassPlugin } from 'esbuild-sass-plugin';
 
 import { cockpitCompressPlugin } from './pkg/lib/esbuild-compress-plugin.js';
 import { cockpitPoEsbuildPlugin } from './pkg/lib/cockpit-po-plugin.js';
@@ -70,10 +69,12 @@ const context = await esbuild.context({
     target: ['es2020'],
     plugins: [
         cleanPlugin(),
-        ...lint ? [
-            stylelintPlugin({ filter: new RegExp(cwd + '\/src\/.*\.(css?|scss?)$') }),
-            eslintPlugin({ filter: new RegExp(cwd + '\/src\/.*\.(jsx?|js?)$') })
-        ] : [],
+        ...lint
+            ? [
+                stylelintPlugin({ filter: new RegExp(cwd + '\/src\/.*\.(css?|scss?)$') }),
+                eslintPlugin({ filter: new RegExp(cwd + '\/src\/.*\.(jsx?|js?)$') })
+            ]
+            : [],
         // Esbuild will only copy assets that are explicitly imported and used
         // in the code. This is a problem for index.html and manifest.json which are not imported
         copy({

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "author": "",
   "license": "LGPL-2.1",
   "scripts": {
-    "watch": "ESBUILD_WATCH='true' node build.js",
-    "build": "node build.js",
+    "watch": "ESBUILD_WATCH='true' ./build.js",
+    "build": "./build.js",
     "eslint": "eslint --ext .jsx --ext .js src/",
     "eslint:fix": "eslint --fix --ext .jsx --ext .js src/",
     "stylelint": "stylelint 'src/**/*{.css,scss}'",


### PR DESCRIPTION
It is already executable, no need to explicitly run it through `node`.