### PR TITLE
test: Update our RHSM server setup

### DIFF
--- a/test/files/mock-rhsm-rest
+++ b/test/files/mock-rhsm-rest
@@ -62,6 +62,10 @@ class handler(BaseHTTPRequestHandler):
 
 
 if __name__ == '__main__':
-    httpd = HTTPServer(('', 443), handler)
-    httpd.socket = ssl.wrap_socket(httpd.socket, certfile=sys.argv[1], keyfile=sys.argv[2], server_side=True)
-    httpd.serve_forever()
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(certfile=sys.argv[1], keyfile=sys.argv[2])
+    context.check_hostname = False
+
+    with HTTPServer(("localhost", 443), handler) as httpd:
+        httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
+        httpd.serve_forever()


### PR DESCRIPTION
Ever since python 3.12, ssl library got rid of already deprecated ssl.wrap_socket and instead replaced it with context.wrap_socket This required few changes to how we setup our http server. This should fix fedora-39's testCreateDownloadRhel