### PR TITLE
Install into /usr/local/ by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ export TEST_OS
 TARFILE=$(RPM_NAME)-$(VERSION).tar.xz
 NODE_CACHE=$(RPM_NAME)-node-$(VERSION).tar.xz
 SPEC=$(RPM_NAME).spec
+PREFIX ?= /usr/local
 APPSTREAMFILE=org.cockpit-project.$(PACKAGE_NAME).metainfo.xml
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check for node_modules/
@@ -100,12 +101,12 @@ clean:
 	rm -f po/LINGUAS
 
 install: $(DIST_TEST) po/LINGUAS
-	mkdir -p $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)
-	cp -r dist/* $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)
-	mkdir -p $(DESTDIR)/usr/share/metainfo/
+	mkdir -p $(DESTDIR)$(PREFIX)/share/cockpit/$(PACKAGE_NAME)
+	cp -r dist/* $(DESTDIR)$(PREFIX)/share/cockpit/$(PACKAGE_NAME)
+	mkdir -p $(DESTDIR)$(PREFIX)/share/metainfo/
 	msgfmt --xml -d po \
 		--template $(APPSTREAMFILE) \
-		-o $(DESTDIR)/usr/share/metainfo/$(APPSTREAMFILE)
+		-o $(DESTDIR)$(PREFIX)/share/metainfo/$(APPSTREAMFILE)
 
 # this requires a built source tree and avoids having to install anything system-wide
 devel-install: $(DIST_TEST)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ make
 
 # Installing
 
-`sudo make install` installs the package in `/usr/share/cockpit/`. This depends
+`sudo make install` installs the package in `/usr/local/share/cockpit/`. This depends
 on the `dist` target, which generates the distribution tarball.
 
 You can also run `make rpm` to build RPMs for local installation.

--- a/packaging/arch/PKGBUILD.in
+++ b/packaging/arch/PKGBUILD.in
@@ -12,5 +12,5 @@ sha256sums=('SKIP')
 
 package() {
   cd $pkgname
-  make DESTDIR="$pkgdir" install
+  make DESTDIR="$pkgdir" install PREFIX=/usr
 }

--- a/packaging/cockpit-machines.spec.in
+++ b/packaging/cockpit-machines.spec.in
@@ -79,7 +79,7 @@ If "virt-install" is installed, you can also create new virtual machines.
 # Nothing to build
 
 %install
-%make_install
+%make_install PREFIX=/usr
 appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/metainfo/*
 
 %files

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -8,3 +8,6 @@ override_dh_auto_clean:
 
 override_dh_auto_test:
 	# don't call `make check`, these are integration tests
+
+override_dh_auto_install:
+	make install DESTDIR=debian/cockpit-machines PREFIX=/usr


### PR DESCRIPTION
/usr is package manager territory, and not even writable on OSTree based systems such as Fedora CoreOS or RHEL Edge. This has been common and good practice in autotools for decades.

You can still override this with `make install PREFIX=...`. Use that in the RPM spec file.

Cherry-picked from https://github.com/cockpit-project/starter-kit/commit/57d7c73d6e32