### PR TITLE
Restyle "needs shutdown" dialog alert and page label

### DIFF
--- a/src/components/common/needsShutdown.jsx
+++ b/src/components/common/needsShutdown.jsx
@@ -119,7 +119,7 @@ export function getDevicesRequiringShutdown(vm) {
 export const NeedsShutdownTooltip = ({ iconId, tooltipId }) => {
     return (
         <Tooltip id={tooltipId} content={NEEDS_SHUTDOWN_MESSAGE}>
-            <Icon status="info">
+            <Icon status="custom">
                 <PendingIcon id={iconId} />
             </Icon>
         </Tooltip>
@@ -127,7 +127,7 @@ export const NeedsShutdownTooltip = ({ iconId, tooltipId }) => {
 };
 
 export const NeedsShutdownAlert = ({ idPrefix }) =>
-    <Alert isInline variant='warning' id={`${idPrefix}-idle-message`} title={NEEDS_SHUTDOWN_MESSAGE} />;
+    <Alert isInline id={`${idPrefix}-idle-message`} customIcon={<PendingIcon />} title={NEEDS_SHUTDOWN_MESSAGE} />;
 
 export const VmNeedsShutdown = ({ vm }) => {
     const devices = getDevicesRequiringShutdown(vm);
@@ -153,13 +153,12 @@ export const VmNeedsShutdown = ({ vm }) => {
     const header = _("VM needs shutdown");
     return (
         <Popover aria-label={header}
-            alertSeverityVariant="info"
             headerContent={header}
             headerIcon={<PendingIcon />}
             position="bottom"
             hasAutoWidth
             bodyContent={body}>
-            <Label className="resource-state-text" color="blue" id={`vm-${vm.name}-needs-shutdown`}
+            <Label className="resource-state-text" color="cyan" id={`vm-${vm.name}-needs-shutdown`}
                    icon={<PendingIcon />} onClick={() => null}>
                 {_("Changes pending")}
             </Label>


### PR DESCRIPTION
Tone down the dialog alert from "warning" to "custom" -- the user did nothing wrong, it's
an expected part of the workflow. Also use the "pending" icon.

Change the on-page label and popover to cyan and custom alert level to
match the dialog alert.

----

This was discussed with @garrett yesterday as a side issue in #1387. As this is a shared component, it should have a separate PR. This will apply to all dialogs, the vCPU one is easiest to test.

Current main:

![needs-shutdown-alert-original](https://github.com/cockpit-project/cockpit-machines/assets/200109/e3f0a13b-ad8e-4801-a4c8-dfb882d519fd)

![image](https://github.com/cockpit-project/cockpit-machines/assets/200109/a83b4ec0-bcfd-4b48-99be-7849637010a0)

This PR:

![needs-shutdown-alert-pr](https://github.com/cockpit-project/cockpit-machines/assets/200109/c89d6397-16db-4cf5-9b0d-be2599d866e5)

![image](https://github.com/cockpit-project/cockpit-machines/assets/200109/2911cfdf-2c4f-49eb-8e41-5bec138f9c32)


