### PR TITLE
Show "Uses SPICE" warning on the overview

### DIFF
--- a/src/components/vms/hostvmslist.jsx
+++ b/src/components/vms/hostvmslist.jsx
@@ -38,6 +38,7 @@ import { vmId, rephraseUI, dummyVmsFilter, DOMAINSTATE } from "../../helpers.js"
 import { ListingTable } from "cockpit-components-table.jsx";
 import StateIcon from '../common/stateIcon.jsx';
 import { VmNeedsShutdown } from '../common/needsShutdown.jsx';
+import { VmUsesSpice } from '../vm/usesSpice.jsx';
 import { AggregateStatusCards } from "../aggregateStatusCards.jsx";
 import store from "../../store.js";
 
@@ -59,7 +60,7 @@ const VmState = ({ vm, dismissError }) => {
             error={vm.error}
             state={state}
             valueId={`${vmId(vm.name)}-${vm.connectionName}-state`}
-            additionalState={<VmNeedsShutdown vm={vm} />} />
+            additionalState={<><VmNeedsShutdown vm={vm} /><VmUsesSpice vm={vm} /></>} />
     );
 };
 

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -2518,10 +2518,12 @@ vnc_password= "{vnc_passwd}"
             self.login_and_go("/machines")
             self.waitPageInit()
             self.waitVmRow(vmName, "system")
+            # warns on the overview
+            b.wait_visible(f"#vm-{vmName}-uses-spice")
             self.goToVmPage(vmName)
             b.wait_text(f"#vm-{vmName}-system-state", "Shut off")
 
-            # warns
+            # warns on the details page
             b.wait_visible(f"#vm-{vmName}-uses-spice")
             # and indeed startup fails
             b.click(f"#vm-{vmName}-system-run")


### PR DESCRIPTION
It turns out that the overview already reads all the VM's XML, so we can show the alert label from commit 5258c32d57f285 also on the overview.

![image](https://github.com/cockpit-project/cockpit-machines/assets/200109/045fe433-f358-415d-915d-9dafcdf4c16f)
