### PR TITLE
Confirmation dialog for VM shutdown, forceoff, reboot and non-maskable interrupt

### DIFF
--- a/src/components/vm/confirmDialog.jsx
+++ b/src/components/vm/confirmDialog.jsx
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from 'cockpit';
+import React, { useEffect, useState } from 'react';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from "@patternfly/react-core/dist/esm/components/DescriptionList";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
+import { useDialogs } from 'dialogs.jsx';
+import { distanceToNow } from 'timeformat.js';
+
+import { domainGetStartTime } from '../../libvirtApi/domain.js';
+
+const _ = cockpit.gettext;
+
+export const ConfirmDialog = ({ idPrefix, actionsList, title, titleIcon, vm }) => {
+    const Dialogs = useDialogs();
+    const [uptime, setUptime] = useState();
+
+    useEffect(() => {
+        return domainGetStartTime({ connectionName: vm.connectionName, vmName: vm.name })
+                .then(res => setUptime(res))
+                .catch(e => console.error(JSON.stringify(e)));
+    }, [vm]);
+
+    const actions = actionsList.map(action =>
+        <Button variant={action.variant}
+            key={action.id}
+            id={`${idPrefix}-${action.id}`}
+            onClick={() => {
+                action.handler();
+                Dialogs.close();
+            }}>
+            {action.name}
+        </Button>
+    );
+    actions.push(
+        <Button variant="link" key="cancel" onClick={Dialogs.close}>
+            {_("Cancel")}
+        </Button>
+    );
+
+    return (
+        <Modal id={`${idPrefix}-confirm-action-modal`}
+            position="top"
+            variant="small"
+            onClose={Dialogs.close}
+            title={title}
+            titleIconVariant={titleIcon}
+            isOpen
+            footer={actions}>
+            {uptime &&
+            <DescriptionList isHorizontal isFluid>
+                <DescriptionListGroup>
+                    <DescriptionListTerm>{_("Uptime")}</DescriptionListTerm>
+                    <DescriptionListDescription id="uptime">{distanceToNow(new Date(uptime))}</DescriptionListDescription>
+                </DescriptionListGroup>
+            </DescriptionList>}
+        </Modal>
+    );
+};

--- a/src/components/vm/vmActions.jsx
+++ b/src/components/vm/vmActions.jsx
@@ -22,7 +22,9 @@ import PropTypes from 'prop-types';
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Dropdown, DropdownItem, DropdownSeparator, KebabToggle } from "@patternfly/react-core/dist/esm/deprecated/components/Dropdown";
 import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip";
+import { PowerOffIcon, RedoIcon } from '@patternfly/react-icons';
 import { useDialogs } from 'dialogs.jsx';
