### PR TITLE
Port domain.js to async functions

### DIFF
--- a/src/components/vm/confirmDialog.jsx
+++ b/src/components/vm/confirmDialog.jsx
@@ -33,7 +33,7 @@ export const ConfirmDialog = ({ idPrefix, actionsList, title, titleIcon, vm }) =
     const [startTime, setStartTime] = useState();
 
     useEffect(() => {
-        return domainGetStartTime({ connectionName: vm.connectionName, vmName: vm.name })
+        domainGetStartTime({ connectionName: vm.connectionName, vmName: vm.name })
                 .then(res => setStartTime(res))
                 .catch(e => console.error(JSON.stringify(e)));
     }, [vm]);


### PR DESCRIPTION
This makes the functions easier to read, in particular the rather deeply nested domainGet() and domainCreate().

Keep the few functions which run several queries in parallel with `Promise.all()`, as that can't be done nicely with `await`.

Also use structural decomposition for the `call()` return values instead of always having to use their `[0]` element.

---

This is purely syntactic change, no logic changes.