### PR TITLE
test: Run with CirrOS 0.5.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ prepare-check: $(NODE_MODULES_TEST) $(VM_IMAGE) test/common test/reference
 # run the browser integration tests
 # this will run all tests/check-* and format them as TAP
 check: prepare-check
-	test/common/run-tests ${RUN_TESTS_OPTIONS}
+	test/common/run-tests --nondestructive-memory-mb=1400 ${RUN_TESTS_OPTIONS}
 
 bots: tools/make-bots
 	tools/make-bots

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -131,9 +131,9 @@ class TestMachinesLifecycle(VirtualMachinesCase):
 
         # switch to and check Usage
         b.click("#vm-subVmTest1-usage")
-        b.wait_in_text(".memory-usage-chart .pf-c-progress__status > .pf-c-progress__measure", "128 MiB")
+        b.wait_in_text(".memory-usage-chart .pf-c-progress__status > .pf-c-progress__measure", "160 MiB")
         b.wait_not_in_text(".memory-usage-chart .pf-c-progress__status > .pf-c-progress__measure", "0 /")
-        usage = b.text(".memory-usage-chart .pf-c-progress__status > .pf-c-progress__measure").split("/ 128 MiB")[0]
+        usage = b.text(".memory-usage-chart .pf-c-progress__status > .pf-c-progress__measure").split("/ 160 MiB")[0]
         wait(lambda: float(usage) > 0.0, delay=3)
 
         b.wait_in_text(".vcpu-usage-chart .pf-c-progress__status > .pf-c-progress__measure", "1 vCPU")

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -126,7 +126,8 @@ class VirtualMachinesCaseHelpers:
     def createVm(self, name, graphics='none', ptyconsole=False, running=True, memory=160, connection='system'):
         m = self.machine
 
-        image_file = m.pull("cirros")
+        import os
+        image_file = os.path.abspath("cirros.img")
 
         if connection == "system":
             img = "/var/lib/libvirt/images/{0}-2.img".format(name)

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -123,7 +123,7 @@ class VirtualMachinesCaseHelpers:
         m.execute("virsh net-start default || true")
         m.execute(r"until virsh net-info default | grep 'Active:\s*yes'; do sleep 1; done")
 
-    def createVm(self, name, graphics='none', ptyconsole=False, running=True, memory=128, connection='system'):
+    def createVm(self, name, graphics='none', ptyconsole=False, running=True, memory=160, connection='system'):
         m = self.machine
 
         image_file = m.pull("cirros")

--- a/test/run
+++ b/test/run
@@ -11,6 +11,11 @@ export RUN_TESTS_OPTIONS=--track-naughties
 # linters are off by default for production builds, but we want to run them in CI
 export LINT=1
 
+make bots
+sed 's/0.4.0/0.5.2/g' bots/images/scripts/cirros.bootstrap > cirros.bootstrap
+sh -ex cirros.bootstrap `pwd`/cirros.img
+rm cirros.bootstrap
+
 make codecheck
 make check
 make po/machines.pot


### PR DESCRIPTION
Check if that fixes any of the kernel oopses in the nested subVmTest.

---
 - [x] #1018 
 - [x] #1023

With #1018 we get more info about the boot failures:

 - VM is slow to boot: [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1018-20230412-083643-20237448-centos-8-stream/log.html#62) -- looks like too little entropy; but both our outer bots VM as well as the inner subVmTestN already has the `virtio-rng-pci` device
 - inner VM has kernel oops on "IO-APIC + timer doesn't work!": [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1018-20230412-083643-20237448-centos-8-stream/log.html#81), [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1018-20230412-083643-20237448-rhel-8-9/log.html#50), [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1018-20230412-083643-20237448-rhel-8-9/log.html#78)

The inner VMs already don't use KVM, as the outer VMs (our rhel-8-9 bots image, for example) don't have /dev/kvm. The only remaining thing to try that comes to my mind is to vary the CirrOS version, or perhaps try the x86_64 one (which will need more RAM, though)
