### PR TITLE
Don't allow watchdog/vsock editing on transient VM

### DIFF
--- a/src/components/vm/overview/vsock.jsx
+++ b/src/components/vm/overview/vsock.jsx
@@ -27,6 +27,7 @@ import { NumberInput } from "@patternfly/react-core/dist/esm/components/NumberIn
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
 import { HelpIcon } from '@patternfly/react-icons';
+import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip";
 import { useDialogs } from 'dialogs.jsx';
 import { fmt_to_fragments } from 'utils.jsx';
 

--- a/src/components/vm/overview/vsock.jsx
+++ b/src/components/vm/overview/vsock.jsx
@@ -183,6 +183,29 @@ export const VsockModal = ({ vm, vms, vmVsockNormalized, isVsockAttached, idPref
         </Form>
     );
 
+    // Transient VM doesn't have offline config
+    // Libvirt doesn't allow live editing vsock, so we should disallow such operation
+    // Similar to https://bugzilla.redhat.com/show_bug.cgi?id=2213740
+    const isEditingTransientVm = isVsockAttached && !vm.persistent;
+    let primaryButton = (
+        <Button variant='primary'
+            id="vsock-dialog-apply"
+            onClick={save}
+            isLoading={actionInProgress == "save"}
+            isAriaDisabled={actionInProgress || isEditingTransientVm}>
+            {isVsockAttached ? _("Save") : _("Add")}
+        </Button>
+    );
+
+    if (isEditingTransientVm) {
+        primaryButton = (
+            <Tooltip id='vsock-live-edit-tooltip'
+                content={_("Cannot edit vsock device on a transient VM")}>
+                {primaryButton}
+            </Tooltip>
+        );
+    }
+
     return (
         <Modal id={`${idPrefix}-vsock-modal`}
                position="top"
@@ -208,13 +231,7 @@ export const VsockModal = ({ vm, vms, vmVsockNormalized, isVsockAttached, idPref
                isOpen
                footer={
                    <>
-                       <Button variant='primary'
-                               id="vsock-dialog-apply"
-                               onClick={save}
-                               isLoading={actionInProgress == "save"}
-                               isDisabled={actionInProgress}>
-                           {isVsockAttached ? _("Save") : _("Add")}
-                       </Button>
+                       {primaryButton}
                        {isVsockAttached &&
                        <Button variant='secondary'
                                id="vsock-dialog-detach"

--- a/src/components/vm/overview/watchdog.jsx
+++ b/src/components/vm/overview/watchdog.jsx
@@ -94,7 +94,7 @@ export const WatchdogModal = ({ vm, isWatchdogAttached, idPrefix }) => {
             hotplug: true,
             isWatchdogAttached,
         })
-                .then(vm.persistent ? setWatchdogColdplug : Promise.resolve)
+                .then(vm.persistent ? setWatchdogColdplug : Dialogs.close())
                 .catch(exc => {
                     if (vm.persistent)
                         setOfferColdplug(true);

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -849,16 +849,28 @@ class TestMachinesSettings(VirtualMachinesCase):
         setVsock(auto=False, address="5", pixel_test_tag="vsock")
         removeVsockDevice()
 
+        b.click("#vm-subVmTest1-system-run")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
+
         # Because of bug in debian-testing, hotplug of vsock device fails
         # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1033872
         if m.image not in ["debian-testing", "debian-stable"]:
-            b.click("#vm-subVmTest1-system-run")
-            b.wait_in_text("#vm-subVmTest1-system-state", "Running")
-
             # Test configuring vsock for running VM
             setVsockLive(new_auto=False, new_address="5")
             setVsockLive(new_auto=True, previous_auto=False, previous_address="5", reboot_machine=True)
             setVsockLive(new_auto=False, new_address="4", previous_auto=True, previous_address=default_libvirt_vsock_address)
+
+            m.execute("virsh undefine subVmTest1")
+            wait(lambda: "no" in m.execute("virsh dominfo subVmTest1 | grep ^Persistent"), delay=3)
+            # UI was notified that VM is transient
+            b.wait_visible("#vm-subVmTest1-memory-count button[aria-disabled=true]")
+
+            # Vsock of transient VM should not be editable
+            b.click("#vm-subVmTest1-vsock-button")
+            b.wait_visible("#vm-subVmTest1-vsock-modal")
+            b.wait_visible("#vsock-dialog-apply[aria-disabled=true]")
+            b.mouse("#vsock-dialog-apply", "mouseenter")
+            b.wait_visible("#vsock-live-edit-tooltip")
 
 
 if __name__ == '__main__':

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -652,6 +652,7 @@ class TestMachinesSettings(VirtualMachinesCase):
             self.assertIn("Unknown --controller options", m.execute(
                 "! virt-xml subVmTest1 --edit model=pci-root --controller target.hotplug=off 2>&1")
             )
+            m.execute("virsh start subVmTest1")
         else:
             # Disable hotplugging for subVmTest1
             m.execute("virt-xml subVmTest1 --edit model=pci-root --controller target.hotplug=off")
@@ -665,7 +666,7 @@ class TestMachinesSettings(VirtualMachinesCase):
             b.click("#reset")
             b.click("#watchdog-dialog-apply")
             b.wait_in_text("#vm-subVmTest1-watchdog-modal .pf-m-warning", "Could not dynamically add watchdog")
-            b.wait_visible("#watchdog-dialog-apply:disabled")
+            b.wait_visible("#watchdog-dialog-apply[aria-disabled=true]")
             # Apply coldplug
             closeWatchDogDialog("#watchdog-dialog-apply-next-boot")
             # Watchdog requires fresh boot
@@ -691,6 +692,13 @@ class TestMachinesSettings(VirtualMachinesCase):
         b.click("#watchdog-dialog-apply")
         b.wait_not_present("#vm-subVmTest2-watchdog-modal")
         b.wait_in_text("#vm-subVmTest2-watchdog-state", action_strings["pause"])
+
+        # Watchdog of transient VM should not be editable
+        b.click("#vm-subVmTest2-watchdog-button")
+        b.wait_visible("#vm-subVmTest2-watchdog-modal")
+        b.wait_visible("#watchdog-dialog-apply[aria-disabled=true]")
+        b.mouse("#watchdog-dialog-apply", "mouseenter")
+        b.wait_visible("#watchdog-live-edit-tooltip")
 
     def testVsock(self):
         b = self.browser

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -675,6 +675,23 @@ class TestMachinesSettings(VirtualMachinesCase):
             m.execute("virsh destroy subVmTest1; virsh start subVmTest1")
             b.wait_not_present("#watchdog-tooltip")
 
+        args = self.createVm("subVmTest2")
+        self.goToMainPage()
+        self.waitPageInit()
+        self.goToVmPage("subVmTest2")
+        m.execute("virsh undefine subVmTest2")
+        wait(lambda: "no" in m.execute("virsh dominfo subVmTest2 | grep ^Persistent"), delay=3)
+        # UI was notified that VM is transient
+        b.wait_visible("#vm-subVmTest2-memory-count button[aria-disabled=true]")
+
+        # Watchdog can be attached to a transient VM
+        b.click("#vm-subVmTest2-watchdog-button")
+        b.wait_visible("#vm-subVmTest2-watchdog-modal")
+        b.click("#pause")
+        b.click("#watchdog-dialog-apply")
+        b.wait_not_present("#vm-subVmTest2-watchdog-modal")
+        b.wait_in_text("#vm-subVmTest2-watchdog-state", action_strings["pause"])
+
     def testVsock(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Libvirt doesn't allow live-editing watchdog and vsock device. Transient is a VM which only has a live configuration. Editing such device on such VM therefore doesn't make sense and would result in an exception, see https://bugzilla.redhat.com/show_bug.cgi?id=2213740