### PR TITLE
Remove dummy UI VM only after we have fetched all the data about the VM

### DIFF
--- a/src/components/vm/vmDetailsPage.jsx
+++ b/src/components/vm/vmDetailsPage.jsx
@@ -31,8 +31,6 @@ import { Popover } from "@patternfly/react-core/dist/esm/components/Popover/inde
 import { ExpandIcon, HelpIcon } from '@patternfly/react-icons';
 import { WithDialogs } from 'dialogs.jsx';
 
-import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
-
 import { vmId } from "../../helpers.js";
 
 import { VmFilesystemsCard, VmFilesystemActions } from './filesystems/vmFilesystemsCard.jsx';
@@ -64,10 +62,6 @@ export const VmDetailsPage = ({
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
-
-    // not initialized yet?
-    if (!vm.capabilities)
-        return <EmptyStatePanel title={ _("Loading...") } loading />;
 
     const vmActionsPageSection = (
         <PageSection className="actions-pagesection" variant={PageSectionVariants.light} isWidthLimited>

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -35,7 +35,6 @@ import {
     getDiskXML,
 } from '../libvirt-xml-create.js';
 import {
-    finishVmCreateInProgress,
     setVmCreateInProgress,
     setVmInstallInProgress,
     updateImageDownloadProgress,
@@ -362,7 +361,6 @@ export function domainCreate({
     return tryDownloadRhelImage()
             .then(() => hashPasswords(args))
             .then(args => cockpit.spawn([pythonPath, "--", "-", JSON.stringify(args)], opts).input(installVmScript))
-            .then(() => finishVmCreateInProgress(vmName, connectionName))
             .finally(() => clearVmUiState(vmName, connectionName));
 }
 

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -361,7 +361,10 @@ export function domainCreate({
     return tryDownloadRhelImage()
             .then(() => hashPasswords(args))
             .then(args => cockpit.spawn([pythonPath, "--", "-", JSON.stringify(args)], opts).input(installVmScript))
-            .finally(() => clearVmUiState(vmName, connectionName));
+            .catch(ex => {
+                clearVmUiState(vmName, connectionName);
+                return Promise.reject(ex);
+            });
 }
 
 export function domainCreateFilesystem({ connectionName, objPath, vmName, source, target, xattr }) {
@@ -708,6 +711,7 @@ export function domainGet({
                 };
 
                 store.dispatch(updateOrAddVm(Object.assign({}, props, dumpxmlParams)));
+                clearVmUiState(props.name, connectionName);
 
                 return snapshotGetAll({ connectionName, domainPath: objPath });
             })


### PR DESCRIPTION
- Remove dummy UI VM only after we have fetched all the data about the VM
    
    Removing dummy UI VM immediately after the creation of VM is finished
    created a race condition, where the dummy UI VM no longer exists, but we
    have not yet fetched all the data about the real VM through libvirt
    APIs.

-  Don't update dummy UI VM before deleting it
    
    After we finish the creation of VM, we update its dummy UI VM's
    properties to 'createInProgress: false', and then we immediately call
    clearUiState which deletes this dummy UI VM.
    This makes no sense, and it creates space for race conditions where VM
    is neither in creation nor it is
