### PR TITLE
fmf: Plumb through $TEST_* variables for unexpected messages

### DIFF
--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -3,6 +3,10 @@ discover:
 execute:
     how: tmt
 
+# Let's handle them upstream only, don't break Fedora/RHEL reverse dependency gating
+environment:
+    TEST_AUDIT_NO_SELINUX: 1
+
 /basic:
     summary: Run basic tests (creation and lifetime)
     discover+:

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -5,12 +5,7 @@ set -eux
 PLAN="$1"
 
 TESTS="$(realpath $(dirname "$0"))"
-if [ -d source ]; then
-    # path for standard-test-source
-    SOURCE="$(pwd)/source"
-else
-    SOURCE="$(realpath $TESTS/../..)"
-fi
+SOURCE="$(realpath $TESTS/../..)"
 
 # https://tmt.readthedocs.io/en/stable/overview.html#variables
 LOGS="${TMT_TEST_DATA:-$(pwd)/logs}"

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -4,11 +4,13 @@ set -eux
 # like "basic", passed on to run-test.sh
 PLAN="$1"
 
+export TEST_BROWSER=${TEST_BROWSER:-firefox}
+
 TESTS="$(realpath $(dirname "$0"))"
-SOURCE="$(realpath $TESTS/../..)"
+export SOURCE="$(realpath $TESTS/../..)"
 
 # https://tmt.readthedocs.io/en/stable/overview.html#variables
-LOGS="${TMT_TEST_DATA:-$(pwd)/logs}"
+export LOGS="${TMT_TEST_DATA:-$(pwd)/logs}"
 mkdir -p "$LOGS"
 chmod a+w "$LOGS"
 
@@ -82,7 +84,9 @@ if [ "$ID" = fedora ]; then
 fi
 
 # Run tests as unprivileged user
-su - -c "env TEST_AUDIT_NO_SELINUX=${TEST_AUDIT_NO_SELINUX:-} TEST_BROWSER=firefox SOURCE=$SOURCE LOGS=$LOGS $TESTS/run-test.sh $PLAN" runtest
+# once we drop support for RHEL 8, use this:
+# runuser -u runtest --whitelist-environment=TEST_BROWSER,TEST_ALLOW_JOURNAL_MESSAGES,TEST_AUDIT_NO_SELINUX,SOURCE,LOGS $TESTS/run-test.sh $PLAN
+runuser -u runtest --preserve-environment env USER=runtest HOME=$(getent passwd runtest | cut -f6 -d:) $TESTS/run-test.sh $PLAN
 
 RC=$(cat $LOGS/exitcode)
 exit ${RC:-1}

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -114,6 +114,10 @@ for t in $EXCLUDES; do
     exclude_options="$exclude_options --exclude $t"
 done
 
+# make it easy to check in logs
+echo "TEST_ALLOW_JOURNAL_MESSAGES: ${TEST_ALLOW_JOURNAL_MESSAGES:-}"
+echo "TEST_AUDIT_NO_SELINUX: ${TEST_AUDIT_NO_SELINUX:-}"
+
 # execute run-tests
 RC=0
 test/common/run-tests --nondestructive $exclude_options \


### PR DESCRIPTION
This will allow us to control the value from test plans, in particular
for disabling at least some unexpected message checks for reverse
dependency testing. We don't want to disable unexpected messages
in general for fmf, as we are looking for exactly these in e.g.
selinux-policy reverse dependency tests.

Move from `su` to `runtest`, as with the former it's impossible to plumb
through variables with non-trivial characters, as they cannot be quoted.

Taken from https://github.com/cockpit-project/cockpit-podman/commit/c38692fa4ce66