### PR TITLE
Don't show empty columns in vNIC table

### DIFF
--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -89,6 +89,15 @@ class TestMachinesNICs(VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-network-1-source", "virbr0")
         b.wait_in_text("#vm-subVmTest1-network-1-ipv4-address", "192.168.122.")
 
+        # Non-running VM doesn't have IP address present, so the "IP address" column should not be present
+        b.wait_visible("th:contains('IP address')")
+        b.wait_visible("#vm-subVmTest1-network-1-ipv4-address")
+        b.wait_visible("#vm-subVmTest1-network-2-ipv4-address")
+        self.performAction("subVmTest1", "forceOff")
+        b.wait_not_present("th:contains('IP address')")
+        b.wait_not_present("#vm-subVmTest1-network-1-ipv4-address")
+        b.wait_not_present("#vm-subVmTest1-network-2-ipv4-address")
+
         # Sources in  Add vNIC dialog should be alphabetically sorted
         m.execute("ip link add name abridge type bridge")
         m.execute("ip link add name 0bridge type bridge")


### PR DESCRIPTION
Just a small fix which was always bothering me. Don't show the column in Network Interfaces table when the column is empty:

### Before
![Screenshot from 2023-05-26 12-32-52](https://github.com/cockpit-project/cockpit-machines/assets/42733240/d242eccb-3632-462f-8681-f3d62a2ea7b0)

### After
![Screenshot from 2023-05-26 12-33-05](https://github.com/cockpit-project/cockpit-machines/assets/42733240/5d67944f-f3ca-413e-86a1-ce6e2a6fc8c8)
