### PR TITLE
test: Ignore noVNC TLS console error

### DIFF
--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -423,6 +423,9 @@ class VirtualMachinesCase(MachineCase, VirtualMachinesCaseHelpers, StorageHelper
         # avoid error noise about resources getting cleaned up
         self.addCleanup(lambda: not self.browser.cdp.valid or self.browser.logout())
 
+        # noVNC warns about this for non-TLS connections; for RHEL downstream testing
+        self.allow_browser_errors("noVNC requires a secure context")
+
         # HACK: older c-ws versions always log an assertion, fixed in PR cockpit#16765
         self.allow_journal_messages("json_object_get_string_member: assertion 'node != NULL' failed")
 


### PR DESCRIPTION
When opening a plain http connection to a non-localhost machine, noVNC writes a console error. This doesn't happen in our CI, as 127.0.0.2 is considered as `window.isSecureContext == true`, but it does happen for downstream testing against an actually remote machine.

https://issues.redhat.com/browse/RHEL-17309

[1] https://github.com/novnc/noVNC/blob/85a465288b314/core/rfb.js#L99

@yunmingyang FYI