### PR TITLE
Add disk dialog bug fixes

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -119,10 +119,6 @@ export const App = () => {
         checkVirtualization();
     }, []);
 
-    useEffect(() => {
-        localStorage.setItem('virtualization-disabled-ignored', emptyStateIgnored);
-    }, [emptyStateIgnored]);
-
     if (!virtualizationEnabled && !emptyStateIgnored) {
         return (
             <Page>
@@ -139,7 +135,10 @@ export const App = () => {
                         </EmptyStateBody>
                         <EmptyStateFooter>
                             <EmptyStateActions>
-                                <Button id="ignore-hw-virtualization-disabled-btn" variant="secondary" onClick={() => setEmptyStateIgnored(true)}>{_("Ignore")}</Button>
+                                <Button id="ignore-hw-virtualization-disabled-btn" variant="secondary" onClick={() => {
+                                    setEmptyStateIgnored(true);
+                                    localStorage.setItem('virtualization-disabled-ignored', true);
+                                }}>{_("Ignore")}</Button>
                             </EmptyStateActions>
                         </EmptyStateFooter>
                     </EmptyState>

--- a/src/components/storagePools/storageVolumeCreate.jsx
+++ b/src/components/storagePools/storageVolumeCreate.jsx
@@ -57,7 +57,14 @@ class CreateStorageVolumeModal extends React.Component {
     }
 
     onValueChanged(key, value) {
-        this.setState({ [key]: value });
+        switch (key) {
+        case 'size':
+            this.setState({ size: parseInt(value) });
+            break;
+
+        default:
+            this.setState({ [key]: value });
+        }
     }
 
     validateParams() {

--- a/src/components/vm/disks/diskAdd.jsx
+++ b/src/components/vm/disks/diskAdd.jsx
@@ -416,8 +416,12 @@ export const AddDiskModalBody = ({ disk, idPrefix, isMediaInsertion, vm, vms, su
 
     useEffect(() => {
         // Follow up state updates after 'existingVolumeName' is changed
-        if (!diskParams.storagePool)
+        if (!diskParams.storagePool) {
+            // if storage pool detection finished, and there are no pools, mark format detection as initialized
+            if (storagePools !== undefined && storagePools.length === 0)
+                setDiskParams(diskParams => ({ ...diskParams, format: null }));
             return;
+        }
 
         let format = getDefaultVolumeFormat(diskParams.storagePool);
         let deviceType = "disk";
@@ -434,7 +438,7 @@ export const AddDiskModalBody = ({ disk, idPrefix, isMediaInsertion, vm, vms, su
             format,
             device: deviceType,
         }));
-    }, [diskParams.storagePool, diskParams.existingVolumeName]);
+    }, [storagePools, diskParams.storagePool, diskParams.existingVolumeName]);
 
     useEffect(() => {
         // Initial state settings and follow up state updates after 'device' is changed

--- a/src/components/vm/disks/diskAdd.jsx
+++ b/src/components/vm/disks/diskAdd.jsx
@@ -370,7 +370,7 @@ export const AddDiskModalBody = ({ disk, idPrefix, isMediaInsertion, vm, vms, su
         cacheMode: 'default',
         device: "disk",
         file: "",
-        format: "",
+        format: undefined,
         serial: "",
         size: 1,
         unit: units.GiB.name,
@@ -475,7 +475,7 @@ export const AddDiskModalBody = ({ disk, idPrefix, isMediaInsertion, vm, vms, su
             setVerificationInProgress(true);
             cockpit.spawn(["head", "--bytes=16", file], { binary: true, err: "message", superuser: "try" })
                     .then(file_header => {
-                        let format = "";
+                        let format;
 
                         // https://git.qemu.org/?p=qemu.git;a=blob;f=docs/interop/qcow2.txt
                         if (file_header[0] == 81 && file_header[1] == 70 &&
@@ -564,7 +564,7 @@ export const AddDiskModalBody = ({ disk, idPrefix, isMediaInsertion, vm, vms, su
     const validationFailed = validate ? _validationFailed : {};
 
     let defaultBody;
-    const dialogLoading = storagePools === undefined;
+    const dialogLoading = storagePools === undefined || diskParams.format === undefined;
     if (dialogLoading) {
         defaultBody = (
             <Bullseye>

--- a/src/components/vm/disks/diskAdd.jsx
+++ b/src/components/vm/disks/diskAdd.jsx
@@ -17,7 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 import { debounce } from 'throttle-debounce';
-import React, { useMemo, useRef, useState, useEffect } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { Bullseye } from "@patternfly/react-core/dist/esm/layouts/Bullseye";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
@@ -463,24 +463,6 @@ export const AddDiskModalBody = ({ disk, idPrefix, isMediaInsertion, vm, vms, su
         const availableTarget = isMediaInsertion ? disk.target : getNextAvailableTarget(existingTargets, diskParams.busType);
         setDiskParams(diskParams => ({ ...diskParams, target: availableTarget }));
     }, [vm.disks, disk?.target, diskParams.busType, isMediaInsertion]);
-
-    const currentPoolRef = useRef();
-    useEffect(() => {
-        if (currentPoolRef.current === undefined) {
-            currentPoolRef.current = diskParams.storagePool;
-
-            // Reset the format only when the Format selection dropdown changes entries - otherwise just keep the old selection
-            // All pool types apart from 'disk' have either 'raw' or 'qcow2' format
-            const prevPool = currentPoolRef.current;
-            if ((diskParams.storagePool?.type == 'disk' && prevPool?.type != 'disk') || (diskParams.storagePool?.type != 'disk' && prevPool?.type == 'disk')) {
-                prevPool.current = diskParams.storagePool;
-                setDiskParams(diskParams => ({
-                    ...diskParams,
-                    format: getDefaultVolumeFormat(diskParams.storagePool?.name),
-                }));
-            }
-        }
-    }, [diskParams.storagePool?.type, diskParams.storagePool?.name, diskParams.storagePool]);
 
     useEffect(() => {
         const file = diskParams.file;

--- a/src/components/vm/disks/diskAdd.jsx
+++ b/src/components/vm/disks/diskAdd.jsx
@@ -534,6 +534,10 @@ export const AddDiskModalBody = ({ disk, idPrefix, isMediaInsertion, vm, vms, su
             setMode(value);
             break;
         }
+        case 'size': {
+            setDiskParams(diskParams => ({ ...diskParams, size: parseInt(value) }));
+            break;
+        }
         default:
             setDiskParams(diskParams => ({ ...diskParams, [key]: value }));
         }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -722,7 +722,7 @@ export function getDefaultVolumeFormat(pool) {
     if (['dir', 'fs', 'netfs', 'gluster', 'vstorage'].indexOf(pool.type) > -1)
         return 'qcow2';
 
-    return undefined;
+    return null;
 }
 
 /**

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -950,6 +950,12 @@ class TestMachinesDisks(VirtualMachinesCase):
         if m.image in ["debian-testing"]:
             self.allow_journal_messages(f'.* type=1400 .* apparmor="DENIED" operation="open" profile="libvirt.* name="{self.vm_tmpdir}.*')
 
+        # HACK: Switching the pool relies on useEffect() to update "Format:" to the default format of the new pool
+        # type; there is an intermediade rendering with the new pool and the old format. This is unfortunately
+        # hard to fix due to the useEffect() maze in the "Add disk" dialog. Until we clean this up, ignore this
+        # particular instance
+        self.allow_browser_errors("VolumeDetails internal error: format qcow2 is not valid for storage pool type disk")
+
     @timeout(900)
     def testAddDiskDirPool(self):
         b = self.browser

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -432,8 +432,6 @@ class VirtualMachinesCase(MachineCase, VirtualMachinesCaseHelpers, StorageHelper
             "Scrollbar test exception: TypeError: document.body is null",
             "Tried changing state of a disconnected RFB object",
             "Failed to get libvirt version from the dbus API:.*Cannot recv data: Connection reset by peer",
-            # FIXME:: https://github.com/cockpit-project/cockpit-machines/issues/1272
-            "Warning: Failed.*type:.*The prop `format` is marked as required in `VolumeCreateBody`, but its value is `undefined`",
             # deprecated PF SelectGroup has invalid properties
             r"Warning: React does not recognize the .* prop.*(inputId|isSelected|sendRef|keyHandler)",
         )

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -434,8 +434,6 @@ class VirtualMachinesCase(MachineCase, VirtualMachinesCaseHelpers, StorageHelper
             "Failed to get libvirt version from the dbus API:.*Cannot recv data: Connection reset by peer",
             # FIXME:: https://github.com/cockpit-project/cockpit-machines/issues/1272
             "Warning: Failed.*type:.*The prop `format` is marked as required in `VolumeCreateBody`, but its value is `undefined`",
-            # FIXME: https://github.com/cockpit-project/cockpit-machines/issues/1273
-            " Warning: Failed.*type:.* Invalid prop `size` of type `string` supplied to `VolumeCreateBody`, expected `number`",
             # deprecated PF SelectGroup has invalid properties
             r"Warning: React does not recognize the .* prop.*(inputId|isSelected|sendRef|keyHandler)",
         )


### PR DESCRIPTION
This has turned into quite a can of worms... This has just renewed my aversion to abusing `useEffect()` -- honestly they should *all* die in diskAdd.jsx, I did not see any valid use case of it. They look like sloppy "let's clean up after our own  bad/wrong decisions", and make state handling immensely brittle and hard to follow. The logic from all of them should be moved into a single `useInit()` to set up the dialog, and the corresponding event handlers (which ought to set up the state correctly right away instead of relying on effects to second-guess them).

This PR at least gets rid of two of them.

Fixes #1272

Fixes #1273