### PR TITLE
Fix broken ESLint check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ vm: $(VM_IMAGE)
 print-vm:
 	@echo $(VM_IMAGE)
 
-codecheck: test/static-code
+codecheck: test/static-code $(NODE_MODULES_TEST)
 	test/static-code --tap
 
 # convenience target to setup all the bits needed for the integration tests

--- a/build.js
+++ b/build.js
@@ -71,8 +71,8 @@ const context = await esbuild.context({
         cleanPlugin(),
         ...lint
             ? [
-                stylelintPlugin({ filter: new RegExp(cwd + '\/src\/.*\.(css?|scss?)$') }),
-                eslintPlugin({ filter: new RegExp(cwd + '\/src\/.*\.(jsx?|js?)$') })
+                stylelintPlugin({ filter: new RegExp(cwd + '/src/.*\\.(css?|scss?)$') }),
+                eslintPlugin({ filter: new RegExp(cwd + '/src/.*\\.(jsx?|js?)$') })
             ]
             : [],
         // Esbuild will only copy assets that are explicitly imported and used


### PR DESCRIPTION
If you look at a [recent test](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1018-20230412-105746-a06b072c-rhel-9-3/log.html), it starts with 

> 1 /static-code/test-eslint # SKIP no eslint

and we missed a few ESLint issues due to that.