### PR TITLE
Watchdog: Use 'reset' as default when no device is attached

### DIFF
--- a/src/components/vm/overview/watchdog.jsx
+++ b/src/components/vm/overview/watchdog.jsx
@@ -37,6 +37,8 @@ import { WATCHDOG_INFO_MESSAGE } from './helpers.jsx';
 
 const _ = cockpit.gettext;
 
+const SUPPORTEDACTIONS = ["reset", "poweroff", "inject-nmi", "pause"];
+
 const WatchdogModalAlert = ({ dialogError }) => {
     const [isExpanded, setIsExpanded] = useState(false);
 
@@ -68,7 +70,7 @@ const WatchdogModalAlert = ({ dialogError }) => {
 
 export const WatchdogModal = ({ vm, isWatchdogAttached, idPrefix }) => {
     const [dialogError, setDialogError] = useState();
-    const [watchdogAction, setWatchdogAction] = useState(vm.watchdog.action || "no-device");
+    const [watchdogAction, setWatchdogAction] = useState(vm.watchdog.action || SUPPORTEDACTIONS[0]); // use first option as default
     const [inProgress, setInProgress] = useState(false);
     const [offerColdplug, setOfferColdplug] = useState(false);
 
@@ -133,8 +135,6 @@ export const WatchdogModal = ({ vm, isWatchdogAttached, idPrefix }) => {
                 .then(Dialogs.close, exc => setDialogError({ text: _("Failed to detach watchdog"), detail: exc.message, variant: "danger" }))
                 .finally(() => setInProgress(false));
     };
-
-    const supportedActions = ["reset", "poweroff", "inject-nmi", "pause"];
 
     const needsShutdown = () => {
         if (vm.state === 'running' && isWatchdogAttached && vm.watchdog.action !== watchdogAction)
@@ -203,7 +203,7 @@ export const WatchdogModal = ({ vm, isWatchdogAttached, idPrefix }) => {
                            fieldId="watchdog-action"
                            hasNoPaddingTop
                            isStack>
-                    {supportedActions.map(action => (
+                    {SUPPORTEDACTIONS.map(action => (
                         <Radio label={rephraseUI("watchdogAction", action)}
                                key={action}
                                id={action}

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -629,13 +629,10 @@ class TestMachinesSettings(VirtualMachinesCase):
 
         openWatchDogDialog()
         # Check no default watchdog device is selected
-        self.assertFalse(b.get_checked("#reset"))
+        self.assertTrue(b.get_checked("#reset"))  # Reset is pre-selected as default when no watchdog is attached
         self.assertFalse(b.get_checked("#poweroff"))
         self.assertFalse(b.get_checked("#inject-nmi"))
         self.assertFalse(b.get_checked("#pause"))
-        # Click "Add" without selecting action
-        b.click("#watchdog-dialog-apply")
-        b.wait_in_text("#vm-subVmTest1-watchdog-modal .pf-m-danger", "unsupported configuration")
         closeWatchDogDialog("#vm-subVmTest1-watchdog-modal button[aria-label=Close]")
 
         # Test configuring watchdog for shutoff VM


### PR DESCRIPTION
Fixes https://github.com/cockpit-project/cockpit-machines/issues/1249

### Before

[Screencast from 2023-10-12 12-25-24.webm](https://github.com/cockpit-project/cockpit-machines/assets/42733240/7d0aabc2-90aa-4d2b-b365-6783b6834264)


### After

[Screencast from 2023-10-12 12-26-09.webm](https://github.com/cockpit-project/cockpit-machines/assets/42733240/65a8d668-9e87-4db8-af6a-2817c861599f)
