### PR TITLE
workflows: Move reposchutz back to Ubuntu 20.04

### DIFF
--- a/.github/workflows/reposchutz.yml
+++ b/.github/workflows/reposchutz.yml
@@ -6,7 +6,8 @@ on:
 jobs:
   check:
     name: Protection checks
-    runs-on: ubuntu-latest
+    # 22.04's podman has issues with piping and causes tar errors
+    runs-on: ubuntu-20.04
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Moving to 22.04 brought back the tar errors.
To avoid these pin this workflow to Ubuntu 20.04 and add a comment to remind us.

See https://github.com/cockpit-project/cockpit/commit/269bf89276c679a03befc8a04244addd5d810048