### PR TITLE
Add manifest conditions

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,6 +3,9 @@
   "requires": {
        "cockpit": "215"
   },
+  "conditions": [
+      {"path-exists": "/usr/share/dbus-1/system.d/org.libvirt.conf"}
+  ],
   "menu": {
      "vms": {
         "label": "Virtual machines",

--- a/test/check-machines-manifest
+++ b/test/check-machines-manifest
@@ -1,0 +1,50 @@
+#!/usr/bin/python3
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+
+# import Cockpit's machinery for test VMs and its browser test API
+TEST_DIR = os.path.dirname(__file__)
+sys.path.append(os.path.join(TEST_DIR, "common"))
+sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
+
+from testlib import MachineCase, nondestructive, test_main  # noqa
+
+
+@nondestructive
+class TestMachinesManifest(MachineCase):
+
+    def testBasic(self):
+        b = self.browser
+        m = self.machine
+
+        self.restore_file("/usr/share/dbus-1/system.d/org.libvirt.conf")
+        m.execute("rm /usr/share/dbus-1/system.d/org.libvirt.conf")
+        self.login_and_go(None)
+        b.wait_in_text("#host-apps .pf-m-current", "Overview")
+
+        if self.is_pybridge():
+            self.assertIn("Machines", b.text("#host-apps .pf-m-current"))
+        else:
+            self.assertNotIn("Machines", b.text("#host-apps .pf-m-current"))
+
+
+if __name__ == '__main__':
+    test_main()


### PR DESCRIPTION
Only enable the machines page when the libvirt-dbus service is installed.

See https://github.com/cockpit-project/cockpit/issues/18935