### PR TITLE
test: Fix TestMachinesHostDevs race

### DIFF
--- a/src/components/networks/networkList.jsx
+++ b/src/components/networks/networkList.jsx
@@ -43,7 +43,7 @@ export class NetworkList extends React.Component {
         const unlocked = superuser.allowed;
 
         return (
-            <WithDialogs>
+            <WithDialogs key="network-list">
                 <Page>
                     <PageBreadcrumb stickyOnBreakpoint={{ default: "top" }}>
                         <Breadcrumb variant={PageSectionVariants.light} className='machines-listing-breadcrumb'>

--- a/src/components/storagePools/storagePoolList.jsx
+++ b/src/components/storagePools/storagePoolList.jsx
@@ -44,7 +44,7 @@ export class StoragePoolList extends React.Component {
         const actions = (<CreateStoragePoolAction loggedUser={loggedUser} libvirtVersion={libvirtVersion} />);
 
         return (
-            <WithDialogs>
+            <WithDialogs key="storage-pool-list">
                 <Page>
                     <PageBreadcrumb stickyOnBreakpoint={{ default: "top" }}>
                         <Breadcrumb className='machines-listing-breadcrumb'>

--- a/src/components/vm/vmDetailsPage.jsx
+++ b/src/components/vm/vmDetailsPage.jsx
@@ -78,7 +78,7 @@ export const VmDetailsPage = ({
 
     if (cockpit.location.path[1] == "console") {
         return (
-            <WithDialogs>
+            <WithDialogs key="vm-details">
                 <Page id={"vm-" + vm.name + "-consoles-page"}
                       className="consoles-page-expanded">
                     <PageBreadcrumb stickyOnBreakpoint={{ default: "top" }}>

--- a/src/components/vms/hostvmslist.jsx
+++ b/src/components/vms/hostvmslist.jsx
@@ -128,7 +128,7 @@ const HostVmsList = ({ vms, config, ui, storagePools, actions, networks, onAddEr
     );
 
     return (
-        <WithDialogs>
+        <WithDialogs key="vms-list">
             <Page>
                 <PageSection>
                     <Gallery className="ct-cards-grid" hasGutter>

--- a/test/check-machines-hostdevs
+++ b/test/check-machines-hostdevs
@@ -226,6 +226,7 @@ class TestMachinesHostDevs(VirtualMachinesCase):
                 b.wait_in_text("#delete-resource-modal-vendor", self._vendor)
 
                 b.click('.pf-v5-c-modal-box__footer button:contains("Remove")')
+                b.wait_not_present("#delete-resource-modal")
                 b.wait_not_present(f"#vm-subVmTest1-hostdev-{self.vm_dev_id}-product")
 
         # Check the error if selecting no devices when the VM is running


### PR DESCRIPTION
Wait for the "Remove host device from VM?" dialog to disappear before
opening the "Add host device" dialog in the next test step. Otherwise it
often happend that the latter dialog just got opened, while
deleteResource.jsx' dialog shutdown handler called `Dialogs.close()`,
which would then close the new instead of the old dialog.

This is purely a test race, as a human user/browser won't allow
interaction with the main page as long as the modal dialog is still
open. But our CDP driver allows that.

Fixes #1292

----

This addresses these failures:
 - https://cockpit-logs.us-east-1.linodeobjects.com/pull-5481-20231104-052435-87e823ba-arch-cockpit-project-cockpit-machines/log.html
 - https://artifacts.dev.testing-farm.io/f3a13af7-1044-4d5b-b9ff-69a0b2f65033/

I also sent https://github.com/cockpit-project/cockpit/pull/19595 to make these errors much easier to debug in the future.