### PR TITLE
Fix TestMachinesNICs.{testNICDelete,testVmNICs} and improve debugging

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -176,7 +176,7 @@ export function arrayEquals(arr1, arr2) {
 }
 
 export function logDebug() {
-    if (window.debugging === "all" || window.debugging === "machines")
+    if (window.debugging === "all" || window.debugging?.includes("machines"))
         console.debug.apply(console, arguments);
 }
 

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -712,8 +712,6 @@ export function domainGet({
                     props.autostart = returnProps[0].Autostart.v.v;
                 props.ui = resolveUiState(props.name, props.connectionName);
 
-                logDebug(`${props.name}.GET_VM(${objPath}, ${connectionName}): update props ${JSON.stringify(props)}`);
-
                 dumpxmlParams = parseDomainDumpxml(connectionName, domainXML, objPath);
 
                 Object.assign(props, dumpxmlParams);
@@ -736,6 +734,8 @@ export function domainGet({
 
                 if (!domainIsRunning(stateStr))
                     props.actualTimeInMs = -1;
+
+                logDebug(`${props.name}.GET_VM(${objPath}, ${connectionName}): update props ${JSON.stringify(props)}`);
 
                 return store.dispatch(updateOrAddVm({ state: stateStr, ...props }));
             })

--- a/src/libvirtApi/helpers.js
+++ b/src/libvirtApi/helpers.js
@@ -20,6 +20,8 @@
 import cockpit from 'cockpit';
 import store from '../store.js';
 
+import { logDebug } from '../helpers.js';
+
 import {
     removeVmCreateInProgress,
     clearVmUiState,
@@ -110,6 +112,7 @@ export const Enum = {
  * Call a Libvirt method
  */
 export function call(connectionName, objectPath, iface, method, args, opts) {
+    logDebug("libvirt call:", connectionName, objectPath, iface, method, JSON.stringify(args), JSON.stringify(opts));
     return dbusClient(connectionName).call(objectPath, iface, method, args, opts);
 }
 

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -193,7 +193,9 @@ class TestMachinesNICs(VirtualMachinesCase):
         self.goToVmPage("subVmTest1")
 
         self.deleteIface(1)
-        b.wait_not_present("#vm-subVmTest1-network-1-mac")
+        # Hot-unplug depends on cooperation with the guest OS and takes painfully long
+        with b.wait_timeout(90):
+            b.wait_not_present("#vm-subVmTest1-network-1-mac")
 
         # Detach NIC when the VM is shutoff, Also check this issue: https://bugzilla.redhat.com/show_bug.cgi?id=1791543
         self.performAction("subVmTest1", "off")
@@ -216,13 +218,15 @@ class TestMachinesNICs(VirtualMachinesCase):
         b.wait_text("#vm-subVmTest1-network-4-model", "e1000e")
         # Detach
         self.deleteIface(2, "52:54:00:4b:73:4f", "subVmTest1")
-        b.wait_not_present("#vm-subVmTest1-network-4-mac")
+        with b.wait_timeout(90):
+            b.wait_not_present("#vm-subVmTest1-network-4-mac")
         b.wait_text_not("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:4f")
         b.wait_text("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:5f")
         b.wait_text("#vm-subVmTest1-network-2-model", "virtio")
         # Test deleting the interface with same MAC address as the other vNIC will delete the correct one
         self.deleteIface(2, "52:54:00:4b:73:5f", "subVmTest1")
-        b.wait_not_present("#vm-subVmTest1-network-3-mac")
+        with b.wait_timeout(90):
+            b.wait_not_present("#vm-subVmTest1-network-3-mac")
         b.wait_text("#vm-subVmTest1-network-2-mac", "52:54:00:4b:73:5f")
         b.wait_text("#vm-subVmTest1-network-2-model", "e1000e")
 

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -66,7 +66,8 @@ class TestMachinesNICs(VirtualMachinesCase):
         self.deleteIface(1)
 
         # Test add network
-        m.execute("virsh attach-interface --domain subVmTest1 --type network --source default --target vnet1 --model virtio --mac 52:54:00:4b:73:5f --config --live")
+        m.execute("virsh attach-interface --domain subVmTest1 --type network --source default --target vnet1 "
+                  "--model virtio --mac 52:54:00:4b:73:5f --config --live", timeout=300)
 
         b.wait_in_text("#vm-subVmTest1-network-1-type", "network")
         b.wait_in_text("#vm-subVmTest1-network-1-source", "default")
@@ -76,7 +77,8 @@ class TestMachinesNICs(VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-network-1-state", "up")
 
         # Test bridge network
-        m.execute("virsh attach-interface --domain subVmTest1 --type bridge --source virbr0 --model virtio --mac 52:54:00:4b:73:5e --config --live")
+        m.execute("virsh attach-interface --domain subVmTest1 --type bridge --source virbr0 --model virtio "
+                  "--mac 52:54:00:4b:73:5e --config --live", timeout=300)
 
         # vNICs are alphabetically sorted by MAC address, so now the new vNIC is first in the list
         b.wait_in_text("#vm-subVmTest1-network-1-type", "bridge")
@@ -110,7 +112,8 @@ class TestMachinesNICs(VirtualMachinesCase):
 
         m.execute("virsh start subVmTest1")
         # Attach vNIC only to live config
-        m.execute("virsh attach-interface --domain subVmTest1 --type network --source default --model virtio --mac 52:54:00:4b:73:6f --live")
+        m.execute("virsh attach-interface --domain subVmTest1 --type network --source default --model virtio "
+                  "--mac 52:54:00:4b:73:6f --live", timeout=300)
         b.wait_in_text("#vm-subVmTest1-network-3-mac", "52:54:00:4b:73:6f")
         # vNIC which is only attached to live config cannot be edited
         b.wait_visible("#vm-subVmTest1-network-3-edit-dialog[aria-disabled=true]")


### PR DESCRIPTION
Our current top flake, with > 40% failure rate on rhel-9-4. Yet, doesn't immediately reproduce locally, so let's get some bot help.

![image](https://github.com/cockpit-project/cockpit-machines/assets/200109/b6bf11f8-19a2-46da-8791-a853d582365a)
