### PR TITLE
test: Drop unnecessary pool-refresh loop for iSCSI pool

### DIFF
--- a/src/libvirtApi/common.js
+++ b/src/libvirtApi/common.js
@@ -378,20 +378,27 @@ function startEventMonitorStoragePools(connectionName) {
             switch (eventType) {
             case Enum.VIR_STORAGE_POOL_EVENT_DEFINED:
             case Enum.VIR_STORAGE_POOL_EVENT_CREATED:
+                logDebug(`StoragePoolEvent on ${connectionName} ${objPath}: DEFINED|CREATED`);
                 storagePoolGet({ connectionName, id: objPath });
                 break;
             case Enum.VIR_STORAGE_POOL_EVENT_STOPPED:
+                logDebug(`StoragePoolEvent on ${connectionName} ${objPath}: STOPPED`);
                 storagePoolUpdateOrDelete(connectionName, objPath);
                 break;
             case Enum.VIR_STORAGE_POOL_EVENT_STARTED:
+                logDebug(`StoragePoolEvent on ${connectionName} ${objPath}: STARTED`);
                 storagePoolGet({ connectionName, id: objPath, updateOnly: true });
                 break;
             case Enum.VIR_STORAGE_POOL_EVENT_UNDEFINED:
+                logDebug(`StoragePoolEvent on ${connectionName} ${objPath}: UNDEFINED`);
                 store.dispatch(undefineStoragePool({ connectionName, id: objPath }));
                 break;
             case Enum.VIR_STORAGE_POOL_EVENT_DELETED:
+                logDebug(`StoragePoolEvent on ${connectionName} ${objPath}: DELETED`);
+                // no need to handle
+                break;
             default:
-                logDebug(`handle StoragePoolEvent on ${connectionName}: ignoring event ${signal}`);
+                logDebug(`handle StoragePoolEvent on ${connectionName}: ignoring event ${eventType}`);
             }
         }
     );
@@ -403,6 +410,7 @@ function startEventMonitorStoragePools(connectionName) {
             switch (signal) {
             case "Refresh":
             /* These signals imply possible changes in what we display, so re-read the state */
+                logDebug(`StoragePool.Refresh on ${connectionName}`);
                 storagePoolGet({ connectionName, id: path });
                 break;
             default:

--- a/src/libvirtApi/common.js
+++ b/src/libvirtApi/common.js
@@ -383,7 +383,7 @@ function startEventMonitorStoragePools(connectionName) {
                 break;
             case Enum.VIR_STORAGE_POOL_EVENT_STOPPED:
                 logDebug(`StoragePoolEvent on ${connectionName} ${objPath}: STOPPED`);
-                storagePoolUpdateOrDelete(connectionName, objPath);
+                storagePoolStopOrUndefine(connectionName, objPath);
                 break;
             case Enum.VIR_STORAGE_POOL_EVENT_STARTED:
                 logDebug(`StoragePoolEvent on ${connectionName} ${objPath}: STARTED`);
@@ -419,7 +419,7 @@ function startEventMonitorStoragePools(connectionName) {
         });
 }
 
-function storagePoolUpdateOrDelete(connectionName, poolPath) {
+function storagePoolStopOrUndefine(connectionName, poolPath) {
     return call(connectionName, "/org/libvirt/QEMU", "org.libvirt.Connect", "ListStoragePools", [0], { timeout, type: "u" })
             .then(objPaths => {
                 if (objPaths[0].includes(poolPath))
@@ -427,7 +427,7 @@ function storagePoolUpdateOrDelete(connectionName, poolPath) {
                 else // Transient pool which got undefined when stopped
                     return store.dispatch(undefineStoragePool({ connectionName, id: poolPath }));
             })
-            .catch(ex => console.warn("storagePoolUpdateOrDelete action failed:", ex.toString()));
+            .catch(ex => console.warn("storagePoolStopOrUndefine action failed:", ex.toString()));
 }
 
 export function getApiData({ connectionName }) {

--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -867,7 +867,8 @@ class TestMachinesStoragePools(VirtualMachinesCase):
                     b.wait_text(f"#pool-{self.name}-{self.connection}-state", "active")
 
                     if self.pool_type == "iscsi":
-                        wait(lambda: "unit:0:0:0" in m.execute(f"virsh pool-refresh {self.name}; virsh vol-list {self.name}"))
+                        # these should get picked up through StoragePoolEvent CREATED
+                        wait(lambda: "unit:0:0:0" in m.execute(f"virsh vol-list {self.name}"))
                     elif self.vol_name:
                         if self.vol_name not in m.execute(f"virsh vol-list {self.name}"):
                             m.execute(f"virsh vol-create-as {self.name} {self.vol_name} 1M")


### PR DESCRIPTION
This isn't necessary -- libvirt sends out `StoragePoolEvent.DEFINED` or
`.CREATED` when defining an iSCSI pool. We want Cockpit to pick this up
on its own, without the API poking.

This is also a race condition: The `StoragePool.Refresh` event queues an
UPDATE_ADD_STORAGE_POOL, which could run _after_ processing the
subsequent UNDEFINED event, and thus (1) logs an error, and (2) triggers
an outdated UI refresh event. There is no UI change that we could wait
for after a refresh, as we don't expect any visible state change from
the refresh, so there's no way to synchronize.

Note that this mostly just papers over a bug: If a user or something
else runs `virsh pool-refresh` at the wrong time while deleting a
storage pool, it could cause the same UI confusion. But fixing this
properly requires some bigger rearchitecting.

Fixes #1284