### PR TITLE
Hide console card if there are no consoles present for the VM

### DIFF
--- a/src/components/vm/vmDetailsPage.jsx
+++ b/src/components/vm/vmDetailsPage.jsx
@@ -124,22 +124,24 @@ export const VmDetailsPage = ({
             title: _("Usage"),
             body: <VmUsageTab vm={vm} />,
         },
-        {
-            id: `${vmId(vm.name)}-consoles`,
-            className: "consoles-card",
-            title: _("Console"),
-            actions: vm.state != "shut off"
-                ? <Button variant="link"
+        ...(vm.displays.length
+            ? [{
+                id: `${vmId(vm.name)}-consoles`,
+                className: "consoles-card",
+                title: _("Console"),
+                actions: vm.state != "shut off"
+                    ? <Button variant="link"
                           onClick={() => {
                               const urlOptions = { name: vm.name, connection: vm.connectionName };
                               return cockpit.location.go(["vm", "console"], { ...cockpit.location.options, ...urlOptions });
                           }}
                           icon={<ExpandIcon />}
                           iconPosition="right">{_("Expand")}</Button>
-                : null,
-            body: <Consoles vm={vm} config={config}
+                    : null,
+                body: <Consoles vm={vm} config={config}
                             onAddErrorNotification={onAddErrorNotification} />,
-        },
+            }]
+            : []),
         {
             id: `${vmId(vm.name)}-disks`,
             className: "disks-card",

--- a/src/components/vm/vmDetailsPage.scss
+++ b/src/components/vm/vmDetailsPage.scss
@@ -42,10 +42,6 @@
         grid-row: 1 / span 2;
         grid-column: 2 / -1;
     }
-
-    .usage-card {
-      grid-column-start: 1;
-    }
   }
 
   .networks-card, .disks-card, .snapshots-card, .hostdevs-card, .filesystems-card {

--- a/test/check-machines-snapshots
+++ b/test/check-machines-snapshots
@@ -104,6 +104,7 @@ class TestMachinesSnapshots(VirtualMachinesCase):
             ignore=[
                 "tr:nth-child(1) .snap-creation-time",
                 "tr:nth-child(2) .snap-creation-time",
+                "tr:nth-child(2) .tooltip-circle",
             ],
             skip_layouts=["rtl"]
         )


### PR DESCRIPTION
* [x]  needs the scrollbar hide hack from main repo

We don't provide the users a way to add/remove consoles from the UI yet.

It's valid configuration to define VMs without console. In this case hide the Consoles card.