### PR TITLE
Cores should equal to number of vCPUs if no topology is specified

### DIFF
--- a/src/components/vm/overview/cpuModal.jsx
+++ b/src/components/vm/overview/cpuModal.jsx
@@ -60,11 +60,11 @@ export const CPUModal = ({ vm, maxVcpu, models }) => {
     const Dialogs = useDialogs();
 
     const [error, setError] = useState(undefined);
-    const [sockets, setSockets] = useState(vm.cpu.topology.sockets || 1);
-    const [threads, setThreads] = useState(vm.cpu.topology.threads || 1);
-    const [cores, setCores] = useState(vm.cpu.topology.cores || 1);
     const [max, setMax] = useState(parseInt(vm.vcpus.max) || 1);
     const [count, setCount] = useState(parseInt(vm.vcpus.count) || 1);
+    const [sockets, setSockets] = useState(vm.cpu.topology.sockets || 1);
+    const [threads, setThreads] = useState(vm.cpu.topology.threads || 1);
+    const [cores, setCores] = useState(vm.cpu.topology.cores || max);
     const [cpuMode, setCpuMode] = useState(vm.cpu.mode);
     const [cpuModel, setCpuModel] = useState(vm.cpu.model);
     const [isLoading, setIsLoading] = useState(false);

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -45,12 +45,15 @@ class TestMachinesSettings(VirtualMachinesCase):
         b = self.browser
         m = self.machine
 
-        self.createVm("subVmTest1")
+        self.createVm("subVmTest1", running=False)
 
         self.login_and_go("/machines")
         self.waitPageInit()
         self.waitVmRow("subVmTest1")
 
+        m.execute("virt-xml subVmTest1 -c qemu:///system --vcpu 2 --edit")
+
+        b.click("#vm-subVmTest1-system-run")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
 
@@ -59,8 +62,11 @@ class TestMachinesSettings(VirtualMachinesCase):
         b.wait_visible("#machines-cpu-modal-dialog")
 
         # Test basic vCPU properties
-        b.wait_val("#machines-vcpu-count-field input", "1")
-        b.wait_val("#machines-vcpu-max-field input", "1")
+        b.wait_val("#machines-vcpu-count-field input", "2")
+        b.wait_val("#machines-vcpu-max-field input", "2")
+        b.wait_val("#socketsSelect", "1")
+        b.wait_val("#coresSelect", "2")
+        b.wait_val("#threadsSelect", "1")
 
         # Set new values
         b.set_input_text("#machines-vcpu-max-field input", "4")


### PR DESCRIPTION
Sometimes VMs can have no topology specified in their XML (e.g. when a new VM is created). In such cases, libvirt automatically assigns a topology where a number of cores is equal to a number of vcpus. We should mimic that in our UI

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2213064