### PR TITLE
fmf: Don't disable SELinux message check globally

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -24,7 +24,7 @@ jobs:
     - fedora-development
     - centos-stream-8
     - centos-stream-9
-  
+
   - job: tests
     trigger: pull_request
     targets:

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -87,7 +87,7 @@ if [ "$ID" = fedora ]; then
 fi
 
 # Run tests as unprivileged user
-su - -c "env TEST_BROWSER=firefox SOURCE=$SOURCE LOGS=$LOGS $TESTS/run-test.sh $PLAN" runtest
+su - -c "env TEST_AUDIT_NO_SELINUX=${TEST_AUDIT_NO_SELINUX:-} TEST_BROWSER=firefox SOURCE=$SOURCE LOGS=$LOGS $TESTS/run-test.sh $PLAN" runtest
 
 RC=$(cat $LOGS/exitcode)
 exit ${RC:-1}

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -24,8 +24,6 @@ if [ "${TEST_OS#centos-}" != "$TEST_OS" ]; then
     TEST_OS="${TEST_OS}-stream"
 fi
 
-export TEST_AUDIT_NO_SELINUX=1
-
 #
 # exclude known-broken tests
 #


### PR DESCRIPTION
It's useful to run cockpit-machines tests to gate changes to selinux-policy. But we can only do that if we actually pay attention to its messages.

The point of this is to not break cockpit-machines tests when they run as gating for other packages in Fedora/RHEL. But let's rather do that in the downstream dist-git test plan. We can inject an environment variable there [1], so just pass it on from the top-level entry point browser.sh to run-test.sh.

[1] https://tmt.readthedocs.io/en/latest/spec/tests.html#environment

---

I'll apply this to starter-kit and friends, too, but first wanted to see if it even passes.