### PR TITLE
Revert "test: handle duplicate id's in PF modal dialogs"

### DIFF
--- a/test/check-machines-migrate
+++ b/test/check-machines-migrate
@@ -147,7 +147,7 @@ class TestMachinesMigration(VirtualMachinesCase):
         self.goToVmPage("subVmTest1")
 
         self.performAction("subVmTest1", "migrate")
-        b.wait_visible("#migrate-modal.pf-v5-c-modal-box")
+        b.wait_visible("#migrate-modal")
 
         if fail == "uri":
             # test failure for syntactically incorrect destination uri
@@ -192,7 +192,7 @@ class TestMachinesMigration(VirtualMachinesCase):
             self.assertIn("subVmTest1", machine1.execute("virsh list --all"))
         else:
             with b.wait_timeout(120):
-                b.wait_not_present("#migrate-modal.pf-v5-c-modal-box")
+                b.wait_not_present("#migrate-modal")
 
             # Verify the state of the migrated VM in the destination host
             # The migrated VM should always exist on destination - domstate depends on the options of the dialog set

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -471,8 +471,7 @@ class TestMachinesSettings(VirtualMachinesCase):
 
         # Change watchdog
         b.click("#vm-subVmTest1-watchdog-button")
-        # HACK: PF modal with duplicate id's https://github.com/patternfly/patternfly-react/issues/9399
-        b.wait_visible("#vm-subVmTest1-watchdog-modal.pf-v5-c-modal-box")
+        b.wait_visible("#vm-subVmTest1-watchdog-modal")
         b.click("#reset")
         b.click("#watchdog-dialog-apply")
         b.wait_not_present("#vm-subVmTest1-watchdog-modal")
@@ -510,12 +509,11 @@ class TestMachinesSettings(VirtualMachinesCase):
 
         def openWatchDogDialog():
             b.click("#vm-subVmTest1-watchdog-button")
-            # HACK: PF modal with duplicate id's https://github.com/patternfly/patternfly-react/issues/9399
-            b.wait_visible("#vm-subVmTest1-watchdog-modal.pf-v5-c-modal-box")
+            b.wait_visible("#vm-subVmTest1-watchdog-modal")
 
         def closeWatchDogDialog(selector):
             b.click(selector)
-            b.wait_not_present("#vm-subVmTest1-watchdog-modal.pf-v5-c-modal-box")
+            b.wait_not_present("#vm-subVmTest1-watchdog-modal")
 
         def setWatchdogAction(action, machine_has_no_watchdog=False, pixel_test_tag=None, reboot_machine=False):
             # If no watchdog action is set, we are attaching a new watchdog device. If watchdog already is set, we are editing an exiting watchdog device
@@ -527,7 +525,7 @@ class TestMachinesSettings(VirtualMachinesCase):
             openWatchDogDialog()
 
             if pixel_test_tag:
-                b.assert_pixels("#vm-subVmTest1-watchdog-modal.pf-v5-c-modal-box", pixel_test_tag, skip_layouts=["rtl"])
+                b.assert_pixels("#vm-subVmTest1-watchdog-modal", pixel_test_tag, skip_layouts=["rtl"])
 
             b.click(f"#{action}")
 
@@ -593,11 +591,10 @@ class TestMachinesSettings(VirtualMachinesCase):
 
         def removeWatchdogDevice(live=True):
             b.click("#vm-subVmTest1-watchdog-button")
-            # HACK: PF modal with duplicate id's https://github.com/patternfly/patternfly-react/issues/9399
-            b.wait_visible("#vm-subVmTest1-watchdog-modal.pf-v5-c-modal-box")
+            b.wait_visible("#vm-subVmTest1-watchdog-modal")
 
             b.click("#watchdog-dialog-detach")
-            b.wait_not_present("#vm-subVmTest1-watchdog-modal.pf-v5-c-modal-box")
+            b.wait_not_present("#vm-subVmTest1-watchdog-modal")
 
             b.wait_in_text("#vm-subVmTest1-watchdog-state", "none")
             # check no watchdog is present in VM's xml (also xmllint is expected to return non-zero code)
@@ -694,8 +691,7 @@ class TestMachinesSettings(VirtualMachinesCase):
 
         # Watchdog can be attached to a transient VM
         b.click("#vm-subVmTest2-watchdog-button")
