### PR TITLE
.github: update how to check out bots

### DIFF
--- a/.github/workflows/npm-update-pf.yml
+++ b/.github/workflows/npm-update-pf.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Run npm-update bot
         run: |
-          make test/common/make-bots tools/node-modules
+          make tools/node-modules
           test/common/make-bots
           git config --global user.name "GitHub Workflow"
           git config --global user.email "cockpituous@cockpit-project.org"

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Run npm-update bot
         run: |
-          make test/common/make-bots tools/node-modules
+          make tools/node-modules
           test/common/make-bots
           git config --global user.name "GitHub Workflow"
           git config --global user.email "cockpituous@cockpit-project.org"


### PR DESCRIPTION
We moved away from `tools/bots` in 89db1c68a9ff2b2b6f9a55e.