### PR TITLE
Test configure before install flake

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1986,9 +1986,7 @@ vnc_password= "{vnc_passwd}"
         b.click("#vm-VmNotInstalled-memory-count button")
         b.wait_visible("#vm-memory-modal")
         b.set_input_text("#vm-VmNotInstalled-memory-modal-max-memory", "150")
-        b.blur("#vm-VmNotInstalled-memory-modal-max-memory")
         b.set_input_text("#vm-VmNotInstalled-memory-modal-memory", "130")
-        b.blur("#vm-VmNotInstalled-memory-modal-memory")
         b.click("#vm-VmNotInstalled-memory-modal-save")
         b.wait_not_present(".pf-v5-c-modal-box__body")
 

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -2060,6 +2060,7 @@ vnc_password= "{vnc_passwd}"
 
         # Check configuration changes survived installation
         # Check memory settings have persisted
+        b.wait_in_text("#vm-VmNotInstalled-memory-count", "130.0 MiB")
         b.click("#vm-VmNotInstalled-memory-count button")
         b.wait_visible("#vm-VmNotInstalled-memory-modal-memory")
         b.wait_val("#vm-VmNotInstalled-memory-modal-max-memory", "150")


### PR DESCRIPTION
It turns out that we clicked on the memory modal button when the memory usage in our UI is still 150 MiB and the memory modal either does not update or updates too slow to get the new 130 MiB value.