### PR TITLE
Allow adding multiple ssh keys at once

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -330,7 +330,7 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                                     user_login="foo",
                                                                     root_password="dogsaremybestfr13nds",
                                                                     ssh_keys=[f"{rsakey} \n {dsakey}"],
-                                                                    expected_ssh_keys=[rsakey],
+                                                                    expected_ssh_keys=[rsakey, dsakey],
                                                                     create_and_run=True))
 
         # Try to create VM with invalid ssh key


### PR DESCRIPTION
The initial version of the ssh key functionality would only add the first key if multiple where provided. Allow adding multiple keys in via a new helper, the validation now needs to happen via SshKeysRow as they are added dynamically and the value provided via properties.

Closes #1300