### PR TITLE
Show error message if snapshot deletion fails during VM deletion

### DIFF
--- a/src/components/vm/deleteDialog.jsx
+++ b/src/components/vm/deleteDialog.jsx
@@ -143,9 +143,7 @@ export class DeleteDialog extends React.Component {
                             .then(() => {
                                 Dialogs.close();
                                 cockpit.location.go(["vms"]);
-                            })
-                            // Fail implicitly returns the exception, which is useful so that cleanup operation doesn't get invoked
-                            .fail(exc => this.dialogErrorSet(cockpit.format(_("Could not delete $0"), vm.name), exc.message));
+                            });
                 })
                 .then(() => { // Cleanup operations
                     return domainDeleteStorage({ connectionName: vm.connectionName, storage, storagePools })
@@ -154,7 +152,8 @@ export class DeleteDialog extends React.Component {
                                 detail: exc,
                                 type: "warning"
                             }));
-                });
+                })
+                .catch(exc => this.dialogErrorSet(cockpit.format(_("Could not delete $0"), vm.name), exc.message));
     }
 
     render() {

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -430,6 +430,30 @@ class TestMachinesLifecycle(VirtualMachinesCase):
             qemu_img_info = m.execute(f"qemu-img info /var/lib/libvirt/images/{name}-2.img")
             self.assertNotIn("snapshotA", qemu_img_info)
 
+            # Snapshot deletion was failing for VMs with file-directory storage-pool volumes as disks.
+            # It was fixed since libvirt 7.1.0 at https://gitlab.com/libvirt/libvirt/-/commit/6423e3082835db932dd285f3ae75b5dad9d91c83
+            # Only debian-stable has libvirt lesser than 7.1.0
+            # Add this condition to notify us when the condition below is no longer needed
+            if m.image == "debian-stable":
+                self.assertLess(m.execute("virsh --version"), "7.1.0")
+            else:
+                # Check deleting VM fails if deleting snapshot is not possible and error message is shown
+                name = "vm-with-failed-snapshots"
+                self.createVm(name, running=False)
+
+                m.execute("virsh vol-create-as --pool images --name tmpdisk --capacity 1 --format qcow2")
+                m.execute(f"virt-xml {name} --add-device --disk source.pool=images,source.volume=tmpdisk,target.dev=sdb,driver.type=qcow2")
+                m.execute(f"virsh snapshot-create-as --domain {name} --name snapshotFails")
+                b.reload()
+                b.enter_page('/machines')
+                self.performAction(name, "delete")
+                b.wait_visible(f"#vm-{name}-delete-modal-dialog")
+                m.execute(f"virsh snapshot-delete --domain {name} --snapshotname snapshotFails")
+                b.click(f"#vm-{name}-delete-modal-dialog button:contains(Delete)")
+                b.wait_in_text(f"#vm-{name}-delete-modal-dialog .pf-c-alert__description", "Domain snapshot not found")
+                b.click(f"#vm-{name}-delete-modal-dialog button:contains(Cancel)")
+                m.execute(f"virsh undefine {name}")
+
         # Try to delete a VM and keep its volume
         name = "vm-keep-vol"
         args = self.createVm(name)


### PR DESCRIPTION
Before we delete a VM, we first delete snapshots. However, if snapshot deletion fails, no error message is shown in dialog and the dialog is just left open.

![Screenshot from 2023-04-12 13-37-07](https://user-images.githubusercontent.com/42733240/231445910-e69f2ecd-1a3a-464a-85ac-a2cde7ffa941.png)
