### PR TITLE
test: Fix MAC overflow, better debugging of VM boot failures

### DIFF
--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -88,12 +88,12 @@ class TestMachinesConsoles(VirtualMachinesCase):
         b.wait_visible(".pf-c-console__vnc canvas")
 
         # make sure the log file is full - then empty it and reboot the VM - the log file should fill up again
-        wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
+        self.waitCirrOSBooted(args['logfile'])
 
         self.machine.execute(f"echo '' > {args['logfile']}")
         b.click("#subVmTest1-system-vnc-sendkey button")
         b.click("#ctrl-alt-Delete")
-        wait(lambda: "Requesting system reboot" in self.machine.execute(f"cat {args['logfile']}"), delay=3)
+        self.waitLogFile(args['logfile'], "Requesting system reboot")
 
     def testInlineConsoleWithUrlRoot(self, urlroot=""):
         self.testInlineConsole(urlroot="/webcon")

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -767,7 +767,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         m.execute("virsh pool-destroy images; virsh pool-undefine images")
 
         # Wait for the system to completely start
-        wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
+        self.waitCirrOSBooted(args['logfile'])
 
         self.login_and_go("/machines")
         self.waitPageInit()
@@ -823,7 +823,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         args = self.createVm("subVmTest1")
 
         # Wait for the system to completely start
-        wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
+        self.waitCirrOSBooted(args['logfile'])
 
         self.login_and_go("/machines")
         self.waitPageInit()
@@ -881,7 +881,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         args = self.createVm("subVmTest1")
 
         # Wait for the system to completely start
-        wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
+        self.waitCirrOSBooted(args['logfile'])
 
         self.login_and_go("/machines")
         self.waitPageInit()
@@ -1402,7 +1402,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         self.waitVmRow("subVmTest1")
 
         # Wait for the login prompt before we try detaching disks - we need the OS to be fully responsive
-        wait(lambda: "login as 'cirros' user" in self.machine.execute(f"cat {args['logfile']}"), delay=3)
+        self.waitCirrOSBooted(args['logfile'])
 
         # Test detaching non permanent disk of a running domain
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
@@ -1482,14 +1482,14 @@ class TestMachinesDisks(VirtualMachinesCase):
         m.execute(f"> {args['logfile']}")  # clear logfile
         m.execute("virsh start subVmTest1")
         # Make sure that the VM booted normally before attempting to suspend it
-        wait(lambda: "login as 'cirros' user" in m.execute(f"cat {args['logfile']}"), delay=3)
+        self.waitCirrOSBooted(args['logfile'])
         m.execute("virsh suspend subVmTest1")
         b.wait_in_text("#vm-subVmTest1-system-state", "Paused")
         b.wait_visible("#vm-subVmTest1-disks-vde-action-kebab")
         b.click("#vm-subVmTest1-disks-vde-action-kebab button")
         b.wait_visible("#delete-vm-subVmTest1-disks-vde a[aria-disabled=true]")
         m.execute("virsh resume subVmTest1")
-        wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
+        self.waitCirrOSBooted(args['logfile'])
 
         # Test detaching of disk on non-persistent VM
         m.execute("virsh undefine subVmTest1")

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -149,12 +149,12 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # Wait for the system to completely start
-        wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
+        self.waitCirrOSBooted(args['logfile'])
 
         # Send Non-Maskable Interrupt (no change in VM state is expected)
         self.performAction("subVmTest1", "sendNMI")
 
-        b.wait(lambda: "NMI received" in self.machine.execute(f"cat {args['logfile']}"))
+        self.waitLogFile(args['logfile'], "NMI received")
 
         # pause
         self.performAction("subVmTest1", "pause")
@@ -170,17 +170,17 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         # reboot
         self.machine.execute(f"echo '' > {args['logfile']}")
         self.performAction("subVmTest1", "reboot")
-        wait(lambda: "reboot: Power down" in self.machine.execute(f"cat {args['logfile']}"), delay=3)
+        self.waitLogFile(args['logfile'], "reboot: Power down")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # force reboot
         self.machine.execute(f"echo '' > {args['logfile']}")
         self.performAction("subVmTest1", "forceReboot")
-        wait(lambda: "Initializing cgroup subsys" in self.machine.execute(f"cat {args['logfile']}"), delay=3)
+        self.waitLogFile(args['logfile'], "Initializing cgroup subsys")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # the shut off button beside the VM name
-        wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
+        self.waitCirrOSBooted(args['logfile'])
         b.click("#vm-subVmTest1-system-shutdown-button")
         b.wait_in_text("#vm-subVmTest1-system-state", "Shut off")
         b.wait_visible("#vm-subVmTest1-system-run")
