### PR TITLE
Different domain's network interfaces will have different IP addresses

### DIFF
--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -866,9 +866,27 @@ export function domainInsertDisk({
 
 export function domainInterfaceAddresses({ connectionName, objPath }) {
     return Promise.allSettled([
-        call(connectionName, objPath, 'org.libvirt.Domain', 'InterfaceAddresses', [Enum.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_LEASE, 0], { timeout, type: 'uu' }),
-        call(connectionName, objPath, 'org.libvirt.Domain', 'InterfaceAddresses', [Enum.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_ARP, 0], { timeout, type: 'uu' }),
+        call(connectionName, objPath, 'org.libvirt.Domain', 'InterfaceAddresses', [Enum.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_LEASE, 0], { timeout, type: 'uu' })
+                .then(res => {
+                    return {
+                        source: 'lease',
+                        ...res
+                    };
+                }),
+        call(connectionName, objPath, 'org.libvirt.Domain', 'InterfaceAddresses', [Enum.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_ARP, 0], { timeout, type: 'uu' })
+                .then(res => {
+                    return {
+                        source: 'arp',
+                        ...res
+                    };
+                }),
         call(connectionName, objPath, 'org.libvirt.Domain', 'InterfaceAddresses', [Enum.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_AGENT, 0], { timeout, type: 'uu' })
+                .then(res => {
+                    return {
+                        source: 'agent',
+                        ...res
+                    };
+                }),
     ]);
 }
 

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -73,7 +73,6 @@ class TestMachinesNICs(VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-network-1-tapdevice", "vnet1")
         b.wait_in_text("#vm-subVmTest1-network-1-model", "virtio")
         b.wait_in_text("#vm-subVmTest1-network-1-mac", "52:54:00:4b:73:5f")
-        b.wait_in_text("#vm-subVmTest1-network-1-ipv4-address", "192.168.122.")
         b.wait_in_text("#vm-subVmTest1-network-1-state", "up")
 
         # Test bridge network
@@ -82,16 +81,11 @@ class TestMachinesNICs(VirtualMachinesCase):
         # vNICs are alphabetically sorted by MAC address, so now the new vNIC is first in the list
         b.wait_in_text("#vm-subVmTest1-network-1-type", "bridge")
         b.wait_in_text("#vm-subVmTest1-network-1-source", "virbr0")
-        b.wait_in_text("#vm-subVmTest1-network-1-ipv4-address", "192.168.122.")
 
         # Non-running VM doesn't have IP address present, so the "IP address" column should not be present
         b.wait_visible("th:contains('IP address')")
-        b.wait_visible("#vm-subVmTest1-network-1-ipv4-address")
-        b.wait_visible("#vm-subVmTest1-network-2-ipv4-address")
         self.performAction("subVmTest1", "forceOff")
         b.wait_not_present("th:contains('IP address')")
-        b.wait_not_present("#vm-subVmTest1-network-1-ipv4-address")
-        b.wait_not_present("#vm-subVmTest1-network-2-ipv4-address")
 
         # Sources in  Add vNIC dialog should be alphabetically sorted
         m.execute("ip link add name abridge type bridge")

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -125,6 +125,19 @@ class TestMachinesNICs(VirtualMachinesCase):
                         # With medium layout this variable width of the columns makes pixel tests references of the table different each test run
                         skip_layouts=["medium", "rtl"])
 
+        # Start vm and wait until kernel is booted
+        wait(lambda: "1" in self.machine.execute("virsh domifaddr subVmTest1 | grep 192.168.122. | wc -l"), delay=3)
+        b.reload()
+        b.enter_page('/machines')
+        self.waitPageInit()
+
+        # Check interfaces have different IP addresses
+        # This tests a fix for a bug[1] where we used to show same IP address for every interface
+        # https://github.com/cockpit-project/cockpit-machines/issues/1142
+        b.wait_visible("#vm-subVmTest1-network-1-ip-unknown")
+        b.wait_in_text("#vm-subVmTest1-network-2-ipv4-address", "192.168.122.")
+        b.wait_visible("#vm-subVmTest1-network-3-ip-unknown")
+
     def testNICPlugingAndUnpluging(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Different domain's network interfaces will have different IP addresses

Until now, we would just take the output of domInterfaceAddresses, find the first valid IP address and show it next to an interface. This however doesn't take into account the fact that different network interfaces may and will have different IP addresses. Therefore we should assign correct IP address to a domain's interface based on an association with it's MAC address
    
Fixes #1142
Fixes #729