### PR TITLE
test: Update our https server setup

### DIFF
--- a/test/files/mock-range-server.py
+++ b/test/files/mock-range-server.py
@@ -85,6 +85,10 @@ class RangeHTTPRequestHandler(SimpleHTTPRequestHandler):
 
 
 if __name__ == '__main__':
-    httpd = HTTPServer(('localhost', 443), RangeHTTPRequestHandler)
-    httpd.socket = ssl.wrap_socket(httpd.socket, certfile=sys.argv[1], keyfile=sys.argv[2], server_side=True)
-    httpd.serve_forever()
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(certfile=sys.argv[1], keyfile=sys.argv[2])
+    context.check_hostname = False
+
+    with HTTPServer(("localhost", 443), RangeHTTPRequestHandler) as httpd:
+        httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
+        httpd.serve_forever()


### PR DESCRIPTION
Ever since python 3.12, ssl library got rid of already deprecated ssl.wrap_socket and instead replaced it with context.wrap_socket This required few changes to how we setup our http server. 

This should stop breaking fedora-rawhide test:

```
> error: spawn 'vm creation' returned error: "{"problem":null,"exit_status":1,"exit_signal":null,"message":"ERROR    internal error: process exited while connecting to monitor: 2023-07-18T08:24:43.721525Z qemu-system-x86_64: -blockdev {\"driver\":\"https\",\"url\":\"https://archive.fedoraproject.org:443/pub/archive/fedora/linux/releases/28/Server/x86_64/os/images/boot.iso\",\"node-name\":\"libvirt-1-storage\",\"auto-read-only\":true,\"discard\":\"unmap\"}: CURL: Error opening file: Failed to connect to archive.fedoraproject.org port 443 after 0 ms: Couldn't connect to server\nDomain installation does not appear to have been successful.\nIf it was, you can restart your domain by running:\n  virsh --connect qemu:///system start subVmTestCreate7\notherwise, please restart your installation.\nTraceback (most recent call last):\n  File \"<stdin>\", line 352, in <module>\n  File \"<stdin>\", line 254, in create_vm\n  File \"/usr/lib64/python3.12/subprocess.py\", line 466, in check_output\n    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/lib64/python3.12/subprocess.py\", line 571, in run\n    raise CalledProcessError(retcode, process.args,\nsubprocess.CalledProcessError: Command '['virt-install', '--connect', 'qemu:///system', '--quiet', '--os-variant', 'fedora28', '--memory', '128', '--name', 'subVmTestCreate7', '--check', 'path_in_use=off', '--wait', '-1', '--noautoconsole', '--disk', 'none', '--graphics', 'vnc,listen=127.0.0.1', '--graphics', 'spice,listen=::1', '--cdrom', 'https://archive.fedoraproject.org/pub/archive/fedora/linux/releases/28/Server/x86_64/os/images/boot.iso']' returned non-zero exit status 1."}"
Traceback (most recent call last):
  File "/var/ARTIFACTS/work-basicri3r_pbj/plans/all/basic/discover/default-0/tests/test/check-machines-create", line 725, in testCreateUrlSource
    runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='url',
  File "/var/ARTIFACTS/work-basicri3r_pbj/plans/all/basic/discover/default-0/tests/test/check-machines-create", line 1721, in createTest
    self._tryCreate(dialog) \
    ^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/ARTIFACTS/work-basicri3r_pbj/plans/all/basic/discover/default-0/tests/test/check-machines-create", line 1515, in _tryCreate
    self._create(dialog)
  File "/var/ARTIFACTS/work-basicri3r_pbj/plans/all/basic/discover/default-0/tests/test/check-machines-create", line 1507, in _create
    b.wait_text(f"#vm-{dialog.name}-{dialog.connection}-state",
  File "/var/ARTIFACTS/work-basicri3r_pbj/plans/all/basic/discover/default-0/tests/test/common/testlib.py", line 660, in wait_text
    self.wait_js_cond("ph_text_is(%s,%s)" % (jsquote(selector), jsquote(text)),
  File "/var/ARTIFACTS/work-basicri3r_pbj/plans/all/basic/discover/default-0/tests/test/common/testlib.py", line 587, in wait_js_cond
    self.raise_cdp_exception("timeout\nwait_js_cond", cond, result["exceptionDetails"], trailer)
  File "/var/ARTIFACTS/work-basicri3r_pbj/plans/all/basic/discover/default-0/tests/test/common/testlib.py", line 293, in raise_cdp_exception
    raise Error("%s(%s): %s" % (func, arg, msg))
testlib.Error: timeout
wait_js_cond(ph_text_is("#vm-subVmTestCreate7-system-state","Running")): #vm-subVmTestCreate7-system-state not found
```