+import { fmt_to_fragments } from 'utils.jsx';
 
 import { updateVm } from '../../actions/store-actions.js';
 import {
@@ -30,6 +32,7 @@ import {
 } from "../../helpers.js";
 
 import { CloneDialog } from './vmCloneDialog.jsx';
+import { ConfirmDialog } from './confirmDialog.jsx';
 import { DeleteDialog } from "./deleteDialog.jsx";
 import { MigrateDialog } from './vmMigrateDialog.jsx';
 import { RenameDialog } from './vmRenameDialog.jsx';
@@ -227,21 +230,72 @@ const VmActions = ({ vm, onAddErrorNotification, isDetailsPage }) => {
                     variant={isDetailsPage ? 'primary' : 'secondary'}
                     isLoading={operationInProgress}
                     isDisabled={operationInProgress}
-                    onClick={() => { setOperationInProgress(true); onShutdown(vm, setOperationInProgress) }} id={`${id}-shutdown-button`}>
+                    id={`${id}-shutdown-button`}
+                    onClick={() => Dialogs.show(
+                        <ConfirmDialog idPrefix={id}
+                            title={fmt_to_fragments(_("Shut down $0?"), <b>{vm.name}</b>)}
+                            titleIcon={PowerOffIcon}
+                            vm={vm}
+                            actionsList={[
+                                {
+                                    variant: "primary",
+                                    handler: () => {
+                                        setOperationInProgress(true);
+                                        onShutdown(vm, setOperationInProgress);
+                                    },
+                                    name: _("Shut down"),
+                                    id: "off",
+                                },
+                                {
+                                    variant: "secondary",
+                                    handler: () => {
+                                        onReboot(vm);
+                                    },
+                                    name: _("Reboot"),
+                                    id: "reboot",
+                                },
+                            ]} />
+                    )}>
                 {_("Shut down")}
             </Button>
         );
         dropdownItems.push(
             <DropdownItem key={`${id}-off`}
                           id={`${id}-off`}
-                          onClick={() => onShutdown(vm)}>
+                          onClick={() => Dialogs.show(
+                              <ConfirmDialog idPrefix={id}
+                                  title={fmt_to_fragments(_("Shut down $0?"), <b>{vm.name}</b>)}
+                                  titleIcon={PowerOffIcon}
+                                  vm={vm}
+                                  actionsList={[
+                                      {
+                                          variant: "primary",
+                                          handler: () => onShutdown(vm),
+                                          name: _("Shut down"),
+                                          id: "off",
+                                      },
+                                  ]} />
+                          )}>
                 {_("Shut down")}
             </DropdownItem>
         );
         dropdownItems.push(
             <DropdownItem key={`${id}-forceOff`}
                           id={`${id}-forceOff`}
-                          onClick={() => onForceoff(vm)}>
+                          onClick={() => Dialogs.show(
+                              <ConfirmDialog idPrefix={id}
+                                  title={fmt_to_fragments(_("Force shut down $0?"), <b>{vm.name}</b>)}
+                                  titleIcon={PowerOffIcon}
+                                  vm={vm}
+                                  actionsList={[
+                                      {
+                                          variant: "primary",
+                                          handler: () => onForceoff(vm),
+                                          name: _("Force shut down"),
+                                          id: "forceOff",
+                                      },
+                                  ]} />
+                          )}>
                 {_("Force shut down")}
             </DropdownItem>
         );
@@ -249,7 +303,19 @@ const VmActions = ({ vm, onAddErrorNotification, isDetailsPage }) => {
         dropdownItems.push(
             <DropdownItem key={`${id}-sendNMI`}
                           id={`${id}-sendNMI`}
-                          onClick={() => onSendNMI(vm)}>
+                          onClick={() => Dialogs.show(
+                              <ConfirmDialog idPrefix={id}
+                                  title={fmt_to_fragments(_("Send non-maskable interrupt to $0?"), <b>{vm.name}</b>)}
+                                  vm={vm}
+                                  actionsList={[
+                                      {
+                                          variant: "primary",
+                                          handler: () => onSendNMI(vm),
+                                          name: _("Send non-maskable interrupt"),
+                                          id: "sendNMI",
+                                      },
+                                  ]} />
+                          )}>
                 {_("Send non-maskable interrupt")}
             </DropdownItem>
         );
@@ -260,14 +326,40 @@ const VmActions = ({ vm, onAddErrorNotification, isDetailsPage }) => {
         dropdownItems.push(
             <DropdownItem key={`${id}-reboot`}
                           id={`${id}-reboot`}
-                          onClick={() => onReboot(vm)}>
+                          onClick={() => Dialogs.show(
+                              <ConfirmDialog idPrefix={id}
+                                  title={fmt_to_fragments(_("Reboot $0?"), <b>{vm.name}</b>)}
+                                  titleIcon={RedoIcon}
+                                  vm={vm}
+                                  actionsList={[
+                                      {
+                                          variant: "primary",
+                                          handler: onReboot(vm),
+                                          name: _("Reboot"),
+                                          id: "reboot",
+                                      },
+                                  ]} />
+                          )}>
                 {_("Reboot")}
             </DropdownItem>
         );
         dropdownItems.push(
             <DropdownItem key={`${id}-forceReboot`}
                           id={`${id}-forceReboot`}
-                          onClick={() => onForceReboot(vm)}>
+                          onClick={() => Dialogs.show(
+                              <ConfirmDialog idPrefix={id}
+                                  title={fmt_to_fragments(_("Force reboot $0?"), <b>{vm.name}</b>)}
+                                  vm={vm}
+                                  titleIcon={RedoIcon}
+                                  actionsList={[
+                                      {
+                                          variant: "primary",
+                                          handler: onForceReboot(vm),
+                                          name: _("Force reboot"),
+                                          id: "forceReboot",
+                                      },
+                                  ]} />
+                          )}>
                 {_("Force reboot")}
             </DropdownItem>
         );

--- a/src/components/vm/vmActions.jsx
+++ b/src/components/vm/vmActions.jsx
@@ -56,6 +56,124 @@ import store from "../../store.js";
 
 const _ = cockpit.gettext;
 
+const onStart = (vm, setOperationInProgress) => domainStart({ name: vm.name, id: vm.id, connectionName: vm.connectionName }).catch(ex => {
+    setOperationInProgress(false);
+    store.dispatch(
+        updateVm({
+            connectionName: vm.connectionName,
+            name: vm.name,
+            error: {
+                text: cockpit.format(_("VM $0 failed to start"), vm.name),
+                detail: ex.message,
+            }
+        })
+    );
+});
+
+const onInstall = (vm, onAddErrorNotification) => domainInstall({ vm, onAddErrorNotification }).catch(ex => {
+    onAddErrorNotification({
+        text: cockpit.format(_("VM $0 failed to get installed"), vm.name),
+        detail: ex.message.split(/Traceback(.+)/)[0],
+        resourceId: vm.id,
+    });
+});
+
+const onReboot = (vm) => domainReboot({ name: vm.name, id: vm.id, connectionName: vm.connectionName }).catch(ex => {
+    store.dispatch(
+        updateVm({
+            connectionName: vm.connectionName,
+            name: vm.name,
+            error: {
+                text: cockpit.format(_("VM $0 failed to reboot"), vm.name),
+                detail: ex.message,
+            }
+        })
+    );
+});
+
+const onForceReboot = (vm) => domainForceReboot({ name: vm.name, id: vm.id, connectionName: vm.connectionName }).catch(ex => {
+    store.dispatch(
+        updateVm({
+            connectionName: vm.connectionName,
+            name: vm.name,
+            error: {
+                text: cockpit.format(_("VM $0 failed to force reboot"), vm.name),
+                detail: ex.message,
+            }
+        })
+    );
+});
+
+const onShutdown = (vm, setOperationInProgress) => domainShutdown({ name: vm.name, id: vm.id, connectionName: vm.connectionName })
+        .then(() => !vm.persistent && cockpit.location.go(["vms"]))
+        .catch(ex => {
+            setOperationInProgress(false);
+            store.dispatch(
+                updateVm({
+                    connectionName: vm.connectionName,
+                    name: vm.name,
+                    error: {
+                        text: cockpit.format(_("VM $0 failed to shutdown"), vm.name),
+                        detail: ex.message,
+                    }
+                })
+            );
+        });
+
+const onPause = (vm) => domainPause({ name: vm.name, id: vm.id, connectionName: vm.connectionName }).catch(ex => {
+    store.dispatch(
+        updateVm({
+            connectionName: vm.connectionName,
+            name: vm.name,
+            error: {
+                text: cockpit.format(_("VM $0 failed to pause"), vm.name),
+                detail: ex.message,
+            }
+        })
+    );
+});
+
+const onResume = (vm) => domainResume({ name: vm.name, id: vm.id, connectionName: vm.connectionName }).catch(ex => {
+    store.dispatch(
+        updateVm({
+            connectionName: vm.connectionName,
+            name: vm.name,
+            error: {
+                text: cockpit.format(_("VM $0 failed to resume"), vm.name),
+                detail: ex.message,
+            }
+        })
+    );
+});
+
+const onForceoff = (vm) => domainForceOff({ name: vm.name, id: vm.id, connectionName: vm.connectionName })
+        .then(() => !vm.persistent && cockpit.location.go(["vms"]))
+        .catch(ex => {
+            store.dispatch(
+                updateVm({
+                    connectionName: vm.connectionName,
+                    name: vm.name,
+                    error: {
+                        text: cockpit.format(_("VM $0 failed to force shutdown"), vm.name),
+                        detail: ex.message,
+                    }
+                })
+            );
+        });
+
+const onSendNMI = (vm) => domainSendNMI({ name: vm.name, id: vm.id, connectionName: vm.connectionName }).catch(ex => {
+    store.dispatch(
+        updateVm({
+            connectionName: vm.connectionName,
+            name: vm.name,
+            error: {
+                text: cockpit.format(_("VM $0 failed to send NMI"), vm.name),
+                detail: ex.message,
+            }
+        })
+    );
+});
+
 const VmActions = ({ vm, onAddErrorNotification, isDetailsPage }) => {
     const Dialogs = useDialogs();
     const [isActionOpen, setIsActionOpen] = useState(false);
@@ -78,123 +196,13 @@ const VmActions = ({ vm, onAddErrorNotification, isDetailsPage }) => {
     const hasInstallPhase = vm.metadata && vm.metadata.hasInstallPhase;
     const dropdownItems = [];
 
-    const onStart = () => domainStart({ name: vm.name, id: vm.id, connectionName: vm.connectionName }).catch(ex => {
-        setOperationInProgress(false);
-        store.dispatch(
-            updateVm({
-                connectionName: vm.connectionName,
-                name: vm.name,
-                error: {
-                    text: cockpit.format(_("VM $0 failed to start"), vm.name),
-                    detail: ex.message,
-                }
-            })
-        );
-    });
-    const onInstall = () => domainInstall({ vm, onAddErrorNotification }).catch(ex => {
-        onAddErrorNotification({
-            text: cockpit.format(_("VM $0 failed to get installed"), vm.name),
-            detail: ex.message.split(/Traceback(.+)/)[0],
-            resourceId: vm.id,
-        });
-    });
-    const onReboot = () => domainReboot({ name: vm.name, id: vm.id, connectionName: vm.connectionName }).catch(ex => {
-        store.dispatch(
-            updateVm({
-                connectionName: vm.connectionName,
-                name: vm.name,
-                error: {
-                    text: cockpit.format(_("VM $0 failed to reboot"), vm.name),
-                    detail: ex.message,
-                }
-            })
-        );
-    });
-    const onForceReboot = () => domainForceReboot({ name: vm.name, id: vm.id, connectionName: vm.connectionName }).catch(ex => {
-        store.dispatch(
-            updateVm({
-                connectionName: vm.connectionName,
-                name: vm.name,
-                error: {
-                    text: cockpit.format(_("VM $0 failed to force reboot"), vm.name),
-                    detail: ex.message,
-                }
-            })
-        );
-    });
-    const onShutdown = () => domainShutdown({ name: vm.name, id: vm.id, connectionName: vm.connectionName })
-            .then(() => !vm.persistent && cockpit.location.go(["vms"]))
-            .catch(ex => {
-                setOperationInProgress(false);
-                store.dispatch(
-                    updateVm({
-                        connectionName: vm.connectionName,
-                        name: vm.name,
-                        error: {
-                            text: cockpit.format(_("VM $0 failed to shutdown"), vm.name),
-                            detail: ex.message,
-                        }
-                    })
-                );
-            });
-    const onPause = () => domainPause({ name: vm.name, id: vm.id, connectionName: vm.connectionName }).catch(ex => {
-        store.dispatch(
-            updateVm({
-                connectionName: vm.connectionName,
-                name: vm.name,
-                error: {
-                    text: cockpit.format(_("VM $0 failed to pause"), vm.name),
-                    detail: ex.message,
-                }
-            })
-        );
-    });
-    const onResume = () => domainResume({ name: vm.name, id: vm.id, connectionName: vm.connectionName }).catch(ex => {
-        store.dispatch(
-            updateVm({
-                connectionName: vm.connectionName,
-                name: vm.name,
-                error: {
-                    text: cockpit.format(_("VM $0 failed to resume"), vm.name),
-                    detail: ex.message,
-                }
-            })
-        );
-    });
-    const onForceoff = () => domainForceOff({ name: vm.name, id: vm.id, connectionName: vm.connectionName })
-            .then(() => !vm.persistent && cockpit.location.go(["vms"]))
-            .catch(ex => {
-                store.dispatch(
-                    updateVm({
-                        connectionName: vm.connectionName,
-                        name: vm.name,
-                        error: {
-                            text: cockpit.format(_("VM $0 failed to force shutdown"), vm.name),
-                            detail: ex.message,
-                        }
-                    })
-                );
-            });
-    const onSendNMI = () => domainSendNMI({ name: vm.name, id: vm.id, connectionName: vm.connectionName }).catch(ex => {
-        store.dispatch(
-            updateVm({
-                connectionName: vm.connectionName,
-                name: vm.name,
-                error: {
-                    text: cockpit.format(_("VM $0 failed to send NMI"), vm.name),
-                    detail: ex.message,
-                }
-            })
-        );
-    });
-
     let shutdown;
 
     if (domainCanPause(state)) {
         dropdownItems.push(
             <DropdownItem key={`${id}-pause`}
                           id={`${id}-pause`}
-                          onClick={() => onPause()}>
+                          onClick={() => onPause(vm)}>
                 {_("Pause")}
             </DropdownItem>
         );
@@ -205,7 +213,7 @@ const VmActions = ({ vm, onAddErrorNotification, isDetailsPage }) => {
         dropdownItems.push(
             <DropdownItem key={`${id}-resume`}
                           id={`${id}-resume`}
-                          onClick={() => onResume()}>
+                          onClick={() => onResume(vm)}>
                 {_("Resume")}
             </DropdownItem>
         );
@@ -219,21 +227,21 @@ const VmActions = ({ vm, onAddErrorNotification, isDetailsPage }) => {
                     variant={isDetailsPage ? 'primary' : 'secondary'}
                     isLoading={operationInProgress}
                     isDisabled={operationInProgress}
-                    onClick={() => { setOperationInProgress(true); onShutdown() }} id={`${id}-shutdown-button`}>
+                    onClick={() => { setOperationInProgress(true); onShutdown(vm, setOperationInProgress) }} id={`${id}-shutdown-button`}>
                 {_("Shut down")}
             </Button>
         );
         dropdownItems.push(
             <DropdownItem key={`${id}-off`}
                           id={`${id}-off`}
-                          onClick={() => onShutdown()}>
+                          onClick={() => onShutdown(vm)}>
                 {_("Shut down")}
             </DropdownItem>
         );
         dropdownItems.push(
             <DropdownItem key={`${id}-forceOff`}
                           id={`${id}-forceOff`}
-                          onClick={() => onForceoff()}>
+                          onClick={() => onForceoff(vm)}>
                 {_("Force shut down")}
             </DropdownItem>
         );
@@ -241,7 +249,7 @@ const VmActions = ({ vm, onAddErrorNotification, isDetailsPage }) => {
         dropdownItems.push(
             <DropdownItem key={`${id}-sendNMI`}
                           id={`${id}-sendNMI`}
-                          onClick={() => onSendNMI()}>
+                          onClick={() => onSendNMI(vm)}>
                 {_("Send non-maskable interrupt")}
             </DropdownItem>
         );
@@ -252,14 +260,14 @@ const VmActions = ({ vm, onAddErrorNotification, isDetailsPage }) => {
         dropdownItems.push(
             <DropdownItem key={`${id}-reboot`}
                           id={`${id}-reboot`}
-                          onClick={() => onReboot()}>
+                          onClick={() => onReboot(vm)}>
                 {_("Reboot")}
             </DropdownItem>
         );
         dropdownItems.push(
             <DropdownItem key={`${id}-forceReboot`}
                           id={`${id}-forceReboot`}
-                          onClick={() => onForceReboot()}>
+                          onClick={() => onForceReboot(vm)}>
                 {_("Force reboot")}
             </DropdownItem>
         );
@@ -274,7 +282,7 @@ const VmActions = ({ vm, onAddErrorNotification, isDetailsPage }) => {
                     variant={isDetailsPage ? 'primary' : 'secondary'}
                     isLoading={operationInProgress}
                     isDisabled={operationInProgress}
-                    onClick={() => { setOperationInProgress(true); onStart() }} id={`${id}-run`}>
+                    onClick={() => { setOperationInProgress(true); onStart(vm, setOperationInProgress) }} id={`${id}-run`}>
                 {_("Run")}
             </Button>
         );
@@ -286,7 +294,7 @@ const VmActions = ({ vm, onAddErrorNotification, isDetailsPage }) => {
             <Button key='action-install' variant="secondary"
                            isLoading={vm.installInProgress}
                            isDisabled={vm.installInProgress}
-                           onClick={() => onInstall()} id={`${id}-install`}>
+                           onClick={() => onInstall(vm, onAddErrorNotification)} id={`${id}-install`}>
                 {_("Install")}
             </Button>
         );

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -183,6 +183,8 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         # the shut off button beside the VM name
         self.waitCirrOSBooted(args['logfile'])
         b.click("#vm-subVmTest1-system-shutdown-button")
+        b.wait_visible("#vm-subVmTest1-system-confirm-action-modal")
+        b.click(".pf-c-modal-box__footer #vm-subVmTest1-system-off")
         b.wait_in_text("#vm-subVmTest1-system-state", "Shut off")
         b.wait_visible("#vm-subVmTest1-system-run")
 
@@ -211,7 +213,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         m.execute("virsh define --file /tmp/subVmTest1.xml")
 
         # start another one, should appear automatically
-        self.createVm("subVmTest2")
+        args2 = self.createVm("subVmTest2")
         b.wait_in_text("#vm-subVmTest2-system-state", "Running")
         self.goToVmPage("subVmTest2")
         b.wait_in_text("#vm-subVmTest2-cpu", "1 vCPU")
@@ -230,6 +232,23 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         self.performAction("subVmTest2", "forceOff")
 
         b.click("#vm-subVmTest2-system-run")
+
+        # reboot through shutdown dialog
+        self.machine.execute(f"echo '' > {args2['logfile']}")
+        b.click("#vm-subVmTest2-system-shutdown-button")
+        b.wait_visible("#vm-subVmTest2-system-confirm-action-modal")
+        b.click(".pf-c-modal-box__footer button:contains(Reboot)")
+        b.wait_not_present("#vm-subVmTest2-system-confirm-action-modal")
+        b.wait_in_text("#vm-subVmTest2-system-state", "Running")
+        self.waitCirrOSBooted(args2['logfile'])
+
+        # Check uptime
+        b.click("#vm-subVmTest2-system-shutdown-button")
+        b.wait_visible("#vm-subVmTest2-system-confirm-action-modal")
+        if run_pixel_tests:
+            b.assert_pixels("#vm-subVmTest2-system-confirm-action-modal", "shutdown-confirm-dialog")
+        b.click(".pf-c-modal-box__footer button:contains(Cancel)")
+        b.wait_not_present("#vm-subVmTest2-system-confirm-action-modal")
 
         b.set_input_text("#text-search", "subVmTest2")
         self.waitVmRow("subVmTest2")
@@ -472,8 +491,10 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         m.execute(f"virsh undefine {name}")
         b.wait_visible(f"tr[data-row-id=vm-{name}-system][data-vm-transient=true]")
         b.click(f"#vm-{name}-system-action-kebab button")
-        b.wait_visible(f"#vm-{name}-system-delete a.pf-m-disabled")
+        b.wait_visible(f"#vm-{name}-system-delete a.pf-m-disabled")  # delete buton should be disabled
         b.click(f"#vm-{name}-system-forceOff")
+        b.wait_visible(f"#vm-{name}-system-confirm-action-modal")
+        b.click(f".pf-c-modal-box__footer #vm-{name}-system-forceOff")
         self.waitVmRow(name, 'system', False)
         b.wait_not_present(f'#vm-{name}-system-state button:contains("view more")')
 

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -39,6 +39,12 @@ class VirtualMachinesCaseHelpers:
         b.wait_visible("#vm-{0}-{1}-action-kebab > .pf-c-dropdown__menu".format(vmName, connectionName))
         b.click("#vm-{0}-{1}-{2} a".format(vmName, connectionName, action))
 
+        # Some actions, which can cause expensive downtime when clicked accidentally, have confirmation dialog
+        if action in ["off", "forceOff", "reboot", "forceReboot", "sendNMI"]:
+            b.wait_visible("#vm-{0}-{1}-confirm-action-modal".format(vmName, connectionName))
+            b.click(".pf-c-modal-box__footer #vm-{0}-{1}-{2}".format(vmName, connectionName, action))
+            b.wait_not_present("#vm-{0}-{1}-confirm-action-modal".format(vmName, connectionName))
+
         if not checkExpectedState:
             return
 


### PR DESCRIPTION
## Machines: Confirm shutdown actions

Show confirmation dialog everywhere where accidental miss click of production VM could result in a costly downtime.

**TODO**: Update screenshots

![Screenshot from 2023-05-05 15-23-07](https://user-images.githubusercontent.com/42733240/236469994-0142affc-d3e3-436f-b734-0300fb4239d9.png)
![Screenshot from 2023-05-05 15-18-59](https://user-images.githubusercontent.com/42733240/236469998-4e7255bb-9405-45e8-a12e-a81c3eec94ef.png)
