### PR TITLE
FormHelper should not be inside InputGroup

### DIFF
--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -804,10 +804,10 @@ const MemoryRow = ({ memorySize, memorySizeUnit, nodeMaxMemory, minimumMemory, o
                         <FormSelectOption value={units.GiB.name} key={units.GiB.name}
                                           label={_("GiB")} />
                     </FormSelect>
-                    <FormHelper fieldId="memory-size"
-                                helperTextInvalid={validationStateMemory == "error" && validationFailed.memory}
-                                helperText={helperText} />
                 </InputGroup>
+                <FormHelper fieldId="memory-size"
+                            helperTextInvalid={validationStateMemory == "error" && validationFailed.memory}
+                            helperText={helperText} />
             </FormGroup>
         </>
     );


### PR DESCRIPTION
This fixes broken position of helper text in the memory row

Before|After
:---:|:---:
![Screenshot from 2023-04-19 01-25-32](https://user-images.githubusercontent.com/42733240/232926244-b5d9b18b-6298-4473-8007-cb5d02a26aa0.png)|![Screenshot from 2023-04-19 01-25-38](https://user-images.githubusercontent.com/42733240/232926267-fb8d8907-daeb-468b-9a2a-102c4c728754.png)
