### PR TITLE
Show virtual interface's TAP device

### DIFF
--- a/src/components/vm/nics/vmNicsCard.jsx
+++ b/src/components/vm/nics/vmNicsCard.jsx
@@ -300,7 +300,7 @@ export class VmNetworkTab extends React.Component {
             {
                 name: _("MAC address"),
                 value: 'mac',
-                props: { width: 20 },
+                props: { width: 15 },
                 hidden: ifaces.every(i => !i.mac),
             },
             {
@@ -324,13 +324,13 @@ export class VmNetworkTab extends React.Component {
                         );
                     }
                 },
-                props: { width: 20 },
+                props: { width: Object.keys(this.state.ips).length ? 20 : 10 },
                 hidden: this.props.vm.state != 'running' && this.props.vm.state != 'paused',
             },
             {
                 name: _("Source"),
                 value: (network, networkId) => <NetworkSource network={network} networkId={networkId} vm={vm} hostDevices={this.hostDevices} />,
-                props: { width: 10 }
+                props: { width: 15 }
             },
             {
                 name: _("State"),
@@ -416,7 +416,7 @@ export class VmNetworkTab extends React.Component {
                         </div>
                     );
                 },
-                props: { width: 20 }
+                props: { width: 10 }
             },
         ];
 

--- a/src/components/vm/nics/vmNicsCard.jsx
+++ b/src/components/vm/nics/vmNicsCard.jsx
@@ -314,14 +314,24 @@ export class VmNetworkTab extends React.Component {
                         return _("Unknown");
                     } else {
                         return (
-                            <>
-                                {ips.inet && <div id={`${id}-network-${networkId}-ipv4-address`}>
-                                    {'inet ' + ips.inet}
-                                </div>}
-                                {ips.inet6 && <div id={`${id}-network-${networkId}-ipv6-address`}>
-                                    {'inet6 ' + ips.inet6}
-                                </div>}
-                            </>
+                            <DescriptionList isHorizontal isFluid>
+                                {ips.inet && <DescriptionListGroup>
+                                    <DescriptionListTerm>
+                                        {_("inet")}
+                                    </DescriptionListTerm>
+                                    <DescriptionListDescription id={`${id}-network-${networkId}-ipv4-address`}>
+                                        {ips.inet}
+                                    </DescriptionListDescription>
+                                </DescriptionListGroup>}
+                                {ips.inet6 && <DescriptionListGroup>
+                                    <DescriptionListTerm>
+                                        {_("inet6")}
+                                    </DescriptionListTerm>
+                                    <DescriptionListDescription id={`${id}-network-${networkId}-ipv6-address`}>
+                                        {ips.inet6}
+                                    </DescriptionListDescription>
+                                </DescriptionListGroup>}
+                            </DescriptionList>
                         );
                     }
                 },

--- a/src/machines.scss
+++ b/src/machines.scss
@@ -35,17 +35,6 @@
     font-size: inherit;
 }
 
-.machines-network-source-descr {
-    color: var(--ct-color-subtle-copy);
-    text-align: right;
-    padding: 5px 10px !important;
-}
-
-.machines-network-source-value {
-    padding: 5px 10px !important;
-    text-align: left !important;
-}
-
 .machines-listing-actions {
     display: flex;
     justify-content: flex-end;

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -163,7 +163,9 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         b.wait_visible("#vm-subVmTest1-disks-vda-action-kebab")
         b.click("#vm-subVmTest1-disks-vda-action-kebab button")
         b.wait_visible("#delete-vm-subVmTest1-disks-vda a[aria-disabled=true]")
-        b.wait_visible("#delete-vm-subVmTest1-iface-1:disabled")
+        b.wait_visible("#vm-subVmTest1-iface-1-action-kebab")
+        b.click("#vm-subVmTest1-iface-1-action-kebab button")
+        b.wait_visible("#delete-vm-subVmTest1-iface-1 a[aria-disabled=true]")
 
         # resume
         self.performAction("subVmTest1", "resume")

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -122,7 +122,8 @@ class TestMachinesLifecycle(VirtualMachinesCase):
                 ".memory-usage-chart",
                 ".vcpu-usage-chart",
                 "#vm-subVmTest1-disks .pf-c-card__body",
-                "#vm-subVmTest1-networks .pf-c-card__body"
+                "#vm-subVmTest1-networks .pf-c-card__body",
+                "#vm-subVmTest1-hostdevs",
                 ])
         b.wait_in_text("#vm-subVmTest1-cpu", "1 vCPU")
 

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -59,6 +59,7 @@ class TestMachinesNICs(VirtualMachinesCase):
 
         b.wait_in_text("#vm-subVmTest1-network-1-type", "network")
         b.wait_in_text("#vm-subVmTest1-network-1-source", "default")
