### PR TITLE
packaging: Remove po/LINGUAS during package cleaning

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -5,6 +5,7 @@
 
 override_dh_auto_clean:
 	# don't call `make clean`, in a release dist/ is precious
+	rm -f po/LINGUAS
 
 override_dh_auto_test:
 	# don't call `make check`, these are integration tests


### PR DESCRIPTION
This would normally be done during `make clean`, but that is deliberately skipped. Remove LINGUAS to avoid an unclean source after a binary package build.

https://bugs.debian.org/1043775