### PR TITLE
test: fix waiting for reboot in performAction()

### DIFF
--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -160,14 +160,12 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
         self.performAction("subVmTest1", "resume")
 
         # reboot
-        self.machine.execute(f"echo '' > {args['logfile']}")
-        self.performAction("subVmTest1", "reboot")
+        self.performAction("subVmTest1", "reboot", logPath=args['logfile'])
         self.waitLogFile(args['logfile'], "reboot: Power down")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # force reboot
-        self.machine.execute(f"echo '' > {args['logfile']}")
-        self.performAction("subVmTest1", "forceReboot")
+        self.performAction("subVmTest1", "forceReboot", logPath=args['logfile'])
         self.waitCirrOSBooted(args['logfile'])
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 


### PR DESCRIPTION
That check for "the reboot does not happen when the dialog is open" was
broken:

 - It checked the log once right after opening the dialog without any
   delay, so neither the dialog nor the VM had any chance to actually do
   anything.

 - The caller clears the log file right before the call, so initialTime
   was always empty.

Wait 5s after opening the dialog to give the VM a good chance to boot (if
it would, which it isn't supposed to). Also add a positive log check that the
VM actually does start to boot after confirming the dialog.

Finally, move the cleaning of the log file from the callers into
performAction(), so that the whole logic is in one place.

Co-Authored-By: Martin Pitt <mpitt@redhat.com>