### PR TITLE
fmf: Put back virtiofsd on Rawhide

### DIFF
--- a/packaging/cockpit-machines.spec.in
+++ b/packaging/cockpit-machines.spec.in
@@ -63,7 +63,7 @@ Requires: libvirt-dbus >= 1.2.0
 Recommends: virt-install >= 3.0.0
 Recommends: libosinfo
 Recommends: python3-gobject-base
-Suggests: qemu-virtiofsd
+Suggests: (qemu-virtiofsd or virtiofsd)
 
 %{NPM_PROVIDES}
 

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -87,9 +87,9 @@ if [ "${PLATFORM_ID:-}" != "platform:el8" ]; then
     systemctl start virtstoraged.socket
 fi
 
-# Fedora 36, 37, 38 split out qemu-virtiofsd; Fedora 39 merged it again
-if [ "$ID" = fedora ] && [ "$VERSION_ID" -ge "36" -a "$VERSION_ID" -le "38" ]; then
-    dnf install -y qemu-virtiofsd
+# Fedora split out qemu-virtiofsd
+if [ "$ID" = fedora ]; then
+    dnf install -y virtiofsd
 fi
 
 # Run tests as unprivileged user


### PR DESCRIPTION
`TestMachinesFilesystems.testBasicSystemConnection` depends on a functioning virtiofsd, so this test got broken on Rawhide with commit 673147c52c41d.

Turns out that there is now a standalone Rust replacement "virtiofsd" which exists on all Fedoras. Use that for testing instead of the package from qemu, and extend our Suggests for either variant.

---

This addresses the last [rawhide failure](https://artifacts.dev.testing-farm.io/5ac3549b-c0ac-4a1a-86a1-21801bd5f2e6/). I'm testing with virtiofsd on all Fedoras first, and if that fails, go back to the version specific install.