### PR TITLE
test: Debian 11 does not support target.hotplug either

### DIFF
--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -644,10 +644,15 @@ class TestMachinesSettings(VirtualMachinesCase):
         # Check rebooting machine will not unexpectedly affect watchdog configuration
         setWatchdogActionLive(action="poweroff", reboot_machine=True)
 
-        # Older libvirt in rhel-8-9 and centos-8-stream doesn't support target.hotplug=off
-        if not m.image.startswith("rhel-8") and m.image != "centos-8-stream":
+        m.execute("virsh destroy subVmTest1")
+
+        # Some OSes don't support target.hotplug=off
+        if m.image.startswith("rhel-8") or m.image in ["centos-8-stream", "debian-stable"]:
+            self.assertIn("Unknown --controller options", m.execute(
+                "! virt-xml subVmTest1 --edit model=pci-root --controller target.hotplug=off 2>&1")
+            )
+        else:
             # Disable hotplugging for subVmTest1
-            m.execute("virsh destroy subVmTest1")
             m.execute("virt-xml subVmTest1 --edit model=pci-root --controller target.hotplug=off")
             # Cleanup watchdog configuration
             m.execute("virt-xml subVmTest1 --remove-device --watchdog 1")


### PR DESCRIPTION
This was previously shadowed because the test got skipped on known issue https://github.com/cockpit-project/bots/issues/1543

---

Fixes [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-4762-20230514-225923-f68610a8-debian-stable-cockpit-project-cockpit-machines/log.html) in https://github.com/cockpit-project/bots/pull/4762 . It failed the same way before, but got naughtied, like [in this run](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1073-20230511-092016-77e25d29-debian-stable/log.html).