### PR TITLE
Add action to replace SPICE support

### DIFF
--- a/src/components/common/needsShutdown.jsx
+++ b/src/components/common/needsShutdown.jsx
@@ -77,6 +77,10 @@ export function needsShutdownWatchdog(vm) {
     return vm.persistent && vm.state === "running" && vm.inactiveXML.watchdog.action !== vm.watchdog.action;
 }
 
+export function needsShutdownSpice(vm) {
+    return vm.hasSpice !== vm.inactiveXML.hasSpice;
+}
+
 export function getDevicesRequiringShutdown(vm) {
     if (!vm.persistent)
         return [];
@@ -112,6 +116,10 @@ export function getDevicesRequiringShutdown(vm) {
     // Watchdog
     if (needsShutdownWatchdog(vm))
         devices.push(_("Watchdog"));
+
+    // SPICE
+    if (needsShutdownSpice(vm))
+        devices.push(_("SPICE"));
 
     return devices;
 }

--- a/src/components/vm/vmActions.jsx
+++ b/src/components/vm/vmActions.jsx
@@ -36,6 +36,7 @@ import { ConfirmDialog } from './confirmDialog.jsx';
 import { DeleteDialog } from "./deleteDialog.jsx";
 import { MigrateDialog } from './vmMigrateDialog.jsx';
 import { RenameDialog } from './vmRenameDialog.jsx';
+import { ReplaceSpiceDialog } from './vmReplaceSpiceDialog.jsx';
 import {
     domainCanDelete,
     domainCanInstall,
@@ -426,6 +427,20 @@ const VmActions = ({ vm, onAddErrorNotification, isDetailsPage }) => {
             </DropdownItem>
         );
         dropdownItems.push(<DropdownSeparator key="separator-migrate" />);
+    }
+
+    if (vm.inactiveXML?.hasSpice) {
+        dropdownItems.push(
+            <DropdownItem key={`${id}-replace-spice`}
+                          id={`${id}-replace-spice`}
+                          onClick={() => Dialogs.show(<ReplaceSpiceDialog vmName={vm.name}
+                                                                          vmId={vm.id}
+                                                                          connectionName={vm.connectionName}
+                                                                          vmRunning={vm.state == 'running'} />)}>
+                {_("Replace SPICE devices")}
+            </DropdownItem>
+        );
+        dropdownItems.push(<DropdownSeparator key="separator-spice" />);
     }
 
     if (domainCanRename(state)) {

--- a/src/components/vm/vmReplaceSpiceDialog.jsx
+++ b/src/components/vm/vmReplaceSpiceDialog.jsx
@@ -1,0 +1,89 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from 'cockpit';
+import React, { useState } from 'react';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
+import { Text, TextContent, TextList, TextListItem } from "@patternfly/react-core/dist/esm/components/Text";
+
+import { ModalError } from 'cockpit-components-inline-notification.jsx';
+import { useDialogs } from 'dialogs.jsx';
+import { fmt_to_fragments } from 'utils.jsx';
+
+import { NeedsShutdownAlert } from '../common/needsShutdown.jsx';
+import { domainReplaceSpice } from '../../libvirtApi/domain.js';
+
+const _ = cockpit.gettext;
+
+export const ReplaceSpiceDialog = ({ vmName, vmId, connectionName, vmRunning }) => {
+    const Dialogs = useDialogs();
+    const [error, dialogErrorSet] = useState(null);
+    const [inProgress, setInProgress] = useState(false);
+
+    function onReplace() {
+        setInProgress(true);
+
+        return domainReplaceSpice({ connectionName, id: vmId })
+                .then(() => Dialogs.close())
+                .catch(exc => {
+                    // we don't know of any case where this would fail, so this is all belt-and-suspenders
+                    // still, give the user some hint how to go on
+                    console.warn("Failed to replace SPICE devices:", exc);
+                    dialogErrorSet({
+                        dialogError: _("Failed to replace SPICE devices"),
+                        dialogErrorDetail: fmt_to_fragments(
+                            _("Please see $0 how to reconfigure your VM manually."),
+                            <a href="https://access.redhat.com/solutions/6955095" target="_blank" rel="noopener noreferrer">
+                                https://access.redhat.com/solutions/6955095
+                            </a>),
+                    });
+                })
+                .finally(() => setInProgress(false));
+    }
+
+    return (
+        <Modal position="top" variant="small" isOpen onClose={Dialogs.close}
+           title={cockpit.format(_("Replace SPICE devices in VM $0"), vmName)}
+           footer={
+               <>
+                   <Button variant='primary'
+                           id="replace-spice-dialog-confirm"
+                           isDisabled={inProgress}
+                           onClick={onReplace}>
+                       {_("Replace")}
+                   </Button>
+                   <Button variant='link' onClick={Dialogs.close}>
+                       {_("Cancel")}
+                   </Button>
+               </>
+           }>
+            { vmRunning && !error && <NeedsShutdownAlert idPrefix="spice-modal" /> }
+            {error && <ModalError dialogError={error.dialogError} dialogErrorDetail={error.dialogErrorDetail} />}
+            <TextContent>
+                <Text>{_("Reconfigure the virtual machine for a host which does not support SPICE, for host upgrades or live migration:")}</Text>
+                <TextList>
+                    <TextListItem>{_("Convert SPICE graphics console to VNC.")}</TextListItem>
+                    <TextListItem>{_("Convert QXL video card to VGA.")}</TextListItem>
+                    <TextListItem>{_("Remove SPICE audio and host devices.")}</TextListItem>
+                </TextList>
+            </TextContent>
+        </Modal>
+    );
+};

--- a/src/libvirt-xml-parse.js
+++ b/src/libvirt-xml-parse.js
@@ -246,6 +246,7 @@ export function parseDomainDumpxml(connectionName, domXml, objPath) {
     const filesystems = parseDumpxmlForFilesystems(devicesElem);
     const watchdog = parseDumpxmlForWatchdog(devicesElem);
     const vsock = parseDumpxmlForVsock(devicesElem);
+    const hasSpice = parseDumpxmlForSpice(devicesElem);
 
     const hasInstallPhase = parseDumpxmlMachinesMetadataElement(metadataElem, 'has_install_phase') === 'true';
     const installSourceType = parseDumpxmlMachinesMetadataElement(metadataElem, 'install_source_type');
@@ -289,6 +290,7 @@ export function parseDomainDumpxml(connectionName, domXml, objPath) {
         watchdog,
         vsock,
         metadata,
+        hasSpice,
     };
 }
 
@@ -479,6 +481,21 @@ export function parseDumpxmlForVsock(devicesElem) {
     }
 
     return { cid };
+}
+
+function parseDumpxmlForSpice(devicesElem) {
+    for (let i = 0; i < devicesElem.children.length; ++i) {
+        const device = devicesElem.children.item(i);
+        // also catch spicevmc
+        if (device.getAttribute("type")?.startsWith("spice"))
+            return true;
+        // qxl video is also related to SPICE
+        if (device.tagName === "video" && getSingleOptionalElem(device, "model")?.getAttribute("type") === "qxl")
+            return true;
+    }
+
+    logDebug("parseDumpxmlForSpice: no SPICE elements found in", devicesElem.children);
+    return false;
 }
 
 export function parseDumpxmlForFilesystems(devicesElem) {

--- a/src/libvirt-xml-update.js
+++ b/src/libvirt-xml-update.js
@@ -1,5 +1,5 @@
 import { getDoc, getSingleOptionalElem } from './libvirt-xml-parse.js';
-import { getNextAvailableTarget } from './helpers.js';
+import { getNextAvailableTarget, logDebug } from './helpers.js';
 
 export function changeMedia({ domXml, target, eject, file, pool, volume }) {
     const s = new XMLSerializer();
@@ -295,4 +295,57 @@ export function updateMaxMemory(domXml, maxMemory) {
     memElem.textContent = `${maxMemory}`;
 
     return s.serializeToString(doc);
+}
+
+function xmlGetXPath(doc, xpath) {
+    const elements = [];
+    let node = null;
+    const iterator = doc.evaluate(xpath, doc);
+    while ((node = iterator.iterateNext()))
+        elements.push(node);
+    return elements;
+}
+
+export function replaceSpice(domXml) {
+    // this implements https://access.redhat.com/solutions/6955095
+    logDebug("replaceSpice original XML:", domXml);
+
+    const doc = getDoc(domXml);
+
+    xmlGetXPath(doc, "/domain/devices/audio[@type='spice']").forEach(n => n.remove());
+    xmlGetXPath(doc, "//domain/devices/redirdev[@type='spicevmc']").forEach(n => n.remove());
+    xmlGetXPath(doc, "//domain/devices/channel[@type='spicevmc']").forEach(n => n.remove());
+
+    xmlGetXPath(doc, "//domain/devices/video").forEach(video => {
+        const model = getSingleOptionalElem(video, "model");
+        if (model?.getAttribute("type") === "qxl") {
+            // remove all attributes except for primary; don't change list while iterating
+            const removeAttrs = [];
+            for (let i = 0; i < model.attributes.length; i++) {
+                const attr = model.attributes.item(i);
+                if (attr.name !== "primary")
+                    removeAttrs.push(attr.name);
+            }
+            removeAttrs.forEach(attr => model.removeAttribute(attr));
+            model.setAttribute("type", "vga");
+        }
+    });
+
+    const spice_graphics = xmlGetXPath(doc, "//domain/devices/graphics[@type='spice']");
+    // do we already have a VNC graphics device?
+    if (xmlGetXPath(doc, "//domain/devices/graphics[@type='vnc']").length > 0) {
+        // then simply remove the spice graphics device
+        spice_graphics.forEach(graphics => graphics.remove());
+    } else {
+        // otherwise replace spice graphics with VNC
+        spice_graphics.forEach(graphics => {
+            graphics.setAttribute("type", "vnc");
+            graphics.setAttribute("port", "-1");
+            getSingleOptionalElem(graphics, "image")?.remove();
+        });
+    }
+
+    const result = (new XMLSerializer()).serializeToString(doc);
+    logDebug("replaceSpice updated XML:", result);
+    return result;
 }

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -2321,6 +2321,177 @@ vnc_password= "{vnc_passwd}"
                                               "expired",
                                               False)
 
+    def testReplaceSpice(self):
+        m = self.machine
+        b = self.browser
+        TestMachinesCreate.CreateVmRunner(self)
+        config = TestMachinesCreate.TestCreateConfig
+
+        self.login_and_go("/machines")
+        self.waitPageInit()
+
+        def checkConnnectInfo(expect_vnc=True, expect_spice=False):
+            # if VNC is available, the inline viewer is the default
+            if expect_vnc:
+                b.wait_visible(".pf-v5-c-console__vnc canvas")
+
+            b.click("#pf-v5-c-console__type-selector")
+            b.wait_visible("#pf-v5-c-console__type-selector + .pf-v5-c-select__menu")
+            b.click("#DesktopViewer button")
+            b.wait_not_present("#pf-v5-c-console__type-selector + .pf-v5-c-select__menu")
+            if expect_vnc:
+                b.wait_in_text(".pf-v5-c-console__manual-connection", "VNC")
+            else:
+                self.assertNotIn("VNC", b.text(".pf-v5-c-console__manual-connection"))
+            if expect_spice:
+                b.wait_in_text(".pf-v5-c-console__manual-connection", "SPICE")
+            else:
+                self.assertNotIn("SPICE", b.text(".pf-v5-c-console__manual-connection"))
+
+        def doReplaceSpice(vmName, expect_running=False):
+            self.performAction(vmName, "replace-spice")
+            if expect_running:
+                b.wait_visible("#spice-modal-idle-message")
+            else:
+                b.wait_in_text(".pf-v5-c-modal-box__body", "Reconfigure")
+                self.assertFalse(b.is_present("#spice-modal-idle-message"))
+
+            b.click("#replace-spice-dialog-confirm")
+            b.wait_not_present(".pf-v5-c-modal-box")
+
+            if expect_running:
+                b.click(f"#vm-{vmName}-needs-shutdown")
+                b.wait_in_text(".pf-v5-c-popover__body", "SPICE")
+            else:
+                b.wait_not_present(f"#vm-{vmName}-needs-shutdown")
+
+            # should not have any spice or qxl video any more
+            dump = m.execute(f"virsh dumpxml --inactive {vmName}")
+            self.assertNotIn("spice", dump)
+            self.assertNotIn("qxl", dump)
+
+        #
+        # c-machines standard VM (vnc + spice on non-RHEL), running
+        #
+
+        dialog = TestMachinesCreate.VmDialog(self, sourceType='cloud',
+                                             location=config.VALID_DISK_IMAGE_PATH,
+                                             create_and_run=True,
+                                             delete=False)
+        vmCockpit = dialog.name
+        dialog.open() \
+            .fill()
+        b.click(".pf-v5-c-modal-box__footer button:contains(Create and run)")
+        self.browser.wait_not_present("#create-vm-dialog")
+        self.waitVmRow(vmCockpit, "system")
+        self.goToVmPage(vmCockpit)
+        b.wait_text(f"#vm-{vmCockpit}-system-state", "Running")
+        domainXML = m.execute(f"virsh dumpxml --inactive {vmCockpit}")
+
+        # on RHEL 9, SPICE is unsupported; on RHEL 8, we disable SPICE in VM creation; so we don't expect any device
+        if m.image.startswith("rhel") or m.image.startswith("centos"):
+            self.assertNotIn("spice", domainXML)
+            self.assertNotIn("qxl", domainXML)
+            # and thus no "Replace SPICE" menu entry
+            b.click(f"#vm-{vmCockpit}-system-action-kebab button")
+            b.wait_in_text(f"#vm-{vmCockpit}-system-action-kebab > .pf-v5-c-dropdown__menu", "Delete")
+            self.assertNotIn("Replace SPICE",
+                             b.text(f"#vm-{vmCockpit}-system-action-kebab > .pf-v5-c-dropdown__menu"))
+        else:
+            # all other OSes configure SPICE by default
+            self.assertIn("graphics type='spice'", domainXML)
+            self.assertIn("channel type='spicevmc'", domainXML)
+            checkConnnectInfo(expect_vnc=True, expect_spice=True)
+
+            doReplaceSpice(vmCockpit, expect_running=True)
+
+            # "Replace SPICE" menu entry goes away (async)
+            for _retry in range(15):
+                time.sleep(1)
+                b.click(f"#vm-{vmCockpit}-system-action-kebab button")
+                b.wait_in_text(f"#vm-{vmCockpit}-system-action-kebab > .pf-v5-c-dropdown__menu", "Delete")
+                menu = b.text(f"#vm-{vmCockpit}-system-action-kebab > .pf-v5-c-dropdown__menu")
+                b.click(f"#vm-{vmCockpit}-system-action-kebab button")
+                b.wait_not_present(".pf-v5-c-dropdown__menu")
+                if "Replace SPICE" not in menu:
+                    break
+            else:
+                self.fail("timed out waiting for Replace SPICE menu item removal")
+
+            # ensure that the VM can start without any SPICE plugins
+            # avoid uninstalling packages to keep this nondestructive
+            plugins = m.execute("find /usr/lib* -path '*qemu*spice*' | xargs").strip()
+            try:
+                m.execute(f"mkdir {self.vm_tmpdir}/qemu; for f in {plugins}; do mv $f {self.vm_tmpdir}/qemu; done")
+                caps = m.execute("virsh domcapabilities")
+                if m.image.startswith("debian") or m.image.startswith("ubuntu"):
+                    # on Debian, spice graphics is built in, spicevmc channels are a plugin
+                    self.assertNotIn("spicevmc", caps)
+                else:
+                    # in Fedora/RHEL we don't expect any remaining capability
+                    self.assertNotIn("spice", caps)
+
+                # restart the VM to make the change effective
+                self.performAction(vmCockpit, "forceOff")
+                b.wait_not_present(f"#vm-{vmCockpit}-needs-shutdown")
+                b.click(f"#vm-{vmCockpit}-system-run")
+                b.wait_text(f"#vm-{vmCockpit}-system-state", "Running")
+                checkConnnectInfo(expect_vnc=True, expect_spice=False)
+            finally:
+                m.execute(f"for f in {plugins}; do mv {self.vm_tmpdir}/qemu/$(basename $f) $f; done")
+
+            b.wait_not_present(f"#vm-{vmCockpit}-needs-shutdown")
+
+        self.goToMainPage()
+        self.machine.execute(f"virsh destroy {vmCockpit}; virsh undefine {vmCockpit}")
+
+        # RHEL 9 doesn't support SPICE, so skip the rest of the test
+        if m.image.startswith("rhel-9") or m.image.startswith("centos-9"):
+            return
+
+        #
+        # custom spice-only VM, not running
+        #
+
+        vmSpiceOnly = "SpiceOnly"
+        self.createVm(vmSpiceOnly, graphics="spice", running=False)
+        self.waitVmRow(vmSpiceOnly, "system")
+        self.goToVmPage(vmSpiceOnly)
+        b.wait_text(f"#vm-{vmSpiceOnly}-system-state", "Shut off")
+        doReplaceSpice(vmSpiceOnly, expect_running=False)
+
+        b.click(f"#vm-{vmSpiceOnly}-system-run")
+        b.wait_text(f"#vm-{vmSpiceOnly}-system-state", "Running")
+        checkConnnectInfo(expect_vnc=True, expect_spice=False)
+
+        self.goToMainPage()
+        self.machine.execute(f"virsh destroy {vmSpiceOnly}; virsh undefine {vmSpiceOnly}")
+
+        # failed migration
+        # we can't test this properly, as it's not possible to poke invalid XML into libvirt
+        # simulate it with hacking virt-xml-validate
+
+        self.write_file("/usr/local/bin/virt-xml-validate",
+                        # ensure to drain stdin (read the XML), to avoid exiting too early
+                        "#!/bin/sh\ncat >/dev/null\necho kaputt >&2\nexit 1",
+                        perm="0755")
+
+        vmKaputt = "Kaputt"
+        self.createVm(vmKaputt, graphics="spice", running=False)
+        self.waitVmRow(vmKaputt, "system")
+        self.goToVmPage(vmKaputt)
+        b.wait_text(f"#vm-{vmKaputt}-system-state", "Shut off")
+        domainXML = m.execute(f"virsh dumpxml {vmKaputt}")
+
+        self.performAction(vmKaputt, "replace-spice")
+        b.click("#replace-spice-dialog-confirm")
+        b.wait_in_text(".pf-v5-c-modal-box .pf-v5-c-alert", "Failed to replace SPICE devices")
+        b.click(".pf-v5-c-modal-box__footer button:contains(Cancel)")
+        b.wait_not_present(".pf-v5-c-modal-box")
+
+        # no change to the XML
+        self.assertEqual(m.execute(f"virsh dumpxml {vmKaputt}"), domainXML)
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
There are some hosts which don't support SPICE, e.g. RHEL 9 or any other
OS where the SPICE support packages are not installed. This action
prepares a VM so that upgrading/changing the host or migrating to a host
without SPICE support will work without failing to restart the VM again.
In particular, it converts "spice" graphics to "vnc", "qxl" video to
"vga", and drops all other spice devices which don't have a replacement
(audio and USB passthrough).

Only show the action if the domain actually has any SPICE devices.

https://issues.redhat.com/browse/RHEL-17434

-----

TODO:
 - [x] Don't migrate a spice graphics console to vnc if there is already a vnc one (covered by test)
 - [x] Handle running VMs, change only gets effective after restart → works, but needs verbiage/sandclock/alert
 - [x] Proper explanation text
 - [x] Integration test: remove spice from VM which doesn't already have VNC
 - [x] Integration test: remove spice from stopped VM
 - [x] Integration test: remove/disable spice packages and ensure that the VM still starts up
 - [x] Integration test: failed migration; it's not possible to add something "funny" to the original XML, as both `virsh edit` and `virsh define` reject invalid XML. So let's hack `virt-xml-validate` instead.
 - [x] Fix [flake with faking virt-xml-validate](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1387-20240118-135703-d3dbdd79-fedora-39/log.html#85-1); the `cockpit.spawn()` promise finishes too early

## Machines: Action to Replace SPICE devices

There are some VM host machines which don't support [SPICE features](https://www.spice-space.org/spice-user-manual.html). In particular, Red Hat Enterprise Linux 9 does not support SPICE at all, and on other operating systems the SPICE support packages may not be installed.

The VM action menu got a "Replace SPICE support" action which prepares a VM so that upgrading/changing the host or migrating to a host without SPICE support will work without failing to start the VM afterwards. In particular, it converts SPICE graphics to VNC, "qxl" video to "vga", and drops all other spice devices which don't have a replacement (audio and USB passthrough).

![Screen Shot 2024-01-24 at 10 03 30](https://github.com/cockpit-project/cockpit-machines/assets/200109/f2823ced-32ef-4bbb-b2c5-cf7937b1b7d3)

**TODO**: Add spice notification label from PR #1398 if it lands in time