### PR TITLE
Change empty state icon from Wrench to VirtualMachine

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -23,7 +23,7 @@ import { EmptyState, EmptyStateIcon, EmptyStateBody, EmptyStatePrimary } from "@
 import { Progress, ProgressMeasureLocation } from "@patternfly/react-core/dist/esm/components/Progress/index.js";
 import { Text, TextContent } from "@patternfly/react-core/dist/esm/components/Text/index.js";
 import { Title } from "@patternfly/react-core/dist/esm/components/Title/index.js";
-import { ExclamationCircleIcon, WrenchIcon } from '@patternfly/react-icons';
+import { ExclamationCircleIcon, VirtualMachineIcon } from '@patternfly/react-icons';
 import { superuser } from "superuser.js";
 import cockpit from 'cockpit';
 
@@ -128,7 +128,7 @@ export const App = () => {
     if (!virtualizationEnabled && !emptyStateIgnored) {
         return (
             <EmptyState className="virtualization-disabled-empty-state">
-                <EmptyStateIcon icon={WrenchIcon} />
+                <EmptyStateIcon icon={VirtualMachineIcon} />
                 <Title headingLevel="h4" size="lg">
                     {_("Hardware virtualization is disabled")}
                 </Title>

--- a/test/check-machines-virtualization
+++ b/test/check-machines-virtualization
@@ -43,6 +43,8 @@ class TestMachinesVirtualization(VirtualMachinesCase):
 
         b.wait_visible("div.pf-c-empty-state .pf-c-title:contains('Hardware virtualization is disabled')")
 
+        b.assert_pixels(".pf-c-empty-state", "virtualization-disabled-warning")
+
         b.click("#ignore-hw-virtualization-disabled-btn")
 
         b.wait_visible("#card-pf-storage-pools")


### PR DESCRIPTION
Follow up of PR #980

Changed the icon from Wrench to VirtualMachine as requested here https://github.com/cockpit-project/cockpit-machines/pull/980#issuecomment-1497398556.

Before:

![image](https://user-images.githubusercontent.com/108616679/230277802-a00f100b-cf80-4396-be26-031f33217762.png)

After:

![image](https://user-images.githubusercontent.com/108616679/230277483-84610c02-a9c2-4a8b-9e85-8643cb343a3d.png)