### PR TITLE
Fix testNICAdd and rawhide "CDP broken" failures

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -29,6 +29,12 @@ if grep -q platform:el8 /etc/os-release; then
     dnf module switch-to -y nodejs:16
 fi
 
+# HACK: nodejs 20 is very segfaulty: https://bugzilla.redhat.com/show_bug.cgi?id=2190075
+if grep -q VERSION_ID=39 /etc/os-release; then
+    dnf install -y nodejs18
+    ln -sfn node-18 /usr/bin/node
+fi
+
 # RHEL/CentOS 8 and Fedora have this, but not RHEL 9; tests check this more precisely
 $DNF libvirt-daemon-driver-storage-iscsi-direct || true
 

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -676,8 +676,9 @@ class TestMachinesNICs(VirtualMachinesCase):
             else:
                 self.deleteIface(self.nic_num)
 
-                # Check NIC is no longer in list
-                self.browser.wait_not_present(f"#vm-subVmTest1-network-{self.nic_num}-mac")
+                # Check NIC is no longer in list; the device-removed signal can take *very* long to arrive
+                with self.browser.wait_timeout(90):
+                    self.browser.wait_not_present(f"#vm-subVmTest1-network-{self.nic_num}-mac")
                 self.browser.wait_not_present(".pf-c-modal-box")
 
 


### PR DESCRIPTION
This fixes [testNICAdd](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1056-20230502-181230-073252a0-fedora-38/log.html#61), which has an impressive failure rate right now, see #1057

It also fails the "CDP broken" parts of [TF rawhide](https://artifacts.dev.testing-farm.io/30382c0f-df95-47c6-9733-e8da1d80ce79/). This  is exactly the [same workaround as in Cockpit](https://github.com/cockpit-project/cockpit/commit/9038b849c97f1713f6b38e81dcd299991d26d9af).

There are more failed tests, at least `TestMachinesLifecycle.testBasic` and `TestMachinesFilesystems.testBasicSystemConnection`, but I'll look at them separately.