### PR TITLE
Fix flaky testDetachDisk, testNICAdd, testCreateDownloadRhel

### DIFF
--- a/src/components/vm/disks/vmDiskColumns.jsx
+++ b/src/components/vm/disks/vmDiskColumns.jsx
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import cockpit from 'cockpit';
 
@@ -110,9 +110,7 @@ DiskExtras.propTypes = {
     idPrefix: PropTypes.string.isRequired,
 };
 
-export const DiskActions = ({ vm, vms, disk, supportedDiskBusTypes, idPrefixRow }) => {
-    const [isActionOpen, setIsActionOpen] = useState(false);
-
+export const DiskActions = ({ vm, vms, disk, supportedDiskBusTypes, idPrefixRow, isActionOpen, setIsActionOpen }) => {
     const Dialogs = useDialogs();
 
     const onRemoveDisk = () => {

--- a/src/components/vm/disks/vmDisksCard.jsx
+++ b/src/components/vm/disks/vmDisksCard.jsx
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import cockpit from 'cockpit';
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
@@ -165,6 +165,7 @@ VmDisksCardLibvirt.propTypes = {
 };
 
 export const VmDisksCard = ({ vm, vms, disks, renderCapacity, supportedDiskBusTypes }) => {
+    const [openActions, setOpenActions] = useState(new Set());
     let renderCapacityUsed, renderAccess, renderAdditional;
     const columnTitles = [_("Device")];
     const idPrefix = `${vmId(vm.name)}-disks`;
@@ -235,7 +236,17 @@ export const VmDisksCard = ({ vm, vms, disks, renderCapacity, supportedDiskBusTy
                                 vms={vms}
                                 disk={disk}
                                 supportedDiskBusTypes={supportedDiskBusTypes}
-                                idPrefixRow={idPrefixRow} />
+                                idPrefixRow={idPrefixRow}
+                                isActionOpen={openActions.has(disk.target)}
+                                setIsActionOpen={open => setOpenActions(prev => {
+                                    const next = new Set(prev);
+                                    if (open)
+                                        next.add(disk.target);
+                                    else
+                                        next.delete(disk.target);
+                                    return next;
+                                })
+                                } />
         });
         return { columns, props: { key: idPrefixRow } };
     });

--- a/src/components/vm/vmDetailsPage.jsx
+++ b/src/components/vm/vmDetailsPage.jsx
@@ -31,6 +31,8 @@ import { Popover } from "@patternfly/react-core/dist/esm/components/Popover/inde
 import { ExpandIcon, HelpIcon } from '@patternfly/react-icons';
 import { WithDialogs } from 'dialogs.jsx';
 
+import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
+
 import { vmId } from "../../helpers.js";
 
 import { VmFilesystemsCard, VmFilesystemActions } from './filesystems/vmFilesystemsCard.jsx';
@@ -62,6 +64,10 @@ export const VmDetailsPage = ({
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    // not initialized yet?
+    if (!vm.capabilities)
+        return <EmptyStatePanel title={ _("Loading...") } loading />;
 
     const vmActionsPageSection = (
         <PageSection className="actions-pagesection" variant={PageSectionVariants.light} isWidthLimited>

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -631,7 +631,8 @@ class TestMachinesNICs(VirtualMachinesCase):
             self.browser.click(".pf-c-modal-box__footer button:contains(Add)")
 
             if not self.xfail:
-                self.browser.wait_not_present("#vm-subVmTest1-add-iface-dialog")
+                with self.browser.wait_timeout(60):
+                    self.browser.wait_not_present("#vm-subVmTest1-add-iface-dialog")
             else:
                 self.browser.wait_in_text(".pf-c-modal-box__body .pf-c-alert__title", self.xfail_error)
                 self.browser.click(".pf-c-modal-box__footer button:contains(Cancel)")


### PR DESCRIPTION
This fixes our [current top flake](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?days=14&repo=cockpit-project%2Fcockpit-machines&test=%2Ftest%2Fcheck-machines-disks+TestMachinesDisks.testDetachDisk) in `TestMachinesDisks.testDetachDisk`:

![image](https://user-images.githubusercontent.com/200109/231197125-2c7db84a-a64c-4f40-b6ca-a8cec431fbaa.png)

Log example [one](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1014-20230411-125144-732b5374-ubuntu-stable/log.html#26-2), [two](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1013-20230410-090748-0a28319b-fedora-38/log.html#26).

It also fixes [this timeout](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1014-20230411-130612-732b5374-arch/log.html#77), which I've seen twice today.

This also fixes our second top flake: testCreateDownloadRhel. [example 1](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1012-20230409-232913-0777ec7b-fedora-37-firefox/log.html#12), [example 2](https://cockpit-logs.us-east-1.linodeobjects.com/pull-4620-20230407-230006-3c56b05e-fedora-37-cockpit-project-cockpit-machines/log.html#12). This is more serious, it causes a page crash even. So let's land this ASAP.