### PR TITLE
tests: Remove special cases for old libvirt versions

### DIFF
--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -185,18 +185,17 @@ class TestMachinesDisks(VirtualMachinesCase):
         b.wait_not_present("#vm-subVmTest1-needs-shutdown")
         b.wait_in_text("#vm-subVmTest1-disks-vdg-access", "Read-only")
 
-        if m.execute("virsh --version") >= "6.10.0":
-            # Check that errors appear correctly and disappear when closing the dialog and reopening
-            m.execute(f"virsh attach-disk --domain subVmTest1 --source {p1}/mydisk4 --target sdb --targetbus sata --persistent")
-            b.reload()
-            b.enter_page('/machines')
-            open("sdb")
-            b.set_checked("#vm-subVmTest1-disks-sdb-edit-readonly", True)
-            save("sdb", "readonly sata disks are not supported")
-            cancel("sdb")
-            open("sdb")
-            b.wait_not_present("#vm-subVmTest1-disks-sdb-edit-dialog .pf-c-alert")
-            cancel("sdb")
+        # Check that errors appear correctly and disappear when closing the dialog and reopening
+        m.execute(f"virsh attach-disk --domain subVmTest1 --source {p1}/mydisk4 --target sdb --targetbus sata --persistent")
+        b.reload()
+        b.enter_page('/machines')
+        open("sdb")
+        b.set_checked("#vm-subVmTest1-disks-sdb-edit-readonly", True)
+        save("sdb", "readonly sata disks are not supported")
+        cancel("sdb")
+        open("sdb")
+        b.wait_not_present("#vm-subVmTest1-disks-sdb-edit-dialog .pf-c-alert")
+        cancel("sdb")
 
         # Virtio bus type should not be shown for CDROM devices
         m.execute("touch /var/lib/libvirt/novell.iso")
@@ -710,7 +709,7 @@ class TestMachinesDisks(VirtualMachinesCase):
 
                 expected_format = self.getExpectedFormat(self.pool_type, self.expected_volume_format)
                 # Unknown pool format isn't present in xml anymore
-                if expected_format == "unknown" and m.execute("virsh --version") >= "5.6.0":
+                if expected_format == "unknown":
                     m.execute(detect_format_cmd.format(volume_xml, "/volume/target") + " | grep -qv format")
                 else:
                     vol_xml = m.execute(detect_format_cmd.format(volume_xml, "/volume/target/format")).rstrip()

--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -452,9 +452,8 @@ class TestMachinesStoragePools(VirtualMachinesCase):
                 source={"host": "127.0.0.1", "source_path": target_iqn}
             ).execute()
 
-            if ("debian" not in m.image and "ubuntu" not in m.image and "rhel-9" not in m.image and "centos-9" not in m.image and
-                    float(m.execute("virsh --version").strip()[:3]) >= 4.7):
-                # iscsi-direct pool type is available since libvirt 4.7, but not in Debian/Ubuntu (https://bugs.debian.org/918728)
+            if "debian" not in m.image and "ubuntu" not in m.image and "rhel-9" not in m.image and "centos-9" not in m.image:
+                # iscsi-direct pool type is not available in Debian/Ubuntu (https://bugs.debian.org/918728)
                 StoragePoolCreateDialog(
                     self,
                     name="my_iscsi_direct_pool",


### PR DESCRIPTION
We no longer test on distros with such old libvirt versions