### PR TITLE
Show alert label for SPICE VM if the host does not support it

### DIFF
--- a/src/components/vm/usesSpice.jsx
+++ b/src/components/vm/usesSpice.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Label } from "@patternfly/react-core/dist/esm/components/Label";
+import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
+import { ExclamationTriangleIcon } from "@patternfly/react-icons";
+
+import cockpit from 'cockpit';
+import { useDialogs } from 'dialogs.jsx';
+
+import { ReplaceSpiceDialog } from './vmReplaceSpiceDialog.jsx';
+
+const _ = cockpit.gettext;
+
+export const VmUsesSpice = ({ vm }) => {
+    const Dialogs = useDialogs();
+
+    if (!vm.hasSpice || vm.capabilities?.supportsSpice)
+        return null;
+
+    const onReplace = () => Dialogs.show(<ReplaceSpiceDialog vmName={vm.name}
+                                                             vmId={vm.id}
+                                                             connectionName={vm.connectionName}
+                                                             vmRunning={vm.state == 'running'} />);
+
+    const header = _("Uses SPICE");
+    return (
+        <Popover
+            alertSeverityVariant="warning"
+            headerContent={header}
+            headerIcon={<ExclamationTriangleIcon />}
+            position="bottom"
+            hasAutoWidth
+            bodyContent={
+                <>
+                    <p>{_("SPICE is not supported on this host and will cause this virtual machine to not boot.")}</p>
+                    <p>{_("Switch to VNC to continue using this machine.")}</p>
+                </>
+            }
+            footerContent={ hide =>
+                <Button variant="secondary" onClick={() => { hide(); onReplace() }}>
+                    {_("Replace SPICE devices")}
+                </Button>
+            }>
+            <Label className="resource-state-text" color="orange" id={`vm-${vm.name}-uses-spice`}
+                   icon={<ExclamationTriangleIcon />} onClick={() => null}>
+                {header}
+            </Label>
+        </Popover>
+    );
+};

--- a/src/components/vm/vmDetailsPage.jsx
+++ b/src/components/vm/vmDetailsPage.jsx
@@ -43,6 +43,7 @@ import VmUsageTab from './vmUsageCard.jsx';
 import { VmSnapshotsCard, VmSnapshotsActions } from './snapshots/vmSnapshotsCard.jsx';
 import VmActions from './vmActions.jsx';
 import { VmNeedsShutdown } from '../common/needsShutdown.jsx';
+import { VmUsesSpice } from './usesSpice.jsx';
 
 import './vmDetailsPage.scss';
 
