### PR TITLE
test: Allow more time for "Add disk" dialog

### DIFF
--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -673,7 +673,8 @@ class TestMachinesDisks(VirtualMachinesCase):
 
             b = self.test_obj.browser
             m = self.test_obj.machine
-            b.wait_not_present(f"#vm-{self.vm_name}-disks-adddisk-dialog-modal-window")
+            with b.wait_timeout(60):
+                b.wait_not_present(f"#vm-{self.vm_name}-disks-adddisk-dialog-modal-window")
             if self.device == "cdrom" or (self.file_path and self.file_path.endswith(".iso")) or self.expected_volume_format == "iso":
                 expected_bus_type = self.bus_type or "scsi"
                 expected_device = self.device or "cdrom"


### PR DESCRIPTION
15s is too short and times out on our CI all the time.

---

See for example [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1083-20230522-123618-567d6c95-arch/log.html) or [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1083-20230522-123616-567d6c95-rhel-9-3/log.html) log.