### PR TITLE
Fix reboot confirmation dialog handlers

### DIFF
--- a/src/components/vm/vmActions.jsx
+++ b/src/components/vm/vmActions.jsx
@@ -334,7 +334,7 @@ const VmActions = ({ vm, onAddErrorNotification, isDetailsPage }) => {
                                   actionsList={[
                                       {
                                           variant: "primary",
-                                          handler: onReboot(vm),
+                                          handler: () => onReboot(vm),
                                           name: _("Reboot"),
                                           id: "reboot",
                                       },
@@ -354,7 +354,7 @@ const VmActions = ({ vm, onAddErrorNotification, isDetailsPage }) => {
                                   actionsList={[
                                       {
                                           variant: "primary",
-                                          handler: onForceReboot(vm),
+                                          handler: () => onForceReboot(vm),
                                           name: _("Force reboot"),
                                           id: "forceReboot",
                                       },


### PR DESCRIPTION
VM should not reboot when confirmation dialog is opened. Also add some tests which check VM logs for a bootup time.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2221144