### PR TITLE
adds VM (domain) title and description to UI

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -3454,3 +3454,29 @@ msgstr "Ja"
 
 #~ msgid "show more"
 #~ msgstr "Zeig mehr"
+
+#: src/components/vm/overview/descriptionModal.jsx
+
+#~ msgid "Description could not be changed"
+#~ msgstr "Beschreibung konnte nicht geändert werden"
+
+#~ msgid "New description"
+#~ msgstr "Neue Beschreibung"
+
+#~ msgid "Set description of $0"
+#~ msgstr "Beschreibung von $0 festlegen"
+
+#: src/components/vm/overview/titleModal.jsx
+
+#~ msgid "Title could not be changed"
+#~ msgstr "Titel konnte nicht geändert werden"
+
+#~ msgid "New title"
+#~ msgstr "Neuer Titel"
+
+#~ msgid "Set title of $0"
+#~ msgstr "Titel von $0 festlegen"
+
+#: src/components/vm/overview/vmOverviewCard.jsx:256
+#~ msgid "Title"
+#~ msgstr "Titel"

--- a/src/components/vm/overview/descriptionModal.jsx
+++ b/src/components/vm/overview/descriptionModal.jsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import cockpit from 'cockpit';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
+import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal/index.js";
+import { useDialogs } from 'dialogs.jsx';
+
+import { ModalError } from 'cockpit-components-inline-notification.jsx';
+import { domainSetDescription } from '../../../libvirtApi/domain.js';
+
+const _ = cockpit.gettext;
+
+export const DescriptionModal = ({ vm }) => {
+    const Dialogs = useDialogs();
+    const [error, setError] = useState({});
+    const [newDescription, setDescription] = useState(vm.description);
+    const [isLoading, setIsLoading] = useState(false);
+
+    function save() {
+        setIsLoading(true);
+        domainSetDescription({
+            name: vm.name,
+            id: vm.id,
+            connectionName: vm.connectionName,
+            description: newDescription
+        }).then(Dialogs.close, exc => {
+            setIsLoading(false);
+            setError({ dialogError: _("Description could not be changed"), dialogErrorDetail: exc.message });
+        });
+    }
+
+    const defaultBody = (
+        <Form isHorizontal>
+            <FormGroup id="description-model-select-group" label={_("New description")}
+                fieldId="rename-dialog-new-description"
+            >
+                <TextInput id='rename-dialog-new-description'
+                    value={newDescription}
+                    onChange={setDescription} />
+            </FormGroup>
+        </Form>
+    );
+
+    return (
+        <Modal position="top" variant="small" isOpen onClose={Dialogs.close}
+            title={cockpit.format(_("Set description of $0"), vm.name)}
+            footer={
+                <>
+                    <Button variant='primary' isDisabled={isLoading} isLoading={isLoading} id="description-config-dialog-apply" onClick={save}>
+                        {_("Save")}
+                    </Button>
+                    <Button variant='link' onClick={Dialogs.close}>
+                        {_("Cancel")}
+                    </Button>
+                </>
+            }>
+            <>
+                {error && error.dialogError && <ModalError dialogError={error.dialogError} dialogErrorDetail={error.dialogErrorDetail} />}
+                {defaultBody}
+            </>
+        </Modal>
+    );
+};