-        # HACK: PF modal with duplicate id's https://github.com/patternfly/patternfly-react/issues/9399
-        b.wait_visible("#vm-subVmTest2-watchdog-modal.pf-v5-c-modal-box")
+        b.wait_visible("#vm-subVmTest2-watchdog-modal")
         b.click("#pause")
         b.click("#watchdog-dialog-apply")
         b.wait_not_present("#vm-subVmTest2-watchdog-modal")
@@ -703,8 +699,7 @@ class TestMachinesSettings(VirtualMachinesCase):
 
         # Watchdog of transient VM should not be editable
         b.click("#vm-subVmTest2-watchdog-button")
-        # HACK: PF modal with duplicate id's https://github.com/patternfly/patternfly-react/issues/9399
-        b.wait_visible("#vm-subVmTest2-watchdog-modal.pf-v5-c-modal-box")
+        b.wait_visible("#vm-subVmTest2-watchdog-modal")
         b.wait_visible("#watchdog-dialog-apply[aria-disabled=true]")
         b.mouse("#watchdog-dialog-apply", "mouseenter")
         b.wait_visible("#watchdog-live-edit-tooltip")
@@ -723,11 +718,10 @@ class TestMachinesSettings(VirtualMachinesCase):
                 b.wait_in_text("#vm-subVmTest1-vsock-button", "edit")
 
             b.click("#vm-subVmTest1-vsock-button")
-            # HACK: PF modal with duplicate id's https://github.com/patternfly/patternfly-react/issues/9399
-            b.wait_visible("#vm-subVmTest1-vsock-modal.pf-v5-c-modal-box")
+            b.wait_visible("#vm-subVmTest1-vsock-modal")
 
             if pixel_test_tag:
-                b.assert_pixels("#vm-subVmTest1-vsock-modal.pf-v5-c-modal-box", pixel_test_tag)
+                b.assert_pixels("#vm-subVmTest1-vsock-modal", pixel_test_tag)
 
             b.set_checked("#vsock-cid-generate", not auto)
             if not auto:
@@ -751,8 +745,7 @@ class TestMachinesSettings(VirtualMachinesCase):
 
         def setVsockLive(new_auto, new_address=None, previous_address=None, previous_auto=None, reboot_machine=False):
             b.click("#vm-subVmTest1-vsock-button")
-            # HACK: PF modal with duplicate id's https://github.com/patternfly/patternfly-react/issues/9399
-            b.wait_visible("#vm-subVmTest1-vsock-modal.pf-v5-c-modal-box")
+            b.wait_visible("#vm-subVmTest1-vsock-modal")
 
             b.set_checked("#vsock-cid-generate", not new_auto)
             if not new_auto:
@@ -825,11 +818,10 @@ class TestMachinesSettings(VirtualMachinesCase):
 
         def removeVsockDevice(live=True):
             b.click("#vm-subVmTest1-vsock-button")
-            # HACK: PF modal with duplicate id's https://github.com/patternfly/patternfly-react/issues/9399
-            b.wait_visible("#vm-subVmTest1-vsock-modal.pf-v5-c-modal-box")
+            b.wait_visible("#vm-subVmTest1-vsock-modal")
 
             b.click("#vsock-dialog-detach")
-            b.wait_not_present("#vm-subVmTest1-vsock-modal.pf-v5-c-modal-box")
+            b.wait_not_present("#vm-subVmTest1-vsock-modal")
 
             b.wait_in_text("#vm-subVmTest1-vsock-address", "none")
             # check no vsock is present in VM's xml (also xmllint is expected to return non-zero code)
@@ -879,7 +871,7 @@ class TestMachinesSettings(VirtualMachinesCase):
 
             # Vsock of transient VM should not be editable
             b.click("#vm-subVmTest1-vsock-button")
-            b.wait_visible("#vm-subVmTest1-vsock-modal.pf-v5-c-modal-box")
+            b.wait_visible("#vm-subVmTest1-vsock-modal")
             b.wait_visible("#vsock-dialog-apply[aria-disabled=true]")
             b.mouse("#vsock-dialog-apply", "mouseenter")
             b.wait_visible("#vsock-live-edit-tooltip")


### PR DESCRIPTION
This reverts commit 15672fd5b38b166e51af28478fe734faf7b6586a.

https://github.com/patternfly/patternfly-react/issues/9399 was fixed in PatternFly 5.1.1, which we depend on.