### PR TITLE
Fix crash if `<redirdev>` has no `<address>`

### DIFF
--- a/src/libvirt-xml-parse.js
+++ b/src/libvirt-xml-parse.js
@@ -529,9 +529,9 @@ export function parseDumpxmlForRedirectedDevices(devicesElem) {
                 type: redirdevElem.getAttribute('type'),
                 bootOrder: bootElem?.getAttribute('order'),
                 address: {
-                    type: addressElem.getAttribute('type'),
-                    bus: addressElem.getAttribute('bus'),
-                    port: addressElem.getAttribute('port'),
+                    type: addressElem?.getAttribute('type'),
+                    bus: addressElem?.getAttribute('bus'),
+                    port: addressElem?.getAttribute('port'),
                 },
                 source: {
                     mode: sourceElem?.getAttribute('mode'),


### PR DESCRIPTION
Old existing domain definitions may have `<redirdev>` elements without any `<address>` child. It's impossible to actually create these with current libvirt, as `virsh import`ing such a definition will automatically add an address -- so we can't create a test for this.

Fixes #1307