--- a/src/components/vm/overview/descriptionModal.jsx
+++ b/src/components/vm/overview/descriptionModal.jsx
@@ -14,7 +14,7 @@ const _ = cockpit.gettext;
 export const DescriptionModal = ({ vm }) => {
     const Dialogs = useDialogs();
     const [error, setError] = useState({});
-    const [newDescription, setDescription] = useState(vm.description);
+    const [newDescription, setNewDescription] = useState(vm.description);
     const [isLoading, setIsLoading] = useState(false);
 
     function save() {
@@ -32,12 +32,12 @@ export const DescriptionModal = ({ vm }) => {
 
     const defaultBody = (
         <Form isHorizontal>
-            <FormGroup id="description-model-select-group" label={_("New description")}
-                fieldId="rename-dialog-new-description"
+            <FormGroup id="description-modal-select-group" label={_("New description")}
+                fieldId="set-description-dialog"
             >
-                <TextInput id='rename-dialog-new-description'
+                <TextInput id='set-description-dialog'
                     value={newDescription}
-                    onChange={setDescription} />
+                    onChange={setNewDescription} />
             </FormGroup>
         </Form>
     );
@@ -47,7 +47,7 @@ export const DescriptionModal = ({ vm }) => {
             title={cockpit.format(_("Set description of $0"), vm.name)}
             footer={
                 <>
-                    <Button variant='primary' isDisabled={isLoading} isLoading={isLoading} id="description-config-dialog-apply" onClick={save}>
+                    <Button variant='primary' isDisabled={isLoading} isLoading={isLoading} id="set-description-dialog-apply" onClick={save}>
                         {_("Save")}
                     </Button>
                     <Button variant='link' onClick={Dialogs.close}>

--- a/src/components/vm/overview/titleModal.jsx
+++ b/src/components/vm/overview/titleModal.jsx
@@ -14,7 +14,7 @@ const _ = cockpit.gettext;
 export const TitleModal = ({ vm }) => {
     const Dialogs = useDialogs();
     const [error, setError] = useState({});
-    const [newTitle, setTitle] = useState(vm.title);
+    const [newTitle, setNewTitle] = useState(vm.title);
     const [isLoading, setIsLoading] = useState(false);
 
     function save() {
@@ -32,12 +32,12 @@ export const TitleModal = ({ vm }) => {
 
     const defaultBody = (
         <Form isHorizontal>
-            <FormGroup id="title-model-select-group" label={_("New title")}
-                fieldId="rename-dialog-new-title"
+            <FormGroup id="title-modal-select-group" label={_("New title")}
+                fieldId="set-title-dialog"
             >
-                <TextInput id='rename-dialog-new-title'
+                <TextInput id='set-title-dialog'
                     value={newTitle}
-                    onChange={setTitle} />
+                    onChange={setNewTitle} />
             </FormGroup>
         </Form>
     );
@@ -47,7 +47,7 @@ export const TitleModal = ({ vm }) => {
             title={cockpit.format(_("Set title of $0"), vm.name)}
             footer={
                 <>
-                    <Button variant='primary' isDisabled={isLoading} isLoading={isLoading} id="title-config-dialog-apply" onClick={save}>
+                    <Button variant='primary' isDisabled={isLoading} isLoading={isLoading} id="set-title-dialog-apply" onClick={save}>
                         {_("Save")}
                     </Button>
                     <Button variant='link' onClick={Dialogs.close}>

--- a/src/components/vm/overview/titleModal.jsx
+++ b/src/components/vm/overview/titleModal.jsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import cockpit from 'cockpit';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
+import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal/index.js";
+import { useDialogs } from 'dialogs.jsx';
+
+import { ModalError } from 'cockpit-components-inline-notification.jsx';
+import { domainSetTitle } from '../../../libvirtApi/domain.js';
+
+const _ = cockpit.gettext;
+
+export const TitleModal = ({ vm }) => {
+    const Dialogs = useDialogs();
+    const [error, setError] = useState({});
+    const [newTitle, setTitle] = useState(vm.title);
+    const [isLoading, setIsLoading] = useState(false);
+
+    function save() {
+        setIsLoading(true);
+        domainSetTitle({
+            name: vm.name,
+            id: vm.id,
+            connectionName: vm.connectionName,
+            title: newTitle
+        }).then(Dialogs.close, exc => {
+            setIsLoading(false);
+            setError({ dialogError: _("Title could not be changed"), dialogErrorDetail: exc.message });
+        });
+    }
+
+    const defaultBody = (
+        <Form isHorizontal>
+            <FormGroup id="title-model-select-group" label={_("New title")}
+                fieldId="rename-dialog-new-title"
+            >
+                <TextInput id='rename-dialog-new-title'
+                    value={newTitle}
+                    onChange={setTitle} />
+            </FormGroup>
+        </Form>
+    );
+
+    return (
+        <Modal position="top" variant="small" isOpen onClose={Dialogs.close}
+            title={cockpit.format(_("Set title of $0"), vm.name)}
+            footer={
+                <>
+                    <Button variant='primary' isDisabled={isLoading} isLoading={isLoading} id="title-config-dialog-apply" onClick={save}>
+                        {_("Save")}
+                    </Button>
+                    <Button variant='link' onClick={Dialogs.close}>
+                        {_("Cancel")}
+                    </Button>
+                </>
+            }>
+            <>
+                {error && error.dialogError && <ModalError dialogError={error.dialogError} dialogErrorDetail={error.dialogErrorDetail} />}
+                {defaultBody}
+            </>
+        </Modal>
+    );
+};

--- a/src/components/vm/overview/vmOverviewCard.jsx
+++ b/src/components/vm/overview/vmOverviewCard.jsx
@@ -68,6 +68,7 @@ class VmOverviewCard extends React.Component {
         this.openCpuType = this.openCpuType.bind(this);
         this.openMemory = this.openMemory.bind(this);
         this.onAutostartChanged = this.onAutostartChanged.bind(this);
+        this.guestOffEditButton = this.guestOffEditButton.bind(this);
     }
 
     componentDidMount() {
@@ -119,6 +120,15 @@ class VmOverviewCard extends React.Component {
         Dialogs.show(<MemoryModal vm={this.props.vm} config={this.props.config} />);
     }
 
+    guestOffEditButton(vm, action) {
+        const editButton = (
+            <Button variant="link" isInline isAriaDisabled={vm.state != 'shut off'} onClick={action}>
+                {_("edit")}
+            </Button>
+        );
+        return vm.state == 'shut off' ? editButton : (<Tooltip content={_("Only editable when the guest is shut off")}>{editButton}</Tooltip>);
+    }
+
     render() {
         const { vm, nodeDevices, libvirtVersion } = this.props;
         const idPrefix = vmId(vm.name);
@@ -148,18 +158,14 @@ class VmOverviewCard extends React.Component {
                         label={_("Run when host boots")} />
             </DescriptionListDescription>
         );
-        const nameLinkButton = (
-            <Button variant="link" isInline isAriaDisabled={vm.state != 'shut off'} onClick={this.openName}>
-                {_("edit")}
-            </Button>
-        );
+
         const nameLink = (
             <DescriptionListDescription id={`${idPrefix}-name`}>
                 <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                     <FlexItem>
                         {vm.name}
                     </FlexItem>
-                    {vm.state == 'shut off' ? nameLinkButton : <Tooltip content={_("Only editable when the guest is shut off")}>{nameLinkButton}</Tooltip>}
+                    {this.guestOffEditButton(vm, this.openName)}
                 </Flex>
             </DescriptionListDescription>
         );
@@ -169,9 +175,7 @@ class VmOverviewCard extends React.Component {
                     <FlexItem>
                         {vm.title}
                     </FlexItem>
-                    <Button variant="link" isInline isDisabled={!vm.persistent} onClick={this.openTitle}>
-                        {_("edit")}
-                    </Button>
+                    {this.guestOffEditButton(vm, this.openTitle)}
                 </Flex>
             </DescriptionListDescription>
         );
@@ -181,9 +185,7 @@ class VmOverviewCard extends React.Component {
                     <FlexItem>
                         {vm.description}
                     </FlexItem>
-                    <Button variant="link" isInline isDisabled={!vm.persistent} onClick={this.openDescription}>
-                        {_("edit")}
-                    </Button>
+                    {this.guestOffEditButton(vm, this.openDescription)}
                 </Flex>
             </DescriptionListDescription>
         );

--- a/src/components/vm/vmDetailsPage.jsx
+++ b/src/components/vm/vmDetailsPage.jsx
@@ -87,15 +87,29 @@ export const VmDetailsPage = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    const vmNameHeadline = (
+        <h2 className="vm-name">{vm.name}</h2>
+    );
+
+    const vmTitleHeadline = (
+        <h2 className="vm-name">
+            {vm.title}
+            <span style={{ fontSize: "var(--pf-global--FontSize--xl)", paddingLeft: "0.83em" }}>
+                ({vm.name})
+            </span>
+        </h2>
+    );
+
     const vmActionsPageSection = (
         <PageSection className="actions-pagesection" variant={PageSectionVariants.light}>
             <div className="vm-top-panel" data-vm-transient={!vm.persistent}>
-                <h2 className="vm-name">{vm.name}</h2>
+                {vm.title ? vmTitleHeadline : vmNameHeadline}
                 <VmActions vm={vm}
                            config={config}
                            onAddErrorNotification={onAddErrorNotification}
                            isDetailsPage />
             </div>
+            { vm.description && <h4>{vm.description}</h4> }
         </PageSection>
     );
 

--- a/src/components/vm/vmDetailsPage.jsx
+++ b/src/components/vm/vmDetailsPage.jsx
@@ -25,6 +25,7 @@ import { CodeBlock, CodeBlockCode } from "@patternfly/react-core/dist/esm/compon
 import { Gallery } from "@patternfly/react-core/dist/esm/layouts/Gallery/index.js";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import { List, ListItem } from "@patternfly/react-core/dist/esm/components/List/index.js";
+import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import { Card, CardActions, CardBody, CardFooter, CardHeader, CardTitle } from "@patternfly/react-core/dist/esm/components/Card/index.js";
 import { Page, PageSection, PageSectionVariants } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Popover } from "@patternfly/react-core/dist/esm/components/Popover/index.js";
@@ -87,27 +88,21 @@ export const VmDetailsPage = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    const vmNameHeadline = (
-        <h2 className="vm-name">{vm.name}</h2>
-    );
-
-    const vmTitleHeadline = (
-        <h2 className="vm-name">
-            {vm.title}
-            <span style={{ fontSize: "var(--pf-global--FontSize--xl)", paddingLeft: "0.83em" }}>
-                ({vm.name})
-            </span>
-        </h2>
-    );
-
     const vmActionsPageSection = (
         <PageSection className="actions-pagesection" variant={PageSectionVariants.light}>
             <div className="vm-top-panel" data-vm-transient={!vm.persistent}>
-                {vm.title ? vmTitleHeadline : vmNameHeadline}
-                <VmActions vm={vm}
-                           config={config}
-                           onAddErrorNotification={onAddErrorNotification}
-                           isDetailsPage />
+                <Flex spaceItems={{ default: 'spaceItemsMd' }}>
+                    <FlexItem component='h2'>{vm.title ? vm.title : vm.name}</FlexItem>
+                    {vm.title &&
+                        <FlexItem component='h3'>
+                            ({vm.name})
+                        </FlexItem>
+                    }
+                    <VmActions vm={vm}
+                               config={config}
+                               onAddErrorNotification={onAddErrorNotification}
+                               isDetailsPage />
+                </Flex>
             </div>
             { vm.description && <h4>{vm.description}</h4> }
         </PageSection>

--- a/src/components/vms/hostvmslist.jsx
+++ b/src/components/vms/hostvmslist.jsx
@@ -167,7 +167,7 @@ const HostVmsList = ({ vms, config, ui, storagePools, actions, networks, onAddEr
                                                               isDisabled={vm.isUi && !vm.createInProgress}
                                                               component="a"
                                                               href={'#' + cockpit.format("vm?name=$0&connection=$1", encodeURIComponent(vm.name), vm.connectionName)}
-                                                              className="vm-list-item-name">{vm.name}</Button>
+                                                              className="vm-list-item-name">{vm.title ? vm.title + ' (' + vm.name + ')' : vm.name}</Button>
                                                 },
                                                 { title: rephraseUI('connections', vm.connectionName) },
                                                 {

--- a/src/libvirt-xml-parse.js
+++ b/src/libvirt-xml-parse.js
@@ -222,6 +222,8 @@ export function parseDomainDumpxml(connectionName, domXml, objPath) {
     const metadataElem = getSingleOptionalElem(domainElem, "metadata");
 
     const name = domainElem.getElementsByTagName("name")[0].childNodes[0].nodeValue;
+    const title = domainElem.getElementsByTagName("title")[0]?.childNodes[0]?.nodeValue;
+    const description = domainElem.getElementsByTagName("description")[0]?.childNodes[0]?.nodeValue;
     const id = objPath;
     const osType = osTypeElem.nodeValue;
     const osBoot = parseDumpxmlForOsBoot(osBootElems);
@@ -267,6 +269,8 @@ export function parseDomainDumpxml(connectionName, domXml, objPath) {
     return {
         connectionName,
         name,
+        title,
+        description,
         id,
         osType,
         osBoot,

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -865,19 +865,40 @@ export function domainSetCpuMode({
     ], opts);
 }
 
-export function domainSetTitle({
+export function domainSetXML({
     name,
     id: objPath,
     connectionName,
-    title,
+    xmlOption,
+    change
 }) {
     const opts = { err: "message", environ: ['LC_ALL=C'] };
     if (connectionName === 'system')
         opts.superuser = 'try';
 
     return cockpit.spawn([
-        'virt-xml', '-c', `qemu:///${connectionName}`, '--metadata', `title="${title}"`, name, '--edit'
+        'virt-xml', '-c', `qemu:///${connectionName}`, xmlOption, change, name, '--edit'
     ], opts);
+}
+
+export function domainSetMetadata({
+    name,
+    id: objPath,
+    connectionName,
+    change
+}) {
+    const xmlOption = '--metadata';
+    return domainSetXML({ name, id: objPath, connectionName, xmlOption, change });
+}
+
+export function domainSetTitle({
+    name,
+    id: objPath,
+    connectionName,
+    title,
+}) {
+    const change = `title="${title}"`;
+    return domainSetMetadata({ name, id: objPath, connectionName, change });
 }
 
 export function domainSetDescription({
@@ -886,13 +907,8 @@ export function domainSetDescription({
     connectionName,
     description,
 }) {
-    const opts = { err: "message", environ: ['LC_ALL=C'] };
-    if (connectionName === 'system')
-        opts.superuser = 'try';
-
-    return cockpit.spawn([
-        'virt-xml', '-c', `qemu:///${connectionName}`, '--metadata', `description="${description}"`, name, '--edit'
-    ], opts);
+    const change = `description="${description}"`;
+    return domainSetMetadata({ name, id: objPath, connectionName, change });
 }
 
 export function domainSetMemoryBacking({ connectionName, vmName, type }) {

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -865,6 +865,36 @@ export function domainSetCpuMode({
     ], opts);
 }
 
+export function domainSetTitle({
+    name,
+    id: objPath,
+    connectionName,
+    title,
+}) {
+    const opts = { err: "message", environ: ['LC_ALL=C'] };
+    if (connectionName === 'system')
+        opts.superuser = 'try';
+
+    return cockpit.spawn([
+        'virt-xml', '-c', `qemu:///${connectionName}`, '--metadata', `title="${title}"`, name, '--edit'
+    ], opts);
+}
+
+export function domainSetDescription({
+    name,
+    id: objPath,
+    connectionName,
+    description,
+}) {
+    const opts = { err: "message", environ: ['LC_ALL=C'] };
+    if (connectionName === 'system')
+        opts.superuser = 'try';
+
+    return cockpit.spawn([
+        'virt-xml', '-c', `qemu:///${connectionName}`, '--metadata', `description="${description}"`, name, '--edit'
+    ], opts);
+}
+
 export function domainSetMemoryBacking({ connectionName, vmName, type }) {
     const options = { err: "message" };
     if (connectionName === "system")


### PR DESCRIPTION
The libvirt domain XML has the title and description element which is not represented in the UI. 
This commit adds, if available, the Title to the VM List in the form "<TITLE> (<NAME>)" and adds Title and description to the VM detail page including the option to modify it. 

* [ ] Blocked on new design mockups for the overview from @garrett 