### PR TITLE
Add "Pre-formatted Block Device" to createStoragePoolDialog

### DIFF
--- a/src/components/storagePools/createStoragePoolDialog.jsx
+++ b/src/components/storagePools/createStoragePoolDialog.jsx
@@ -152,6 +152,10 @@ const StoragePoolSourceRow = ({ onValueChanged, dialogValues }) => {
     let placeholder;
     const diskPoolSourceFormatTypes = ['dos', 'dvh', 'gpt', 'mac'];
     const diskPoolSourceFsTypes = ['auto', 'ext2', 'ext3', 'ext4', 'xfs'];
+    /*
+      FsTypes lists the types listed below:
+      https://libvirt.org/storage.html#valid-filesystem-pool-format-types
+    */
 
     if (dialogValues.type == 'netfs') {
         validationState = dialogValues.source.dir.length == 0 && dialogValues.validationFailed.source ? 'error' : 'default';

--- a/src/components/storagePools/createStoragePoolDialog.jsx
+++ b/src/components/storagePools/createStoragePoolDialog.jsx
@@ -151,11 +151,8 @@ const StoragePoolSourceRow = ({ onValueChanged, dialogValues }) => {
     let validationState;
     let placeholder;
     const diskPoolSourceFormatTypes = ['dos', 'dvh', 'gpt', 'mac'];
+    // https://libvirt.org/storage.html#valid-filesystem-pool-format-types
     const diskPoolSourceFsTypes = ['auto', 'ext2', 'ext3', 'ext4', 'xfs'];
-    /*
-      FsTypes lists the types listed below:
-      https://libvirt.org/storage.html#valid-filesystem-pool-format-types
-    */
 
     if (dialogValues.type == 'netfs') {
         validationState = dialogValues.source.dir.length == 0 && dialogValues.validationFailed.source ? 'error' : 'default';

--- a/src/components/storagePools/createStoragePoolDialog.jsx
+++ b/src/components/storagePools/createStoragePoolDialog.jsx
@@ -60,6 +60,7 @@ const StoragePoolTypeRow = ({ onValueChanged, dialogValues, libvirtVersion, pool
         { type: 'iscsi', detail: _("iSCSI target") },
         { type: 'disk', detail: _("Physical disk device") },
         { type: 'logical', detail: _("LVM volume group") },
+        { type: 'fs', detail: _("Pre-formatted Block Device") },
     ];
     // iscsi-direct exists since 4.7.0
     if (libvirtVersion && libvirtVersion >= 4007000)
@@ -68,7 +69,6 @@ const StoragePoolTypeRow = ({ onValueChanged, dialogValues, libvirtVersion, pool
     const supportedPoolTypes = poolTypes.filter(pool => poolCapabilities[pool.type] ? poolCapabilities[pool.type].supported === "yes" : true);
 
     /* TODO
-        { type: 'fs', detail _("Pre-formatted Block Device") },
         { type: 'gluster', detail _("Gluster Filesystem") },
         { type: 'mpath', detail _("Multipath Device Enumerator") },
         { type: 'rbd', detail _("RADOS Block Device/Ceph") },
@@ -98,7 +98,7 @@ const StoragePoolTypeRow = ({ onValueChanged, dialogValues, libvirtVersion, pool
 const StoragePoolTargetRow = ({ onValueChanged, dialogValues }) => {
     const validationState = dialogValues.target.length == 0 && dialogValues.validationFailed.target ? 'error' : 'default';
 
-    if (['dir', 'netfs', 'iscsi', 'disk'].includes(dialogValues.type)) {
+    if (['dir', 'netfs', 'iscsi', 'disk', 'fs'].includes(dialogValues.type)) {
         return (
             <FormGroup fieldId='storage-pool-dialog-target' label={_("Target path")}
                        id="storage-pool-dialog-target-group">
@@ -151,6 +151,7 @@ const StoragePoolSourceRow = ({ onValueChanged, dialogValues }) => {
     let validationState;
     let placeholder;
     const diskPoolSourceFormatTypes = ['dos', 'dvh', 'gpt', 'mac'];
+    const diskPoolSourceFsTypes = ['auto', 'ext2', 'ext3', 'ext4', 'xfs'];
 
     if (dialogValues.type == 'netfs') {
         validationState = dialogValues.source.dir.length == 0 && dialogValues.validationFailed.source ? 'error' : 'default';
@@ -200,6 +201,35 @@ const StoragePoolSourceRow = ({ onValueChanged, dialogValues }) => {
                                 value={dialogValues.source.format}
                                 onChange={(_event, value) => onValueChanged('source', { format: value })}>
                         { diskPoolSourceFormatTypes
+                                .map(format => {
+                                    return (
+                                        <FormSelectOption value={format} key={format}
+                                                          label={format} />
+                                    );
+                                })
+                        }
+                    </FormSelect>
+                </FormGroup>
+            </Grid>
+        );
+    else if (dialogValues.type == 'fs')
+        return (
+            <Grid hasGutter>
+                <FormGroup fieldId='storage-pool-dialog-source' label={_("Source path")}
+                           className="pf-m-8-col"
+                           id="storage-pool-dialog-source-group">
+                    <FileAutoComplete id='storage-pool-dialog-source'
+                                      superuser='try'
+                                      placeholder={placeholder}
+                                      onChange={value => onValueChanged('source', { device: value })} />
+                    <FormHelper fieldId="storage-pool-dialog-source" helperTextInvalid={validationState == "error" && _("Source path should not be empty")} />
+                </FormGroup>
+                <FormGroup fieldId='storage-pool-dialog-source-format' label={_("Format")}
+                           className="pf-m-4-col">
+                    <FormSelect id='storage-pool-dialog-source-format'
+                                value={dialogValues.source.format}
+                                onChange={(_event, value) => onValueChanged('source', { format: value })}>
+                        { diskPoolSourceFsTypes
                                 .map(format => {
                                     return (
                                         <FormSelectOption value={format} key={format}

--- a/src/components/storagePools/createStoragePoolDialog.jsx
+++ b/src/components/storagePools/createStoragePoolDialog.jsx
@@ -183,7 +183,7 @@ const StoragePoolSourceRow = ({ onValueChanged, dialogValues }) => {
                 <FormHelper fieldId="storage-pool-dialog-source" helperTextInvalid={validationState == "error" && _("Source path should not be empty")} />
             </FormGroup>
         );
-    else if (dialogValues.type == 'disk')
+    else if (dialogValues.type == 'disk' || dialogValues.type == 'fs')
         return (
             <Grid hasGutter>
                 <FormGroup fieldId='storage-pool-dialog-source' label={_("Source path")}
@@ -200,36 +200,7 @@ const StoragePoolSourceRow = ({ onValueChanged, dialogValues }) => {
                     <FormSelect id='storage-pool-dialog-source-format'
                                 value={dialogValues.source.format}
                                 onChange={(_event, value) => onValueChanged('source', { format: value })}>
-                        { diskPoolSourceFormatTypes
-                                .map(format => {
-                                    return (
-                                        <FormSelectOption value={format} key={format}
-                                                          label={format} />
-                                    );
-                                })
-                        }
-                    </FormSelect>
-                </FormGroup>
-            </Grid>
-        );
-    else if (dialogValues.type == 'fs')
-        return (
-            <Grid hasGutter>
-                <FormGroup fieldId='storage-pool-dialog-source' label={_("Source path")}
-                           className="pf-m-8-col"
-                           id="storage-pool-dialog-source-group">
-                    <FileAutoComplete id='storage-pool-dialog-source'
-                                      superuser='try'
-                                      placeholder={placeholder}
-                                      onChange={value => onValueChanged('source', { device: value })} />
-                    <FormHelper fieldId="storage-pool-dialog-source" helperTextInvalid={validationState == "error" && _("Source path should not be empty")} />
-                </FormGroup>
-                <FormGroup fieldId='storage-pool-dialog-source-format' label={_("Format")}
-                           className="pf-m-4-col">
-                    <FormSelect id='storage-pool-dialog-source-format'
-                                value={dialogValues.source.format}
-                                onChange={(_event, value) => onValueChanged('source', { format: value })}>
-                        { diskPoolSourceFsTypes
+                        { (dialogValues.type === 'fs' ? diskPoolSourceFsTypes : diskPoolSourceFormatTypes)
                                 .map(format => {
                                     return (
                                         <FormSelectOption value={format} key={format}

--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -488,6 +488,20 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
             source={"source_path": "vol_grp1"},
         ).execute()
 
+        # Prepare a disk with ext4 filesystem to test the fs storage pool type
+        dev = self.add_ram_disk(2)
+        m.execute(f"parted {dev} mklabel gpt")
+        m.execute(f"parted -s {dev} mkpart primary ext4 0% 100%")
+        part_dev = f"{dev}p1"
+        m.execute(f"mkfs.ext4 {part_dev}")
+        StoragePoolCreateDialog(
+            delf,
+            name="my_fs_pool",
+            pool_type="fs",
+            target="/media/",
+            source={"source_path": dev, "format":"ext4"},
+        ).execute()
+
     def testStorageVolumesCreate(self):
         b = self.browser
         m = self.machine

--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -489,7 +489,6 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
         ).execute()
 
         # Prepare a disk with ext4 filesystem to test the fs storage pool type
-        dev = self.add_ram_disk(2)
         m.execute(f"parted {dev} mklabel gpt")
         m.execute(f"parted -s {dev} mkpart primary ext4 0% 100%")
         part_dev = f"{dev}p1"

--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -498,7 +498,7 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
             name="my_fs_pool",
             pool_type="fs",
             target="/media/",
-            source={"source_path": part_dev, "format":"ext4"},
+            source={"source_path": part_dev, "format": "ext4"},
         ).execute()
 
     def testStorageVolumesCreate(self):

--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -270,7 +270,7 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
                     b.set_file_autocomplete_val("#storage-pool-dialog-target-group", self.target)
 
                 if 'source_path' in self.source:
-                    if self.pool_type != 'disk':
+                    if self.pool_type not in ['disk', 'fs']:
                         b.set_input_text("#storage-pool-dialog-source", self.source['source_path'])
                     else:
                         b.set_file_autocomplete_val("#storage-pool-dialog-source-group", self.source['source_path'])
@@ -490,15 +490,15 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
 
         # Prepare a disk with ext4 filesystem to test the fs storage pool type
         m.execute(f"parted {dev} mklabel gpt")
-        m.execute(f"parted -s {dev} mkpart primary ext4 0% 100%")
-        part_dev = f"{dev}p1"
+        m.execute(f"parted -s {dev} mkpart primary ext4 20kiB 2000kiB")
+        part_dev = f"{dev}1"
         m.execute(f"mkfs.ext4 {part_dev}")
         StoragePoolCreateDialog(
             self,
             name="my_fs_pool",
             pool_type="fs",
             target="/media/",
-            source={"source_path": dev, "format":"ext4"},
+            source={"source_path": part_dev, "format":"ext4"},
         ).execute()
 
     def testStorageVolumesCreate(self):

--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -495,7 +495,7 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
         part_dev = f"{dev}p1"
         m.execute(f"mkfs.ext4 {part_dev}")
         StoragePoolCreateDialog(
-            delf,
+            self,
             name="my_fs_pool",
             pool_type="fs",
             target="/media/",


### PR DESCRIPTION
Partition-based storage pool (use Pre-formatted Block Device) created by
virt-manager and virsh could not be created by cockpit-machines before.
With this change, when cockpit-machines creates a storage pool, it will be possible
to select a partition-based pool type.
![fs-create1](https://github.com/cockpit-project/cockpit-machines/assets/116320458/a5acfb84-fa6a-4ce9-9060-88a050991c09)
![fs-create2](https://github.com/cockpit-project/cockpit-machines/assets/116320458/ba2f6e7c-fa30-4ec4-8c3b-74770c96579d)

## Machines: Add support for Pre-formatted Block Device storage pool type

This pool type is similar to the existing "Physical disk device", but more robust: It avoids that the [guest sees and possibly reformats the raw disk device on its own](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_virtualization/managing-storage-for-virtual-machines_configuring-and-managing-virtualization#proc_creating-disk-based-storage-pools-using-the-web-console_assembly_managing-virtual-machine-storage-pools-using-the-web-console).

![fs-create1](https://github.com/cockpit-project/cockpit-machines/assets/116320458/a5acfb84-fa6a-4ce9-9060-88a050991c09)

_Thanks to Haruka Ohata for this contribution!_