### PR TITLE
fmf: Drop qemu-virtiofsd from Fedora 39 on

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -81,8 +81,8 @@ if [ "${PLATFORM_ID:-}" != "platform:el8" ]; then
     systemctl start virtstoraged.socket
 fi
 
-# Fedora 36+ split out qemu-virtiofsd
-if [ "$ID" = fedora ] && [ "$VERSION_ID" -ge "36" ]; then
+# Fedora 36, 37, 38 split out qemu-virtiofsd; Fedora 39 merged it again
+if [ "$ID" = fedora ] && [ "$VERSION_ID" -ge "36" -a "$VERSION_ID" -le "38" ]; then
     dnf install -y qemu-virtiofsd
 fi
 


### PR DESCRIPTION
The package got merged back into QEMU [1]. Possibly this was overzealous, but it's the status quo. See [2] for details.

[1] https://src.fedoraproject.org/rpms/qemu/c/f2cb56a43cfeb660682837ccd90b58c276d2add2
[2] https://bugzilla.redhat.com/show_bug.cgi?id=2189368

---

This should fix the recent TF rawhide install failures: https://artifacts.dev.testing-farm.io/0f5ee502-36a5-4f23-99a0-c8becd340e77/
