### PR TITLE
workflows: Move npm-update back to Ubuntu 20.04

### DIFF
--- a/.github/workflows/npm-update-pf.yml
+++ b/.github/workflows/npm-update-pf.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v3

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Similarly to reposchutz in Cockpit (commit 269bf89276c6), the npm-update* workflows pipeline large tar archives, which is broken in Ubuntu 22.04's version.

npm-update works here, but npm-update-pf fails https://github.com/cockpit-project/cockpit-machines/actions/runs/5307247859/jobs/9605610658