### PR TITLE
Adjust Breadcrumb usage to match PF5 guidelines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = 5648586f0a43fcfea57982a792108af3c89866d8 # 289 + HelperText fixes
+COCKPIT_REPO_COMMIT = 1dd0d07151c754db0772e84d0ec679e26c44c43d # 290 + breadcrumbs PF override
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'

--- a/src/components/networks/networkList.jsx
+++ b/src/components/networks/networkList.jsx
@@ -20,7 +20,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Breadcrumb, BreadcrumbItem } from "@patternfly/react-core/dist/esm/components/Breadcrumb";
 import { Card, CardActions, CardBody, CardHeader, CardTitle } from "@patternfly/react-core/dist/esm/components/Card";
-import { Page, PageSection, PageSectionVariants } from "@patternfly/react-core/dist/esm/components/Page";
+import { Page, PageBreadcrumb, PageSection, PageSectionVariants } from "@patternfly/react-core/dist/esm/components/Page";
 import { Text, TextVariants } from "@patternfly/react-core/dist/esm/components/Text";
 import { WithDialogs } from 'dialogs.jsx';
 
@@ -45,17 +45,17 @@ export class NetworkList extends React.Component {
 
         return (
             <WithDialogs>
-                <Page groupProps={{ sticky: 'top' }}
-                  isBreadcrumbGrouped
-                  breadcrumb={
-                      <Breadcrumb variant={PageSectionVariants.light} className='machines-listing-breadcrumb'>
-                          <BreadcrumbItem to='#'>
-                              {_("Virtual machines")}
-                          </BreadcrumbItem>
-                          <BreadcrumbItem isActive>
-                              {_("Networks")}
-                          </BreadcrumbItem>
-                      </Breadcrumb>}>
+                <Page>
+                    <PageBreadcrumb stickyOnBreakpoint={{ default: "top" }}>
+                        <Breadcrumb variant={PageSectionVariants.light} className='machines-listing-breadcrumb'>
+                            <BreadcrumbItem to='#'>
+                                {_("Virtual machines")}
+                            </BreadcrumbItem>
+                            <BreadcrumbItem isActive>
+                                {_("Networks")}
+                            </BreadcrumbItem>
+                        </Breadcrumb>
+                    </PageBreadcrumb>
                     <PageSection id='networks-listing'>
                         <Card>
                             <CardHeader>

--- a/src/components/storagePools/storagePoolList.jsx
+++ b/src/components/storagePools/storagePoolList.jsx
@@ -20,7 +20,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Breadcrumb, BreadcrumbItem } from "@patternfly/react-core/dist/esm/components/Breadcrumb";
 import { Card, CardActions, CardBody, CardHeader, CardTitle } from "@patternfly/react-core/dist/esm/components/Card";
-import { Page, PageSection } from "@patternfly/react-core/dist/esm/components/Page";
+import { Page, PageBreadcrumb, PageSection } from "@patternfly/react-core/dist/esm/components/Page";
 import { Text, TextVariants } from "@patternfly/react-core/dist/esm/components/Text";
 import { WithDialogs } from 'dialogs.jsx';
 
@@ -46,17 +46,17 @@ export class StoragePoolList extends React.Component {
 
         return (
             <WithDialogs>
-                <Page groupProps={{ sticky: 'top' }}
-                      isBreadcrumbGrouped
-                      breadcrumb={
-                          <Breadcrumb className='machines-listing-breadcrumb'>
-                              <BreadcrumbItem to='#'>
-                                  {_("Virtual machines")}
-                              </BreadcrumbItem>
-                              <BreadcrumbItem isActive>
-                                  {_("Storage pools")}
-                              </BreadcrumbItem>
-                          </Breadcrumb>}>
+                <Page>
+                    <PageBreadcrumb stickyOnBreakpoint={{ default: "top" }}>
+                        <Breadcrumb className='machines-listing-breadcrumb'>
+                            <BreadcrumbItem to='#'>
+                                {_("Virtual machines")}
+                            </BreadcrumbItem>
+                            <BreadcrumbItem isActive>
+                                {_("Storage pools")}
+                            </BreadcrumbItem>
+                        </Breadcrumb>
+                    </PageBreadcrumb>
                     <PageSection id='storage-pools-listing'>
                         <Card>
                             <CardHeader>

--- a/src/components/vm/consoles/consoles.css
+++ b/src/components/vm/consoles/consoles.css
@@ -18,10 +18,8 @@
      grid-template-rows: min-content 1fr;
 }
 
-.consoles-page-expanded .pf-c-page__main {
-    .actions-pagesection {
-        padding-bottom: 0;
-    }
+.consoles-page-expanded .actions-pagesection .pf-c-page__main-body {
+     padding-bottom: 0;
 }
 
 /* Hide send key button - there is not way to do that from the JS

--- a/src/components/vm/vmDetailsPage.jsx
+++ b/src/components/vm/vmDetailsPage.jsx
@@ -26,7 +26,7 @@ import { Gallery } from "@patternfly/react-core/dist/esm/layouts/Gallery";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { List, ListItem } from "@patternfly/react-core/dist/esm/components/List";
 import { Card, CardActions, CardBody, CardFooter, CardHeader, CardTitle } from "@patternfly/react-core/dist/esm/components/Card";
-import { Page, PageSection, PageSectionVariants } from "@patternfly/react-core/dist/esm/components/Page";
+import { Page, PageGroup, PageBreadcrumb, PageSection, PageSectionVariants } from "@patternfly/react-core/dist/esm/components/Page";
 import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
 import { ExpandIcon, HelpIcon } from '@patternfly/react-icons';
 import { WithDialogs } from 'dialogs.jsx';
@@ -79,22 +79,21 @@ export const VmDetailsPage = ({
     if (cockpit.location.path[1] == "console") {
         return (
             <WithDialogs>
-                <Page groupProps={{ sticky: 'top' }}
-                      id={"vm-" + vm.name + "-consoles-page"}
-                      className="consoles-page-expanded"
-                      isBreadcrumbGrouped
-                      breadcrumb={
-                          <Breadcrumb className='machines-listing-breadcrumb'>
-                              <BreadcrumbItem to='#'>
-                                  {_("Virtual machines")}
-                              </BreadcrumbItem>
-                              <BreadcrumbItem to={'#' + cockpit.format("vm?name=$0&connection=$1", encodeURIComponent(vm.name), vm.connectionName)}>
-                                  {vm.name}
-                              </BreadcrumbItem>
-                              <BreadcrumbItem isActive>
-                                  {_("Console")}
-                              </BreadcrumbItem>
-                          </Breadcrumb>}>
+                <Page id={"vm-" + vm.name + "-consoles-page"}
+                      className="consoles-page-expanded">
+                    <PageBreadcrumb stickyOnBreakpoint={{ default: "top" }}>
+                        <Breadcrumb className='machines-listing-breadcrumb'>
+                            <BreadcrumbItem to='#'>
+                                {_("Virtual machines")}
+                            </BreadcrumbItem>
+                            <BreadcrumbItem to={'#' + cockpit.format("vm?name=$0&connection=$1", encodeURIComponent(vm.name), vm.connectionName)}>
+                                {vm.name}
+                            </BreadcrumbItem>
+                            <BreadcrumbItem isActive>
+                                {_("Console")}
+                            </BreadcrumbItem>
+                        </Breadcrumb>
+                    </PageBreadcrumb>
                     {vmActionsPageSection}
                     <PageSection variant={PageSectionVariants.light}>
                         <Consoles vm={vm} config={config}
@@ -237,17 +236,20 @@ export const VmDetailsPage = ({
         <WithDialogs>
             <Page id="vm-details"
                   className="vm-details"
-                  data-pools-count={storagePools.length}
-                  breadcrumb={
-                      <Breadcrumb className='machines-listing-breadcrumb'>
-                          <BreadcrumbItem to='#'>
-                              {_("Virtual machines")}
-                          </BreadcrumbItem>
-                          <BreadcrumbItem isActive>
-                              {vm.name}
-                          </BreadcrumbItem>
-                      </Breadcrumb>}>
-                {vmActionsPageSection}
+                  data-pools-count={storagePools.length}>
+                <PageGroup>
+                    <PageBreadcrumb>
+                        <Breadcrumb className='machines-listing-breadcrumb'>
+                            <BreadcrumbItem to='#'>
+                                {_("Virtual machines")}
+                            </BreadcrumbItem>
+                            <BreadcrumbItem isActive>
+                                {vm.name}
+                            </BreadcrumbItem>
+                        </Breadcrumb>
+                    </PageBreadcrumb>
+                    {vmActionsPageSection}
+                </PageGroup>
                 <PageSection>
                     <Gallery className='ct-vm-overview' hasGutter>
                         {cards}

--- a/src/machines.scss
+++ b/src/machines.scss
@@ -102,3 +102,11 @@
   // Use a max width of 60 0-characters across and let it size for mobile too
    --pf-c-empty-state__content--MaxWidth: min(60ch, 100%);
 }
+
+// Can be removed once https://github.com/cockpit-project/cockpit/pull/18694 is included in the used pkg/lib
+.pf-theme-dark {
+  .pf-c-page__main-group section {
+    --pf-c-page__main-breadcrumb--BackgroundColor: var(--pf-global--BackgroundColor--dark-100);
+    background-color: var(--pf-global--BackgroundColor--dark-100);
+  }
+}

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1161,9 +1161,9 @@ vnc_password= "{vnc_passwd}"
             else:
                 b.wait_not_present("#source-type")
             if self.sourceType == 'file' or self.sourceType == 'cloud':
-                b.set_file_autocomplete_val("#source-file-group", self.location)
+                b.set_file_autocomplete_val("#source-file-group", self.location or " ")
             elif self.sourceType == 'disk_image':
-                b.set_file_autocomplete_val("#source-disk-group", self.location)
+                b.set_file_autocomplete_val("#source-disk-group", self.location or " ")
             elif self.sourceType == 'pxe':
                 b.select_from_dropdown("#network-select", self.location)
             elif self.sourceType == 'url':
@@ -1627,9 +1627,9 @@ vnc_password= "{vnc_passwd}"
             if dialog.sourceType == 'disk_image' or (dialog.os_name == TestMachinesCreate.TestCreateConfig.RHEL_8_1):
                 b.wait_visible(".disks-card table tbody > tr:first-child")
                 if b.is_present(f"#vm-{name}-disks-vda-device"):
-                    b.wait_in_text(f"#vm-{name}-disks-vda-source-file", dialog.location)
+                    b.wait_in_text(f"#vm-{name}-disks-vda-source-file", dialog.location.strip())
                 elif b.is_present(f"#vm-{name}-disks-hda-device"):
-                    b.wait_in_text(f"#vm-{name}-disks-hda-source-file", dialog.location)
+                    b.wait_in_text(f"#vm-{name}-disks-hda-source-file", dialog.location.strip())
                 else:
                     raise AssertionError("Unknown disk device")
             # New volume was created or existing volume was already chosen as destination


### PR DESCRIPTION
This is still PF4 compatible.

See design suggestion: https://github.com/cockpit-project/cockpit/pull/18476#pullrequestreview-1343830115

This needs pkg/lib update from https://github.com/cockpit-project/cockpit/pull/18683
otherwise breaks dark-theme.

All pixel tests updates fall into two changes:

* Reducer spacer in consoles subpage - which was before too much
* Fixed alignment of help button in create dialog with the pkg/lib update 