### PR TITLE
test: Move pixel test references to Fedora 38

### DIFF
--- a/test/reference-image
+++ b/test/reference-image
@@ -1,1 +1,1 @@
-fedora-37
+fedora-38


### PR DESCRIPTION
This also updates them for Chromium 114, see https://github.com/cockpit-project/cockpituous/pull/551