+        b.wait_in_text("#vm-subVmTest1-network-1-tapdevice", "vnet0")
         b.wait_in_text("#vm-subVmTest1-network-1-ipv4-address", "192.168.122.")
         b.wait_in_text("#vm-subVmTest1-network-1-state", "up")
         b.assert_pixels("#vm-subVmTest1-networks",
@@ -72,10 +73,11 @@ class TestMachinesNICs(VirtualMachinesCase):
         self.deleteIface(1)
 
         # Test add network
-        m.execute("virsh attach-interface --domain subVmTest1 --type network --source default --model virtio --mac 52:54:00:4b:73:5f --config --live")
+        m.execute("virsh attach-interface --domain subVmTest1 --type network --source default --target vnet1 --model virtio --mac 52:54:00:4b:73:5f --config --live")
 
         b.wait_in_text("#vm-subVmTest1-network-1-type", "network")
         b.wait_in_text("#vm-subVmTest1-network-1-source", "default")
+        b.wait_in_text("#vm-subVmTest1-network-1-tapdevice", "vnet1")
         b.wait_in_text("#vm-subVmTest1-network-1-model", "virtio")
         b.wait_in_text("#vm-subVmTest1-network-1-mac", "52:54:00:4b:73:5f")
         b.wait_in_text("#vm-subVmTest1-network-1-ipv4-address", "192.168.122.")

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -224,6 +224,9 @@ class VirtualMachinesCaseHelpers:
     def deleteIface(self, iface, mac=None, vm_name=None):
         b = self.browser
 
+        b.wait_visible(f"#vm-subVmTest1-iface-{iface}-action-kebab")
+        b.click(f"#vm-subVmTest1-iface-{iface}-action-kebab button")
+        b.wait_visible(f"#delete-vm-subVmTest1-iface-{iface}")
         b.click(f"#delete-vm-subVmTest1-iface-{iface}")
         b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Remove network interface?")
         if mac and vm_name:


### PR DESCRIPTION
Network interfaces that are attached to VMs have a TAP device. Tap devices exist to facilitate virtual private networks, network tunnels...
Every virtual network interface is assigned to a TAP device, since tap device is a representation of a virtual network device on lower layers:
![Tun-tap-osilayers-diagram](https://github.com/cockpit-project/cockpit-machines/assets/42733240/4b4df46d-4de6-4590-b499-8ec60df16063)

If you want to troubleshoot the virtual network device manually, capture its packets, etc. on those lower layers, you need to know the interface name, so we should show it in the UI:

BEFORE
![Screenshot from 2023-06-22 14-53-24](https://github.com/cockpit-project/cockpit-machines/assets/42733240/6e10794c-1681-41ec-8c88-214b031a5b98)

AFTER
![Screenshot from 2023-06-26 12-43-15](https://github.com/cockpit-project/cockpit-machines/assets/42733240/10edce04-ddc0-47c2-89b2-fc177f19ec7b)

Fixes #1047

## Show virtual interface's TAP device

Network interfaces attached to VMs have a TAP device assigned, which represents the device at lower layers. Troubleshooting the virtual network device may require knowledge of the associated TAP device.

![Screenshot from 2023-06-26 12-43-15](https://github.com/cockpit-project/cockpit-machines/assets/42733240/51e1cd8c-cc08-4595-84cb-12b3052b1d6a)
