### PR TITLE
Fix FormHelper warning variants for Memory, Storage and Source rows

### DIFF
--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -807,6 +807,7 @@ const MemoryRow = ({ memorySize, memorySizeUnit, nodeMaxMemory, minimumMemory, o
                     </FormSelect>
                 </InputGroup>
                 <FormHelper fieldId="memory-size"
+                            variant={validationStateMemory}
                             helperTextInvalid={validationStateMemory == "error" && validationFailed.memory}
                             helperText={helperText} />
             </FormGroup>
@@ -906,6 +907,7 @@ const StorageRow = ({ connectionName, allowNoDisk, storageSize, storageSizeUnit,
                     </InputGroup>
                     <FormHelper
                         fieldId="storage-limit"
+                        variant={validationStateStorage}
                         helperTextInvalid={validationStateStorage == "error" && validationFailed.storage}
                         helperText={helperTextNewVolume} />
                 </FormGroup>

--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -376,6 +376,7 @@ const SourceRow = ({ connectionName, source, sourceType, networks, nodeDevices, 
                              id={installationSourceId + "-group"} fieldId={installationSourceId}>
                     {installationSource}
                     <FormHelper
+                        variant={validationStateSource}
                         helperTextInvalid={validationStateSource == "error" && validationFailed.source}
                         helperText={installationSourceWarning} />
                 </FormGroup>

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -140,6 +140,14 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                                          create_and_run=False, os_name=None),
                                              {"os-select": "You need to select the most closely matching operating system"})
 
+        # Check PXE warning about macvtap is present
+        runner.checkDialogFormValidationTest(TestMachinesCreate.VmDialog(self,
+                                                                         sourceType='pxe',
+                                                                         location=f"type=direct,source={iface}"),
+                                             {"network": "macvtap does not work for host to guest network communication"},
+                                             create=False,
+                                             is_warning=True)
+
         # When switching from PXE mode to anything else make sure that the source input is empty
         runner.checkDialogFormValidationTest(TestMachinesCreate.VmDialog(self, storage_size=1,
                                                                          sourceType='pxe',

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -154,7 +154,8 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                                          location=config.VALID_DISK_IMAGE_PATH,
                                                                          user_login="foo",
                                                                          create_and_run=True),
-                                             {"create-vm-dialog-user-password-pw1": "User password must not be empty when user login is set"})
+                                             {"create-vm-dialog-user-password-pw1": "User password must not be empty when user login is set"},
+                                             is_warning=True)
 
         # user login
         runner.checkDialogFormValidationTest(TestMachinesCreate.VmDialog(self, sourceType='cloud',
@@ -171,7 +172,8 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                                          root_password="foo",
                                                                          create_and_run=True),
                                              {"create-vm-dialog-root-password-pw1": "Password quality check failed"},
-                                             False)
+                                             create=False,
+                                             is_warning=True)
 
         # Check swithing from "os" to "cloud" source type doesn't reset passwords
         # https://bugzilla.redhat.com/show_bug.cgi?id=2109986
@@ -1217,7 +1219,7 @@ vnc_password= "{vnc_passwd}"
                 raise Exception("There is no dialog to cancel")
             return self
 
-        def createAndExpectInlineValidationErrors(self, errors, create):
+        def createAndExpectInlineValidationErrors(self, errors, create, is_warning):
             b = self.browser
 
             if create:
@@ -1233,7 +1235,7 @@ vnc_password= "{vnc_passwd}"
                         b.click(".pf-c-modal-box__footer button:contains(Create and edit)")
 
             for error, error_msg in errors.items():
-                if "pw1" in error:
+                if is_warning:
                     error_location = f".pf-c-modal-box__body #{error}-group .pf-c-form__helper-text .pf-m-warning"
                 else:
                     error_location = f".pf-c-modal-box__body #{error}-group .pf-c-form__helper-text .pf-m-error"
@@ -1674,10 +1676,10 @@ vnc_password= "{vnc_passwd}"
             self._assertScriptFinished().checkEnvIsEmpty()
 
         # Many of testCreate* tests use these helpers - let's keep them here to avoid repetition
-        def checkDialogFormValidationTest(self, dialog, errors, create=True):
+        def checkDialogFormValidationTest(self, dialog, errors, create=True, is_warning=False):
             dialog.open() \
                 .fill() \
-                .createAndExpectInlineValidationErrors(errors, create) \
+                .createAndExpectInlineValidationErrors(errors, create, is_warning) \
                 .cancel(True)
             if dialog.check_script_finished:
                 self._assertScriptFinished()

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -887,9 +887,12 @@ vnc_password= "{vnc_passwd}"
 
             # Check minimum requirement warnings are present
             b.set_input_text("#memory-size", "127")
-            b.wait_in_text("#memory-size-helper", "The selected operating system has minimum memory requirement of 128 MiB")
+            # memory limit must be a warning, not an error
+            b.wait_in_text("#memory-size-helper.pf-m-warning", "The selected operating system has minimum memory requirement of 128 MiB")
+
             b.set_input_text("#storage-limit", "127")
-            b.wait_in_text("#storage-limit-helper", "The selected operating system has minimum storage size requirement of 128 MiB")
+            # storage limit must be a warning, not an error
+            b.wait_in_text("#storage-limit-helper.pf-m-warning", "The selected operating system has minimum storage size requirement of 128 MiB")
 
             b.set_input_text("#os-select-group input", suse)
             b.click(f"#os-select li button:contains('{suse}')")


### PR DESCRIPTION
Because of missing tests, there is a regression for some form helper texts which should be warning variants, but are instead shown as plain text. 
Fix it and add the missing tests.

Before|After
:---:|:---:
![Screenshot from 2023-04-21 13-51-28](https://user-images.githubusercontent.com/42733240/233628753-f1b7816e-636b-4c39-87b4-77dbb418f334.png)|![Screenshot from 2023-04-21 13-46-37](https://user-images.githubusercontent.com/42733240/233628768-dac10326-fc97-41a7-8b0f-ca9d50d75cd4.png)
