### PR TITLE
build.js: support flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ $(DIST_TEST): $(COCKPIT_REPO_STAMP) $(shell find src/ -type f) package.json buil
 	$(MAKE) package-lock.json && NODE_ENV=$(NODE_ENV) ./build.js
 
 watch: $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP)
-	NODE_ENV=$(NODE_ENV) ESBUILD_WATCH=true ./build.js
+	NODE_ENV=$(NODE_ENV) ./build.js -w
 
 clean:
 	rm -rf dist/

--- a/build.js
+++ b/build.js
@@ -19,15 +19,21 @@ const useWasm = os.arch() !== 'x64';
 const esbuild = (await import(useWasm ? 'esbuild-wasm' : 'esbuild'));
 
 const production = process.env.NODE_ENV === 'production';
-const watchMode = process.env.ESBUILD_WATCH === "true" || false;
 // linters dominate the build time, so disable them for production builds by default, but enable in watch mode
-const lint = process.env.LINT ? (process.env.LINT !== '0') : (watchMode || !production);
+const lintDefault = process.env.LINT ? process.env.LINT === '0' : production;
 /* List of directories to use when resolving import statements */
 const nodePaths = ['pkg/lib'];
 const outdir = 'dist';
 
 // Obtain package name from package.json
 const packageJson = JSON.parse(fs.readFileSync('package.json'));
+
+const parser = (await import('argparse')).default.ArgumentParser();
+parser.add_argument('-r', '--rsync', { help: "rsync bundles to ssh target after build", metavar: "HOST" });
+parser.add_argument('-w', '--watch', { action: 'store_true', help: "Enable watch mode", default: process.env.ESBUILD_WATCH === "true" });
+parser.add_argument('-e', '--no-eslint', { action: 'store_true', help: "Disable eslint linting", default: lintDefault });
+parser.add_argument('-s', '--no-stylelint', { action: 'store_true', help: "Disable stylelint linting", default: lintDefault });
+const args = parser.parse_args();
 
 function notifyEndPlugin() {
     return {
@@ -89,12 +95,8 @@ const context = await esbuild.context({
     target: ['es2020'],
     plugins: [
         cleanPlugin(),
-        ...lint
-            ? [
-                stylelintPlugin({ filter: new RegExp(cwd + '/src/.*\\.(css?|scss?)$') }),
-                eslintPlugin({ filter: new RegExp(cwd + '/src/.*\\.(jsx?|js?)$') })
-            ]
-            : [],
+        ...args.no_stylelint ? [] : [stylelintPlugin({ filter: new RegExp(cwd + '/src/.*\\.(css?|scss?)$') })],
+        ...args.no_eslint ? [] : [eslintPlugin({ filter: new RegExp(cwd + '/src/.*\\.(jsx?|js?)$') })],
         // Esbuild will only copy assets that are explicitly imported and used
         // in the code. This is a problem for index.html and manifest.json which are not imported
         copy({
@@ -134,12 +136,12 @@ const context = await esbuild.context({
 try {
     await context.rebuild();
 } catch (e) {
-    if (!watchMode)
+    if (!args.watch)
         process.exit(1);
     // ignore errors in watch mode
 }
 
-if (watchMode) {
+if (args.watch) {
     const on_change = async path => {
         console.log("change detected:", path);
         await context.cancel();

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "LGPL-2.1",
   "scripts": {
-    "watch": "ESBUILD_WATCH='true' ./build.js",
+    "watch": "./build.js -w",
     "build": "./build.js",
     "eslint": "eslint --ext .jsx --ext .js src/",
     "eslint:fix": "eslint --fix --ext .jsx --ext .js src/",


### PR DESCRIPTION
Adds flags to build.js to use rsync, disable linting and use watch mode.