### PR TITLE
test: Use standard "wait for boot" in TestMachinesLifecycle

### DIFF
--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -176,7 +176,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         # force reboot
         self.machine.execute(f"echo '' > {args['logfile']}")
         self.performAction("subVmTest1", "forceReboot")
-        self.waitLogFile(args['logfile'], "Initializing cgroup subsys")
+        self.waitCirrOSBooted(args['logfile'])
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # the shut off button beside the VM name


### PR DESCRIPTION
There is no particular reason why it waits for a different message than the login prompt. That line does not exist any more with newer CirrOS versions.