### PR TITLE
test: Fix whitespace

### DIFF
--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -29,7 +29,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
 
     def createUser(self, user_group):
         user_name = f"test_{user_group if user_group else 'none'}_user"
-        self.machine.execute(f"useradd{' -G ' + user_group if user_group else '' } {user_name}")
+        self.machine.execute(f"useradd{' -G ' + user_group if user_group else ''} {user_name}")
         self.machine.execute(f"echo '{user_name}:foobar' | chpasswd")
         # user libvirtd instance tends to SIGABRT with "Failed to find user record for uid .." on shutdown during cleanup
         # so make sure that there are no leftover user processes that bleed into the next test


### PR DESCRIPTION
Spotted by current ruff 0.1.6:
    
> E202 whitespace before '}'

----

This happens since the recent tasks container refresh in https://github.com/cockpit-project/cockpituous/pull/567