### PR TITLE
test: Adjust for rhel-9-4

### DIFF
--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -26,7 +26,7 @@ from testlib import nondestructive, skipImage, test_main, wait
 @nondestructive
 class TestMachinesConsoles(VirtualMachinesCase):
 
-    @skipImage('spice-server does not exist on RHEL 9', "rhel-9-1", "rhel-9-2", "rhel-9-3", "centos-9-stream")
+    @skipImage('spice-server does not exist on RHEL 9', "rhel-9*", "centos-9-stream")
     def testExternalConsole(self):
         b = self.browser
 


### PR DESCRIPTION
This failed downstream in RHEL 9.4 in `TestMachinesCreate.testCreateUrlSource`: [RHEL test log](http://artifacts.osci.redhat.com/testing-farm/b8c33716-8da8-49cc-a1cd-bafd3bb95d63/)

Let's see if it reproduces here.