### PR TITLE
Use python.spawn() for calling install_machine.py

### DIFF
--- a/src/libvirtApi/common.js
+++ b/src/libvirtApi/common.js
@@ -49,7 +49,6 @@ import {
 import {
     domainGet,
     domainGetAll,
-    getPythonPath,
 } from "../libvirtApi/domain.js";
 import {
     call,
@@ -444,7 +443,6 @@ export function getApiData({ connectionName }) {
 }
 
 export const initState = () => Promise.all([
-    getPythonPath(),
     getLoggedInUser(),
     getOsInfoList(),
 ]);


### PR DESCRIPTION
This avoids duplicating the logic for detecting the Python interpreter.

---

@jelly That was a follow-up from https://github.com/cockpit-project/cockpit-machines/pull/1397#discussion_r1463114858