### PR TITLE
Replace deprecated font redhat--monospace with basic PF's monospace

### DIFF
--- a/src/machines.scss
+++ b/src/machines.scss
@@ -81,7 +81,7 @@
 }
 
 .ct-monospace {
-    font-family: var(--pf-v5-global--FontFamily--redhat--monospace);
+    font-family: var(--pf-v5-global--FontFamily--monospace);
 }
 
 // Do not add a box-shadow to a "subsection", while it's technically correct it looks weird.

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -302,6 +302,7 @@ class TestMachinesDisks(VirtualMachinesCase):
             pool_name=None, volume_name=None,
             file_path=None,
             force=False,
+            pixel_tag=None,
         ):
             self.test_obj = test_obj
             self.mode = mode
@@ -311,6 +312,7 @@ class TestMachinesDisks(VirtualMachinesCase):
             self.volume_name = volume_name
             self.target = target
             self.force = force
+            self.pixel_tag = pixel_tag
 
         def _get_disks(self):
             m = self.test_obj.machine
@@ -402,6 +404,9 @@ class TestMachinesDisks(VirtualMachinesCase):
             b = self.test_obj.browser
             b.click(f"#vm-{self.vm_name}-disks-{self.target}-eject-button")  # button
             b.wait_in_text(".pf-v5-c-modal-box__title", "Eject disc from VM")
+
+            if self.pixel_tag:
+                b.assert_pixels(".pf-v5-c-modal-box", self.pixel_tag)
 
             if self.mode == "custom-path":
                 b.wait_in_text(f"#vm-{self.vm_name}-disks-{self.target}-modal-description-file", self.file_path)
@@ -1632,6 +1637,7 @@ class TestMachinesDisks(VirtualMachinesCase):
             mode='custom-path',
             target='sda',
             file_path='/var/lib/libvirt/novell.iso',
+            pixel_tag='vm-disc-eject-modal',
         ).execute()
 
         self.VMInsertMediaDialog(


### PR DESCRIPTION
PF dropped pf-v5-global--FontFamily--redhat--monospace since patternfly/patternfly@4ec21e34fc3

Example (see "Disk identifier")
![Screenshot from 2023-08-14 14-59-49](https://github.com/cockpit-project/cockpit-machines/assets/42733240/26c79e82-b0ff-46b2-8465-2348b339595a)