@@ -72,6 +73,7 @@ export const VmDetailsPage = ({
                            onAddErrorNotification={onAddErrorNotification}
                            isDetailsPage />
                 <VmNeedsShutdown vm={vm} />
+                <VmUsesSpice vm={vm} />
             </div>
         </PageSection>
     );

--- a/src/libvirt-xml-parse.js
+++ b/src/libvirt-xml-parse.js
@@ -182,6 +182,21 @@ export function getDomainCapDiskBusTypes(capsXML) {
     return busElem && Array.prototype.map.call(busElem.getElementsByTagName("value"), valueElem => valueElem.textContent);
 }
 
+export function getDomainCapSupportsSpice(capsXML) {
+    const domainCapsElem = getElem(capsXML);
+    const graphicsCapsElems = domainCapsElem.getElementsByTagName("graphics")?.[0]
+            ?.getElementsByTagName("enum")?.[0]
+            ?.getElementsByTagName("value");
+    const hasSpiceGraphics = graphicsCapsElems && Array.prototype.find.call(
+        graphicsCapsElems, valueElem => valueElem.textContent == "spice");
+    const channelCapsElems = domainCapsElem.getElementsByTagName("channel")?.[0]
+            ?.getElementsByTagName("enum")?.[0]
+            ?.getElementsByTagName("value");
+    const hasSpiceChannel = channelCapsElems && Array.prototype.find.call(
+        channelCapsElems, valueElem => valueElem.textContent == "spicevmc");
+    return hasSpiceGraphics || hasSpiceChannel;
+}
+
 export function getSingleOptionalElem(parent, name) {
     const subElems = parent.getElementsByTagName(name);
     return subElems.length > 0 ? subElems[0] : undefined; // optional

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -56,6 +56,7 @@ import {
     getDomainCapCPUCustomModels,
     getDomainCapCPUHostModel,
     getDomainCapDiskBusTypes,
+    getDomainCapSupportsSpice,
     getSingleOptionalElem,
     parseDomainDumpxml,
     getHostDevElemBySource,
@@ -666,6 +667,7 @@ export async function domainGet({
             cpuModels: getDomainCapCPUCustomModels(domCaps),
             cpuHostModel: getDomainCapCPUHostModel(domCaps),
             supportedDiskBusTypes: getDomainCapDiskBusTypes(domCaps),
+            supportsSpice: getDomainCapSupportsSpice(domCaps),
         };
 
         const [state] = await call(connectionName, objPath, 'org.libvirt.Domain', 'GetState', [0], { timeout, type: 'u' });

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -2408,6 +2408,9 @@ vnc_password= "{vnc_passwd}"
         b.wait_text(f"#vm-{vmCockpit}-system-state", "Running")
         domainXML = m.execute(f"virsh dumpxml --inactive {vmCockpit}")
 
+        # no warning label: on RHEL the VM doesn't use SPICE, on other OSes the host supports SPICE
+        b.wait_not_present(f"#vm-{vmCockpit}-uses-spice")
+
         # on RHEL 9, SPICE is unsupported; on RHEL 8, we disable SPICE in VM creation; so we don't expect any device
         if m.image.startswith("rhel") or m.image.startswith("centos"):
             self.assertNotIn("spice", domainXML)
@@ -2443,11 +2446,13 @@ vnc_password= "{vnc_passwd}"
                 # restart the VM to make the change effective
                 self.performAction(vmCockpit, "forceOff")
                 b.wait_not_present(f"#vm-{vmCockpit}-needs-shutdown")
+                b.wait_not_present(f"#vm-{vmCockpit}-uses-spice")
                 b.click(f"#vm-{vmCockpit}-system-run")
                 b.wait_text(f"#vm-{vmCockpit}-system-state", "Running")
                 checkConnnectInfo(expect_vnc=True, expect_spice=False)
 
             b.wait_not_present(f"#vm-{vmCockpit}-needs-shutdown")
+            b.wait_not_present(f"#vm-{vmCockpit}-uses-spice")
 
         self.goToMainPage()
         self.machine.execute(f"virsh destroy {vmCockpit}; virsh undefine {vmCockpit}")
@@ -2498,6 +2503,43 @@ vnc_password= "{vnc_passwd}"
 
         # no change to the XML
         self.assertEqual(m.execute(f"virsh dumpxml {vmKaputt}"), domainXML)
+
+    # we need this test to create a SPICE VM to simulate the host change to "no spice support"
+    @testlib.skipImage('SPICE not supported on RHEL', "rhel-*", "centos-*")
+    @testlib.skipImage("SPICE support is compiled in, cannot be removed from the host", "ubuntu-2204")
+    def testNoSpiceAlert(self):
+        b = self.browser
+
+        vmName = "subVmTest1"
+        self.createVm(vmName, graphics="spice", running=False)
+
+        with self.remove_spice_plugins():
+            self.login_and_go("/machines")
+            self.waitPageInit()
+            self.waitVmRow(vmName, "system")
+            self.goToVmPage(vmName)
+            b.wait_text(f"#vm-{vmName}-system-state", "Shut off")
+
+            # warns
+            b.wait_visible(f"#vm-{vmName}-uses-spice")
+            # and indeed startup fails
+            b.click(f"#vm-{vmName}-system-run")
+            b.wait_in_text(f"#vm-{vmName}-system-state-error", "Failed")
+            b.click(f"#vm-{vmName}-system-state-error button[aria-label=Close]")
+            b.wait_not_present(f"#vm-{vmName}-system-state-error")
+
+            b.click(f"#vm-{vmName}-uses-spice")
+            b.wait_in_text(".pf-v5-c-popover", "Uses SPICE")
+            b.click(".pf-v5-c-popover footer button")
+            # clicking the action auto-closes the popover and brings up the dialog
+            b.wait_not_present(".pf-v5-c-popover")
+            b.click("#replace-spice-dialog-confirm")
+            b.wait_not_present(f"#vm-{vmName}-uses-spice")
+
+            # works now
+            b.click(f"#vm-{vmName}-system-run")
+            b.wait_text(f"#vm-{vmName}-system-state", "Running")
+            b.wait_not_present(f"#vm-{vmName}-system-state-error")
 
 
 if __name__ == '__main__':

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import contextlib
 import math
 import os
 import re
@@ -2321,6 +2322,25 @@ vnc_password= "{vnc_passwd}"
                                               "expired",
                                               False)
 
+    @contextlib.contextmanager
+    def remove_spice_plugins(self):
+        m = self.machine
+        # avoid uninstalling packages to keep this nondestructive
+        plugins = m.execute("find /usr/lib* -path '*qemu*spice*' | xargs").strip()
+        try:
+            m.execute(f"mkdir {self.vm_tmpdir}/qemu; for f in {plugins}; do mv $f {self.vm_tmpdir}/qemu; done")
+            caps = m.execute("virsh domcapabilities")
+            if m.image.startswith("debian") or m.image.startswith("ubuntu"):
+                # on Debian, spice graphics is built in, spicevmc channels are a plugin
+                self.assertNotIn("spicevmc", caps)
+            else:
+                # in Fedora/RHEL we don't expect any remaining capability
+                self.assertNotIn("spice", caps)
+
+            yield
+        finally:
+            m.execute(f"for f in {plugins}; do mv {self.vm_tmpdir}/qemu/$(basename $f) $f; done")
+
     def testReplaceSpice(self):
         m = self.machine
         b = self.browser
@@ -2419,26 +2439,13 @@ vnc_password= "{vnc_passwd}"
                 self.fail("timed out waiting for Replace SPICE menu item removal")
 
             # ensure that the VM can start without any SPICE plugins
-            # avoid uninstalling packages to keep this nondestructive
-            plugins = m.execute("find /usr/lib* -path '*qemu*spice*' | xargs").strip()
-            try:
-                m.execute(f"mkdir {self.vm_tmpdir}/qemu; for f in {plugins}; do mv $f {self.vm_tmpdir}/qemu; done")
-                caps = m.execute("virsh domcapabilities")
-                if m.image.startswith("debian") or m.image.startswith("ubuntu"):
-                    # on Debian, spice graphics is built in, spicevmc channels are a plugin
-                    self.assertNotIn("spicevmc", caps)
-                else:
-                    # in Fedora/RHEL we don't expect any remaining capability
-                    self.assertNotIn("spice", caps)
-
+            with self.remove_spice_plugins():
                 # restart the VM to make the change effective
                 self.performAction(vmCockpit, "forceOff")
                 b.wait_not_present(f"#vm-{vmCockpit}-needs-shutdown")
                 b.click(f"#vm-{vmCockpit}-system-run")
                 b.wait_text(f"#vm-{vmCockpit}-system-state", "Running")
                 checkConnnectInfo(expect_vnc=True, expect_spice=False)
-            finally:
-                m.execute(f"for f in {plugins}; do mv {self.vm_tmpdir}/qemu/$(basename $f) $f; done")
 
             b.wait_not_present(f"#vm-{vmCockpit}-needs-shutdown")
 


### PR DESCRIPTION
This makes the operation more discoverable in situations where VM
startup is already broken.

----

Related to https://issues.redhat.com/browse/RHEL-17434

This implements the [next step in the design](https://github.com/cockpit-project/cockpit-machines/pull/1387#issuecomment-1895348199):

![image](https://github.com/cockpit-project/cockpit-machines/assets/200109/d27ca88a-86f2-4382-9f01-399ac57c81c3)

This only appears on the details page, not on the overview, as it's rather expensive to determine this for all VMs at the same time on the overview -- I don't feel like penalizing all users all the time for this fringe case.

 - [x] builds on top of PR #1387 