### PR TITLE
Always return the store.dispatch calls

### DIFF
--- a/src/libvirtApi/common.js
+++ b/src/libvirtApi/common.js
@@ -189,7 +189,7 @@ function doUsagePolling(name, connectionName, objPath) {
                     });
 
                     logDebug(`doUsagePolling: ${JSON.stringify(props)}`);
-                    store.dispatch(updateVm(props));
+                    return store.dispatch(updateVm(props));
                 }
             })
             .catch(ex => console.warn(`GetStats(${name}, ${connectionName}) failed: ${ex.toString()}`))
@@ -198,9 +198,7 @@ function doUsagePolling(name, connectionName, objPath) {
 
 function getLoggedInUser() {
     logDebug(`GET_LOGGED_IN_USER:`);
-    return cockpit.user().then(loggedUser => {
-        store.dispatch(setLoggedInUser({ loggedUser }));
-    });
+    return cockpit.user().then(loggedUser => store.dispatch(setLoggedInUser({ loggedUser })));
 }
 
 export function getLibvirtVersion({ connectionName }) {
@@ -235,9 +233,9 @@ function networkUpdateOrDelete(connectionName, netPath) {
     call(connectionName, "/org/libvirt/QEMU", "org.libvirt.Connect", "ListNetworks", [0], { timeout, type: "u" })
             .then(objPaths => {
                 if (objPaths[0].includes(netPath))
-                    networkGet({ connectionName, id: netPath, updateOnly: true });
+                    return networkGet({ connectionName, id: netPath, updateOnly: true });
                 else // Transient network which got undefined when stopped
-                    store.dispatch(undefineNetwork({ connectionName, id: netPath }));
+                    return store.dispatch(undefineNetwork({ connectionName, id: netPath }));
             })
             .catch(ex => console.warn("networkUpdateOrDelete action failed:", ex.toString()));
 }
@@ -245,7 +243,7 @@ function networkUpdateOrDelete(connectionName, netPath) {
 function parseOsInfoList(osList) {
     const osinfodata = JSON.parse(osList);
 
-    store.dispatch(updateOsInfoList(osinfodata.filter(os => os.shortId)));
+    return store.dispatch(updateOsInfoList(osinfodata.filter(os => os.shortId)));
 }
 
 /**
@@ -414,12 +412,12 @@ function startEventMonitorStoragePools(connectionName) {
 }
 
 function storagePoolUpdateOrDelete(connectionName, poolPath) {
-    call(connectionName, "/org/libvirt/QEMU", "org.libvirt.Connect", "ListStoragePools", [0], { timeout, type: "u" })
+    return call(connectionName, "/org/libvirt/QEMU", "org.libvirt.Connect", "ListStoragePools", [0], { timeout, type: "u" })
             .then(objPaths => {
                 if (objPaths[0].includes(poolPath))
-                    storagePoolGet({ connectionName, id: poolPath, updateOnly: true });
+                    return storagePoolGet({ connectionName, id: poolPath, updateOnly: true });
                 else // Transient pool which got undefined when stopped
-                    store.dispatch(undefineStoragePool({ connectionName, id: poolPath }));
+                    return store.dispatch(undefineStoragePool({ connectionName, id: poolPath }));
             })
             .catch(ex => console.warn("storagePoolUpdateOrDelete action failed:", ex.toString()));
 }

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -715,9 +715,10 @@ export function domainGet({
                 if (!domainIsRunning(stateStr))
                     props.actualTimeInMs = -1;
 
-                store.dispatch(updateOrAddVm({ state: stateStr, ...props }));
+                return store.dispatch(updateOrAddVm({ state: stateStr, ...props }));
+            })
+            .then(() => {
                 clearVmUiState(props.name, connectionName);
-
                 return snapshotGetAll({ connectionName, domainPath: objPath });
             })
             .catch(ex => {

--- a/src/libvirtApi/interface.js
+++ b/src/libvirtApi/interface.js
@@ -39,7 +39,7 @@ export function interfaceGet({
 }) {
     const props = {};
 
-    call(connectionName, objPath, 'org.freedesktop.DBus.Properties', 'GetAll', ['org.libvirt.Interface'], { timeout, type: 's' })
+    return call(connectionName, objPath, 'org.freedesktop.DBus.Properties', 'GetAll', ['org.libvirt.Interface'], { timeout, type: 's' })
             .then(resultProps => {
                 /* Sometimes not all properties are returned; for example when some network got deleted while part
                  * of the properties got fetched from libvirt. Make sure that there is check before reading the attributes.
@@ -57,7 +57,7 @@ export function interfaceGet({
             })
             .then(xml => {
                 const iface = parseIfaceDumpxml(xml);
-                store.dispatch(updateOrAddInterface(Object.assign({}, props, iface)));
+                return store.dispatch(updateOrAddInterface(Object.assign({}, props, iface)));
             })
             .catch(ex => console.log('listInactiveInterfaces action for path', objPath, ex.toString()));
 }

--- a/src/libvirtApi/network.js
+++ b/src/libvirtApi/network.js
@@ -107,7 +107,7 @@ export function networkGet({
             })
             .then(xml => {
                 const network = parseNetDumpxml(xml);
-                store.dispatch(updateOrAddNetwork(Object.assign({}, props, network), updateOnly));
+                return store.dispatch(updateOrAddNetwork(Object.assign({}, props, network), updateOnly));
             })
             .catch(ex => console.warn('GET_NETWORK action failed for path', objPath, ex.toString()));
 }

--- a/src/libvirtApi/snapshot.js
+++ b/src/libvirtApi/snapshot.js
@@ -72,7 +72,7 @@ export function snapshotGetAll({ connectionName, domainPath }) {
                             .catch(error => ({ success: false, error }));
                 };
 
-                Promise.all(promises.map(toResultObject))
+                return Promise.all(promises.map(toResultObject))
                         .then(snapXmlList => {
                             snapXmlList.forEach(snap => {
                                 if (snap.success) {
@@ -96,7 +96,7 @@ export function snapshotGetAll({ connectionName, domainPath }) {
                     logDebug("LIST_DOMAIN_SNAPSHOTS action failed for domain", domainPath, ", not supported by libvirt-dbus");
                 else
                     console.warn("LIST_DOMAIN_SNAPSHOTS action failed for domain", domainPath, ":", JSON.stringify(ex), "name:", ex.name);
-                store.dispatch(updateDomainSnapshots({
+                return store.dispatch(updateDomainSnapshots({
                     connectionName,
                     domainPath,
                     snaps: -1

--- a/src/libvirtApi/storagePool.js
+++ b/src/libvirtApi/storagePool.js
@@ -95,13 +95,13 @@ export function storagePoolGet({
 
                 props.volumes = [];
                 if (props.active) {
-                    storageVolumeGetAll({ connectionName, poolName: dumpxmlParams.name })
+                    return storageVolumeGetAll({ connectionName, poolName: dumpxmlParams.name })
                             .then(volumes => {
                                 props.volumes = volumes;
                             })
                             .finally(() => store.dispatch(updateOrAddStoragePool(Object.assign({}, dumpxmlParams, props), updateOnly)));
                 } else {
-                    store.dispatch(updateOrAddStoragePool(Object.assign({}, dumpxmlParams, props), updateOnly));
+                    return store.dispatch(updateOrAddStoragePool(Object.assign({}, dumpxmlParams, props), updateOnly));
                 }
             })
             .catch(ex => console.warn('GET_STORAGE_POOL action failed for path', objPath, ex.toString()));


### PR DESCRIPTION
These are promises and need to be returned in order to be used properly in the promise chaining.

With this change, getApiData will now only return after all store updates are finished.

This might make the initial render slightly slower but it will ensure that no state  updates can get mixed ups from the initial API data fetch and followup updates.