### PR TITLE
Hide SPICE on RHEL 8

### DIFF
--- a/src/scripts/install_machine.py
+++ b/src/scripts/install_machine.py
@@ -39,6 +39,15 @@ def get_graphics_capabilies(connection):
         for value in graphics.find('enum').findall('value'):
             consoles.append(value.text)
 
+    # HACK: Ignore spice on RHEL 8; https://issues.redhat.com/browse/RHEL-18058
+    try:
+        with open("/etc/os-release") as f:
+            if "platform:el8" in f.read():
+                logging.debug("get_graphics_capabilies: ignoring spice on RHEL 8")
+                consoles.remove('spice')
+    except FileNotFoundError:
+        pass  # not RHEL then
+
     logging.debug('get_graphics_capabilies: %s', ', '.join(consoles))
 
     return [c for c in consoles if c in ['vnc', 'spice']]

--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -26,7 +26,7 @@ from testlib import nondestructive, skipImage, test_main, wait
 @nondestructive
 class TestMachinesConsoles(VirtualMachinesCase):
 
-    @skipImage('spice-server does not exist on RHEL 9', "rhel-9*", "centos-9-stream")
+    @skipImage('SPICE not supported on RHEL', "rhel-*", "centos-*")
     def testExternalConsole(self):
         b = self.browser
 

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1218,13 +1218,14 @@ vnc_password= "{vnc_passwd}"
             domainXML = m.execute(f"virsh dumpxml --security-info {self.name}")
             root = ET.fromstring(domainXML)
 
-            expect_spice = not m.image.startswith("rhel-9") and m.image not in ["centos-9-stream"]
-            spice = root.findall(".//graphics[@type='spice']")
-            if expect_spice:
+            if m.image.startswith("rhel-9") or m.image in ["centos-9-stream"]:
+                # we don't expect any SPICE device, unsupported on RHEL 9
+                self.assertNotIn("spice", domainXML)
+            else:
+                # SPICE is supported on all other OSes
+                spice = root.findall(".//graphics[@type='spice']")
                 self.assertEqual(spice_listen, spice[0].attrib['listen'])
                 self.assertEqual(spice_passwd, spice[0].attrib.get('passwd', None))
-            else:
-                self.assertEqual(spice, [])
 
             vnc = root.findall(".//graphics[@type='vnc']")[0]
             self.assertEqual(vnc_listen, vnc.attrib['listen'])

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1218,8 +1218,8 @@ vnc_password= "{vnc_passwd}"
             domainXML = m.execute(f"virsh dumpxml --security-info {self.name}")
             root = ET.fromstring(domainXML)
 
-            if m.image.startswith("rhel-9") or m.image in ["centos-9-stream"]:
-                # we don't expect any SPICE device, unsupported on RHEL 9
+            if m.image.startswith("rhel") or m.image.startswith("centos"):
+                # we don't expect any SPICE device, unsupported on RHEL
                 self.assertNotIn("spice", domainXML)
             else:
                 # SPICE is supported on all other OSes


### PR DESCRIPTION
SPICE got deprecated in RHEL 8.3 [1]. Stop configuring SPICE for new
VMs as requested by the libvirt team. libvirt still announces spice
as supported in the API, so we need to do a "check os-release" hack.

https://issues.redhat.com/browse/RHEL-18058

[1] https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/8.3_release_notes/rhel-8-3-0-release#deprecated-functionality_virtualization