### PR TITLE
Return a promise from networkGet and storagePoolGet functions

### DIFF
--- a/src/libvirtApi/network.js
+++ b/src/libvirtApi/network.js
@@ -87,7 +87,7 @@ export function networkGet({
 }) {
     const props = {};
 
-    call(connectionName, objPath, 'org.freedesktop.DBus.Properties', 'GetAll', ['org.libvirt.Network'], { timeout, type: 's' })
+    return call(connectionName, objPath, 'org.freedesktop.DBus.Properties', 'GetAll', ['org.libvirt.Network'], { timeout, type: 's' })
             .then(resultProps => {
                 /* Sometimes not all properties are returned; for example when some network got deleted while part
                  * of the properties got fetched from libvirt. Make sure that there is check before reading the attributes.

--- a/src/libvirtApi/storagePool.js
+++ b/src/libvirtApi/storagePool.js
@@ -76,7 +76,7 @@ export function storagePoolGet({
     let dumpxmlParams;
     const props = {};
 
-    call(connectionName, objPath, 'org.libvirt.StoragePool', 'GetXMLDesc', [0], { timeout, type: 'u' })
+    return call(connectionName, objPath, 'org.libvirt.StoragePool', 'GetXMLDesc', [0], { timeout, type: 'u' })
             .then(poolXml => {
                 dumpxmlParams = parseStoragePoolDumpxml(connectionName, poolXml[0], objPath);
 


### PR DESCRIPTION
So that getApiData can correctly return when all nested promises are also resolved.