### PR TITLE
Disk add dialog: Change format together with the storage pool

### DIFF
--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -604,6 +604,9 @@ class TestMachinesDisks(VirtualMachinesCase):
                 # Type in file path
                 b.set_file_autocomplete_val(f"#vm-{self.vm_name}-disks-adddisk-file", self.file_path)
                 if self.device:
+                    if self.file_path.endswith(".iso"):
+                        # wait for auto-detection to finish
+                        b.wait_val(f"#vm-{self.vm_name}-disks-adddisk-select-device", "cdrom")
                     b.select_from_dropdown(f"#vm-{self.vm_name}-disks-adddisk-select-device", self.device)
             elif self.mode == "use-existing":
                 b.wait_visible(f"#vm-{self.vm_name}-disks-adddisk-existing-select-pool:enabled")

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -953,12 +953,6 @@ class TestMachinesDisks(VirtualMachinesCase):
         if m.image in ["debian-testing"]:
             self.allow_journal_messages(f'.* type=1400 .* apparmor="DENIED" operation="open" profile="libvirt.* name="{self.vm_tmpdir}.*')
 
-        # HACK: Switching the pool relies on useEffect() to update "Format:" to the default format of the new pool
-        # type; there is an intermediade rendering with the new pool and the old format. This is unfortunately
-        # hard to fix due to the useEffect() maze in the "Add disk" dialog. Until we clean this up, ignore this
-        # particular instance
-        self.allow_browser_errors("VolumeDetails internal error: format qcow2 is not valid for storage pool type disk")
-
     @timeout(900)
     def testAddDiskDirPool(self):
         b = self.browser


### PR DESCRIPTION
Otherwise we create a race condition: The ModalBody already gets re-rendered with the new pool name, but with possibly with a format that is invalid for the new pool type. That triggers our new assertion.

This is very redundant with the effect which fine-tunes the format and disk type according to the other data. This effect is evil and should be dropped, but doing so requires more intrusive code cleanup. Introduce a helper function to avoid repeated code.

---

Follow-up from https://github.com/cockpit-project/cockpit-machines/pull/1327#issuecomment-1825682485