### PR TITLE
Revert "test: Run static-code verbosely"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ print-vm:
 	@echo $(VM_IMAGE)
 
 codecheck: test/static-code $(NODE_MODULES_TEST)
-	test/static-code --tap
+	test/static-code
 
 # convenience target to setup all the bits needed for the integration tests
 # without actually running them


### PR DESCRIPTION
Outputting TAP interferes with the integration TAP plan, and messes up the log.html results viewer. It's awkward to parse, merge, and present multiple TAP plans; also, it's not really interesting to show the static-code results in log.html, as they are empty anyway.

Skipped tests still show a "WARNING" even without --tap.

This reverts commit c68e548863151109a006350c5433b21e6b66ccd5.

----

This avoids the messy results count and interleaving of static-code and browser tests that we get [e.g. here](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1019-20230413-072512-3cc72fd3-rhel-8-9/log.html):

![image](https://user-images.githubusercontent.com/200109/231704480-9b55da21-a8d3-4d7c-af78-33bba1551485.png)
