### PR TITLE
test: Don't wait for VM to boot when only asserting uptime value

### DIFF
--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -235,7 +235,6 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         b.click(".pf-v5-c-modal-box__footer button:contains(Reboot)")
         b.wait_not_present("#vm-subVmTest2-system-confirm-action-modal")
         b.wait_in_text("#vm-subVmTest2-system-state", "Running")
-        self.waitCirrOSBooted(args2['logfile'])
 
         # Check uptime
         b.click("#vm-subVmTest2-system-shutdown-button")


### PR DESCRIPTION

    This fixes a flake where sometimes the value on the reference picture
    says that uptime is "1 minute" instead of expected "less than a minute".
    The reason why this race condition exists is that we after starting up
    the VM, we wait for booting up to finish `waitCirrOSBooted`. This however
    sometimes may take more than a minute.
    
    Fortunately, waiting for VM to boot here is unecessary, since we don't
    really do anything with the VM where we expect the OS to be responsive,
    so we can remote the wait which should eliminate the race condition.

