### PR TITLE
Catch the error when the architecture doesn't support spice

### DIFF
--- a/src/scripts/install_machine.py
+++ b/src/scripts/install_machine.py
@@ -45,7 +45,7 @@ def get_graphics_capabilies(connection):
             if "platform:el8" in f.read():
                 logging.debug("get_graphics_capabilies: ignoring spice on RHEL 8")
                 consoles.remove('spice')
-    except FileNotFoundError:
+    except (FileNotFoundError, ValueError):
         pass  # not RHEL then
 
     logging.debug('get_graphics_capabilies: %s', ', '.join(consoles))


### PR DESCRIPTION
If the architecture(like s390x) doesn't support spice, there will be no corresponding value in consoles, and there will be an ValueError raised. The error is not catched, and the VM creation will be failed.

https://issues.redhat.com/browse/RHEL-22241