@@ -189,7 +189,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         self.machine.execute(f"echo '' > {args['logfile']}")
         b.click("#vm-subVmTest1-system-run")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
-        wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
+        self.waitCirrOSBooted(args['logfile'])
         self.performAction("subVmTest1", "off")
 
         # force shut off
@@ -395,7 +395,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         self.goToVmPage(name)
 
         # Make sure that the VM booted normally before attempting to suspend it
-        wait(lambda: "login as 'cirros' user" in self.machine.execute(f"cat {args['logfile']}"), delay=3)
+        self.waitCirrOSBooted(args['logfile'])
 
         self.machine.execute(f"virsh -c qemu:///system suspend {name}")
         b.wait_in_text(f"#vm-{name}-system-state", "Paused")

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -161,7 +161,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         self.waitPageInit()
         self.waitVmRow("subVmTest1")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
-        wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
+        self.waitCirrOSBooted(args['logfile'])
         self.goToVmPage("subVmTest1")
 
         self.deleteIface(1)
@@ -280,7 +280,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         m.execute(f"> {args['logfile']}")  # clear logfile
         b.click("#vm-subVmTest1-system-run")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
-        wait(lambda: "login as 'cirros' user." in self.machine.execute(f"cat {args['logfile']}"), delay=3)
+        self.waitCirrOSBooted(args['logfile'])
 
         # Because of bug in debian-testing, attachment of virtio vNICs after restarting VM will fail
         # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1005284

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -401,7 +401,7 @@ class TestMachinesSettings(VirtualMachinesCase):
 
         # Check memory hotunplugging
         # The balloon driver needs to be loaded to descrease memory
-        wait(lambda: "login as 'cirros' user" in self.machine.execute(f"cat {args['logfile']}"), delay=3)
+        self.waitCirrOSBooted(args['logfile'])
 
         b.set_input_text("#vm-subVmTest1-memory-modal-memory", str(current_memory - 10))
         b.blur("#vm-subVmTest1-memory-modal-memory")
@@ -447,7 +447,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
 
-        wait(lambda: "login as 'cirros' user" in m.execute(f"cat {args['logfile']}"), delay=3)
+        self.waitCirrOSBooted(args['logfile'])
 
         # Change CPU model setting
         b.click("#vm-subVmTest1-cpu-model button")
@@ -612,7 +612,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         setWatchdogActionLive(action="reset")
         setWatchdogActionLive(action="pause", previous_action="reset")
         # Make sure that the VM booted normally before attempting to hotunplug
-        wait(lambda: "login as 'cirros' user" in m.execute(f"cat {args['logfile']}"), delay=3)
+        self.waitCirrOSBooted(args['logfile'])
         removeWatchdogDevice(live=True)
         # Check rebooting machine will not unexpectedly affect watchdog configuration
         setWatchdogActionLive(action="poweroff", reboot_machine=True)

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -228,7 +228,7 @@ class VirtualMachinesCaseHelpers:
     def get_next_mac(self, last_mac):
         parts = last_mac.split(':')
         suffix = parts[-1]
-        new_suffix = format(int(suffix, 16) + 1, "x").zfill(2)
+        new_suffix = format((int(suffix, 16) + 1) & 0xFF, "x").zfill(2)
         parts[-1] = new_suffix
         new_mac = ':'.join(parts)
         return new_mac


### PR DESCRIPTION
During my investigations in #1015 I saw `TestMachinesNICs.testNICDelete` [fail](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1015-20230412-073028-72a21a50-centos-8-stream/log.html#78-2) [several](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1015-20230412-071242-0e56ff99-rhel-8-9/log.html#78) [times](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1015-20230412-074921-72a21a50-centos-8-stream/log.html#78-1). It's impossible to see why, so I made that easier to debug. [This failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1015-20230412-080736-72a21a50-centos-8-stream/log.html) is similar (although there the screenshot makes it easier to compare the log with the console output).

I also found a [TestMachinesNetworks.testNetworkSettings failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1015-20230412-073028-72a21a50-rhel-8-9/log.html#57) where it tried to increment a MAC 52:54:00:b6:51:FF to :100 (which is invalid). The second commit fixes this.

 - [x] Goes on top of #1015, as it's otherwise impossible to get tests to green