### PR TITLE
Add Suspend To Disk Option to the VM control menu

### DIFF
--- a/src/components/vm/overview/vmOverviewCard.jsx
+++ b/src/components/vm/overview/vmOverviewCard.jsx
@@ -163,7 +163,7 @@ class VmOverviewCard extends React.Component {
                             <DescriptionListTerm>{_("State")}</DescriptionListTerm>
                             <DescriptionListDescription>
                                 <StateIcon error={vm.error}
-                                               state={vm.state}
+                                               state={vm.state + (vm.suspendImage ? " (suspended)" : "")}
                                                valueId={`${idPrefix}-${vm.connectionName}-state`}
                                                dismissError={() => store.dispatch(updateVm({
                                                    connectionName: vm.connectionName,

--- a/src/components/vm/vmActions.jsx
+++ b/src/components/vm/vmActions.jsx
@@ -49,6 +49,8 @@ import {
     domainCanPause,
     domainCanShutdown,
     domainForceOff,
+    domainCanSuspendToDisk,
+    domainCanSuspenImageRemove,
     domainForceReboot,
     domainInstall,
     domainPause,
@@ -58,6 +60,9 @@ import {
     domainShutdown,
     domainStart,
     domainAddTPM,
+    domainSuspendToDisk,
+    domainSuspendImageRemove,
+    domainHasSuspendImage,
 } from '../../libvirtApi/domain.js';
 import store from "../../store.js";
 
@@ -182,6 +187,43 @@ const onSendNMI = (vm) => domainSendNMI({ name: vm.name, id: vm.id, connectionNa
     );
 });
 
+const onSuspendToDisk = (vm) => domainSuspendToDisk({ name: vm.name, id: vm.id, connectionName: vm.connectionName, flags: vm.state == 'running' ? 2 : 4 }).catch(ex => {
+    store.dispatch(
+        updateVm({
+            connectionName: vm.connectionName,
+            name: vm.name,
+            error: {
+                text: cockpit.format(_("VM $0 failed to save "), vm.name),
+                detail: ex.message,
+            }
+        })
+    );
+});
+
+const onSuspendImageRemove = (vm) => domainSuspendImageRemove({ name: vm.name, id: vm.id, connectionName: vm.connectionName })
+        .then(() => domainHasSuspendImage({ name: vm.name, id: vm.id, connectionName: vm.connectionName }))
+        .then((SuspendImage) => {
+            store.dispatch(
+                updateVm({
+                    connectionName: vm.connectionName,
+                    name: vm.name,
+                    suspendImage: SuspendImage[0],
+                })
+            );
+        })
+        .catch(ex => {
+            store.dispatch(
+                updateVm({
+                    connectionName: vm.connectionName,
+                    name: vm.name,
+                    error: {
+                        text: cockpit.format(_("VM $0 failed to remove save image "), vm.name),
+                        detail: ex.message,
+                    }
+                })
+            );
+        });
+
 const onAddTPM = (vm, onAddErrorNotification) => domainAddTPM({ connectionName: vm.connectionName, vmName: vm.name })
         .catch(ex => onAddErrorNotification({
             text: cockpit.format(_("Failed to add TPM to VM $0"), vm.name),
@@ -207,6 +249,7 @@ const VmActions = ({ vm, vms, onAddErrorNotification, isDetailsPage = undefined 
 
     const id = `${vmId(vm.name)}-${vm.connectionName}`;
     const state = vm.state;
+    const suspendImage = vm.suspendImage;
     const hasInstallPhase = vm.metadata && vm.metadata.hasInstallPhase;
     const dropdownItems = [];
 
@@ -220,8 +263,18 @@ const VmActions = ({ vm, vms, onAddErrorNotification, isDetailsPage = undefined 
                 {_("Pause")}
             </DropdownItem>
         );
-        dropdownItems.push(<Divider key="separator-pause" />);
     }
+
+    if (domainCanSuspendToDisk(state)) {
+        dropdownItems.push(
+            <DropdownItem key={`${id}-save`}
+                          id={`${id}-save`}
+                          onClick={() => onSuspendToDisk(vm)}>
+                {_("Suspend to disk")}
+            </DropdownItem>
+        );
+        dropdownItems.push(<Divider key="separator-suspend" />);
+    }      
 
     if (domainCanResume(state)) {
         dropdownItems.push(
@@ -233,6 +286,19 @@ const VmActions = ({ vm, vms, onAddErrorNotification, isDetailsPage = undefined 
         );
         dropdownItems.push(<Divider key="separator-resume" />);
     }
+
+
+    if (domainCanSuspenImageRemove(state, suspendImage)) {
+        dropdownItems.push(
+            <DropdownItem key={`${id}-saveRemove`}
+                          id={`${id}-savedRemove`}
+                          onClick={() => onSuspendImageRemove(vm)}>
+                {_("Remove Suspend Image")}
+            </DropdownItem>
+        );
+        dropdownItems.push(<Divider key="separator-suspend" />);
+    }
+
 
     if (domainCanShutdown(state)) {
         shutdown = (

--- a/src/components/vms/hostvmslist.tsx
+++ b/src/components/vms/hostvmslist.tsx
@@ -69,6 +69,8 @@ const VmState = ({
         } else if (vm.createInProgress) {
             state = _("Creating VM");
         }
+    } else if (vm.state == "shut off" && vm.suspendImage === true) {
+        state = `${vm.state} (suspended)`;
     } else {
         state = vm.state;
     }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -232,6 +232,7 @@ const transform: Record<string, Record<string, string>> = {
         paused: _("Paused"),
         shutdown: _("Shutting down"),
         'shut off': _("Shut off"),
+        'shut off (suspended)': _("Shut off (Suspended)"),  
         crashed: _("Crashed"),
         dying: _("Dying"),
         pmsuspended: _("Suspended (PM)"),

--- a/src/libvirtApi/domain.ts
+++ b/src/libvirtApi/domain.ts
@@ -95,6 +95,8 @@ export const domainCanShutdown = (vmState: VMState) => domainCanReset(vmState);
 export const domainCanPause = (vmState: VMState) => vmState == 'running';
 export const domainCanRename = (vmState: VMState) => vmState == 'shut off';
 export const domainCanResume = (vmState: VMState) => vmState == 'paused';
+export const domainCanSuspendToDisk = (vmState: VMState) => vmState == 'running' || vmState == 'paused';
+export const domainCanSuspenImageRemove = (vmState: VMState, saveImage: Boolean) => vmState == "shut off" && saveImage == true;
 export const domainIsRunning = (vmState: VMState) => domainCanReset(vmState);
 export const domainSerialConsoleCommand = ({ vm, alias } : { vm: VM, alias: string }) => {
     if (vm.displays.find(display => display.type == 'pty'))
@@ -859,6 +861,9 @@ export async function domainGet({
             supportsTPM: getDomainCapSupportsTPM(domCaps),
         };
 
+        const [suspendImage] = await call<[number]>(connectionName, objPath, 'org.libvirt.Domain', 'HasManagedSaveImage', [0], { timeout, type: 'u' });
+        props.suspendImage = suspendImage?true:false;
+
         const [state] = await call<[number[]]>(connectionName, objPath, 'org.libvirt.Domain', 'GetState', [0], { timeout, type: 'u' });
         const stateStr = DOMAINSTATE[state[0]];
 
@@ -1122,6 +1127,36 @@ export function domainResume({
     id: string,
 }): Promise<void> {
     return call(connectionName, objPath, 'org.libvirt.Domain', 'Resume', [], { timeout, type: '' });
+}
+
+export function domainSuspendToDisk({
+    connectionName,
+    id: objPath,
+    flags
+} : {
+    connectionName: ConnectionName,
+    id: string,
+    flags: Number,
+}): Promise<void> {
+    return call(connectionName, objPath, 'org.libvirt.Domain', 'ManagedSave', [flags], { timeout, type: 'u' });
+}
+export function domainSuspendImageRemove({
+    connectionName,
+    id: objPath,
+} : {
+    connectionName: ConnectionName,
+    id: string,
+}): Promise<void> {
+    return call(connectionName, objPath, 'org.libvirt.Domain', 'ManagedSaveRemove', [0], { timeout, type: 'u' });
+}
+export function domainHasSuspendImage({
+    connectionName,
+    id: objPath,
+} : {
+    connectionName: ConnectionName,
+    id: string,
+}): Promise<void> {
+    return call(connectionName, objPath, 'org.libvirt.Domain', 'HasManagedSaveImage', [0], { timeout, type: 'u' });
 }
 
 export function domainSendKey({

--- a/src/types.ts
+++ b/src/types.ts
@@ -389,6 +389,7 @@ export interface VM extends VMXML {
     persistent: boolean;
     autostart: boolean;
     usagePolling?: boolean;
+    suspendImage: boolean;
 
     error?: VMError | null;
 


### PR DESCRIPTION
The stop function can only pause the VM, which means that the VM continues to allocate resources and the status of the VM is lost when the Host is rebooted. 

It would be useful to have a function that allows you to save the state of a VM to disk and resume it at a later point in time.
Libvirt offers the managedsave function for this purpose.

This patch adds this function to the control menu of the VM 

[
![Bildschirmfoto vom 2023-12-21 01-57-54](https://github.com/cockpit-project/cockpit-machines/assets/154479822/f806a520-d2be-4a73-94f6-1c64e3ce67aa)
](url)

