### PR TITLE
Fix crash in VM details page

### DIFF
--- a/src/components/vm/nics/vmNicsCard.jsx
+++ b/src/components/vm/nics/vmNicsCard.jsx
@@ -45,7 +45,11 @@ const getNetworkDevices = () => {
             })
             .then(bridges => {
                 const bridgeNames = JSON.parse(bridges).map(br => br.ifname);
-                bridgeNames.forEach(br => { devs[br].type = "bridge" });
+                bridgeNames.forEach(br => {
+                    if (devs[br]) {
+                        devs[br].type = "bridge";
+                    }
+                });
             })
             .then(() => {
                 return Promise.resolve(devs);


### PR DESCRIPTION
There is some raise condition when a bridge is added from the CLI /sys/class/net is not immediately in sync with the data ip command, when it comes to which bridges are present on the system.

Only update devices that /sys/class/net contains in order to fix the crash.

Fixes crash as seen here. https://cockpit-logs.us-east-1.linodeobjects.com/pull-1054-20230428-132647-f9d64efc-fedora-37/log.html#74-1