### PR TITLE
test: Fix TestMachinesDisks.testAddDiskPool race

### DIFF
--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -917,6 +917,15 @@ class TestMachinesDisks(VirtualMachinesCase):
         m.upload([os.path.join(BOTS_DIR, "machine/cloud-init.iso")], "/var/lib/libvirt/images/defaultVol.iso")
         m.execute("virsh pool-refresh images")
         wait(lambda: "defaultVol.iso" in m.execute("virsh vol-list images"), delay=3)
+
+        # wait until the volume bubbled through the UI
+        b.go("/machines#/storages")
+        self.waitPoolRow("images")
+        self.togglePoolRow("images")
+        b.click("tr[data-row-id=pool-images-system] + tr li:contains('Storage volumes') button")
+        b.wait_in_text("#storage-pools-listing", "defaultVol.iso")
+        b.go("/machines#vm?name=subVmTest1&connection=system")
+
         dialog = self.VMAddDiskDialog(
             self,
             mode="use-existing",


### PR DESCRIPTION
Waiting for the defaultVol.iso volume to appear in the API isn't enough -- it also needs to bubble trough libvirt-dbus and Redux. Wait until the UI sees the volume before trying to select it in the "Add disk" dialog. The dialog won't (and shouldn't) dynamically update the available selections once its open.

---

The test recently [started to fail](https://artifacts.dev.testing-farm.io/a1df201f-fe24-4243-8bac-e5d71f604e18/#artifacts-/plans/all/storage) on TF on both C8S and C9S. I can locally reproduce this reliably in a `tmt` VM (but not on ours).