### PR TITLE
Add mass SPICE replacement

### DIFF
--- a/src/components/vm/usesSpice.jsx
+++ b/src/components/vm/usesSpice.jsx
@@ -11,13 +11,13 @@ import { ReplaceSpiceDialog } from './vmReplaceSpiceDialog.jsx';
 
 const _ = cockpit.gettext;
 
-export const VmUsesSpice = ({ vm }) => {
+export const VmUsesSpice = ({ vm, vms }) => {
     const Dialogs = useDialogs();
 
     if (!vm.hasSpice || vm.capabilities?.supportsSpice)
         return null;
 
-    const onReplace = () => Dialogs.show(<ReplaceSpiceDialog vm={vm} />);
+    const onReplace = () => Dialogs.show(<ReplaceSpiceDialog vm={vm} vms={vms} />);
 
     const header = _("Uses SPICE");
     return (

--- a/src/components/vm/usesSpice.jsx
+++ b/src/components/vm/usesSpice.jsx
@@ -17,10 +17,7 @@ export const VmUsesSpice = ({ vm }) => {
     if (!vm.hasSpice || vm.capabilities?.supportsSpice)
         return null;
 
-    const onReplace = () => Dialogs.show(<ReplaceSpiceDialog vmName={vm.name}
-                                                             vmId={vm.id}
-                                                             connectionName={vm.connectionName}
-                                                             vmRunning={vm.state == 'running'} />);
+    const onReplace = () => Dialogs.show(<ReplaceSpiceDialog vm={vm} />);
 
     const header = _("Uses SPICE");
     return (

--- a/src/components/vm/vmActions.jsx
+++ b/src/components/vm/vmActions.jsx
@@ -178,7 +178,7 @@ const onSendNMI = (vm) => domainSendNMI({ name: vm.name, id: vm.id, connectionNa
     );
 });
 
-const VmActions = ({ vm, onAddErrorNotification, isDetailsPage }) => {
+const VmActions = ({ vm, vms, onAddErrorNotification, isDetailsPage }) => {
     const Dialogs = useDialogs();
     const [isActionOpen, setIsActionOpen] = useState(false);
     const [operationInProgress, setOperationInProgress] = useState(false);
@@ -433,7 +433,7 @@ const VmActions = ({ vm, onAddErrorNotification, isDetailsPage }) => {
         dropdownItems.push(
             <DropdownItem key={`${id}-replace-spice`}
                           id={`${id}-replace-spice`}
-                          onClick={() => Dialogs.show(<ReplaceSpiceDialog vm={vm} />)}>
+                          onClick={() => Dialogs.show(<ReplaceSpiceDialog vm={vm} vms={vms} />)}>
                 {_("Replace SPICE devices")}
             </DropdownItem>
         );
@@ -492,6 +492,7 @@ const VmActions = ({ vm, onAddErrorNotification, isDetailsPage }) => {
 
 VmActions.propTypes = {
     vm: PropTypes.object.isRequired,
+    vms: PropTypes.array,
     onAddErrorNotification: PropTypes.func.isRequired,
 };
 

--- a/src/components/vm/vmActions.jsx
+++ b/src/components/vm/vmActions.jsx
@@ -433,10 +433,7 @@ const VmActions = ({ vm, onAddErrorNotification, isDetailsPage }) => {
         dropdownItems.push(
             <DropdownItem key={`${id}-replace-spice`}
                           id={`${id}-replace-spice`}
-                          onClick={() => Dialogs.show(<ReplaceSpiceDialog vmName={vm.name}
-                                                                          vmId={vm.id}
-                                                                          connectionName={vm.connectionName}
-                                                                          vmRunning={vm.state == 'running'} />)}>
+                          onClick={() => Dialogs.show(<ReplaceSpiceDialog vm={vm} />)}>
                 {_("Replace SPICE devices")}
             </DropdownItem>
         );

--- a/src/components/vm/vmReplaceSpiceDialog.jsx
+++ b/src/components/vm/vmReplaceSpiceDialog.jsx
@@ -32,7 +32,7 @@ import { domainReplaceSpice } from '../../libvirtApi/domain.js';
 
 const _ = cockpit.gettext;
 
-export const ReplaceSpiceDialog = ({ vmName, vmId, connectionName, vmRunning }) => {
+export const ReplaceSpiceDialog = ({ vm }) => {
     const Dialogs = useDialogs();
     const [error, dialogErrorSet] = useState(null);
     const [inProgress, setInProgress] = useState(false);
@@ -40,7 +40,7 @@ export const ReplaceSpiceDialog = ({ vmName, vmId, connectionName, vmRunning }) 
     function onReplace() {
         setInProgress(true);
 
-        return domainReplaceSpice({ connectionName, id: vmId })
+        return domainReplaceSpice({ connectionName: vm.connectionName, id: vm.id })
                 .then(() => Dialogs.close())
                 .catch(exc => {
                     // we don't know of any case where this would fail, so this is all belt-and-suspenders
@@ -60,7 +60,7 @@ export const ReplaceSpiceDialog = ({ vmName, vmId, connectionName, vmRunning }) 
 
     return (
         <Modal position="top" variant="small" isOpen onClose={Dialogs.close}
-           title={cockpit.format(_("Replace SPICE devices in VM $0"), vmName)}
+           title={cockpit.format(_("Replace SPICE devices in VM $0"), vm.name)}
            footer={
                <>
                    <Button variant='primary'
@@ -74,7 +74,7 @@ export const ReplaceSpiceDialog = ({ vmName, vmId, connectionName, vmRunning }) 
                    </Button>
                </>
            }>
-            { vmRunning && !error && <NeedsShutdownAlert idPrefix="spice-modal" /> }
+            { vm.state === 'running' && !error && <NeedsShutdownAlert idPrefix="spice-modal" /> }
             {error && <ModalError dialogError={error.dialogError} dialogErrorDetail={error.dialogErrorDetail} />}
             <TextContent>
                 <Text>{_("Reconfigure the virtual machine for a host which does not support SPICE, for host upgrades or live migration:")}</Text>

--- a/src/components/vm/vmReplaceSpiceDialog.jsx
+++ b/src/components/vm/vmReplaceSpiceDialog.jsx
@@ -20,8 +20,14 @@
 import cockpit from 'cockpit';
 import React, { useState } from 'react';
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Divider } from "@patternfly/react-core/dist/esm/components/Divider";
+import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
+import { Menu, MenuContent, MenuList, MenuItem } from "@patternfly/react-core/dist/esm/components/Menu";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
+import { Panel, PanelFooter, PanelMain, PanelMainBody } from "@patternfly/react-core/dist/esm/components/Panel";
 import { Text, TextContent, TextList, TextListItem } from "@patternfly/react-core/dist/esm/components/Text";
+import { HelpIcon } from '@patternfly/react-icons';
+import { Popover, PopoverPosition } from "@patternfly/react-core/dist/esm/components/Popover";
 
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
 import { useDialogs } from 'dialogs.jsx';
@@ -30,42 +36,98 @@ import { fmt_to_fragments } from 'utils.jsx';
 import { NeedsShutdownAlert } from '../common/needsShutdown.jsx';
 import { domainReplaceSpice } from '../../libvirtApi/domain.js';
 
+import './vmReplaceSpiceDialog.scss';
+
 const _ = cockpit.gettext;
 
-export const ReplaceSpiceDialog = ({ vm }) => {
+const selectionId = vm => vm.connectionName + vm.id;
+
+export const ReplaceSpiceDialog = ({ vm, vms }) => {
+    const spiceVMs = vms?.filter(vm => vm.inactiveXML?.hasSpice);
+    // sort spiceVMs by name, put the current VM first
+    spiceVMs?.sort((a, b) => (a === vm) ? -1 : (b === vm) ? 1 : a.name.localeCompare(b.name));
+    const isMultiple = spiceVMs?.length > 1;
+
     const Dialogs = useDialogs();
     const [error, dialogErrorSet] = useState(null);
     const [inProgress, setInProgress] = useState(false);
+    const defaultSelected = isMultiple ? [selectionId(spiceVMs[0])] : null;
+    const [selected, setSelected] = useState(defaultSelected);
 
-    function onReplace() {
+    async function onReplace() {
         setInProgress(true);
 
-        return domainReplaceSpice({ connectionName: vm.connectionName, id: vm.id })
-                .then(() => Dialogs.close())
-                .catch(exc => {
-                    // we don't know of any case where this would fail, so this is all belt-and-suspenders
-                    // still, give the user some hint how to go on
-                    console.warn("Failed to replace SPICE devices:", exc);
-                    dialogErrorSet({
-                        dialogError: _("Failed to replace SPICE devices"),
-                        dialogErrorDetail: fmt_to_fragments(
-                            _("Please see $0 how to reconfigure your VM manually."),
-                            <a href="https://access.redhat.com/solutions/6955095" target="_blank" rel="noopener noreferrer">
-                                https://access.redhat.com/solutions/6955095
-                            </a>),
-                    });
-                })
-                .finally(() => setInProgress(false));
+        try {
+            if (isMultiple) {
+                // convert them serially, to avoid hammering libvirt with too many parallel requests
+                for (const sel of spiceVMs)
+                    if (selected.includes(selectionId(sel)))
+                        await domainReplaceSpice({ connectionName: sel.connectionName, id: sel.id });
+            } else {
+                await domainReplaceSpice({ connectionName: vm.connectionName, id: vm.id });
+            }
+            Dialogs.close();
+        } catch (ex) {
+            // we don't know of any case where this would fail, so this is all belt-and-suspenders
+            // still, give the user some hint how to go on
+            console.warn("Failed to replace SPICE devices:", ex);
+            setInProgress(false);
+            dialogErrorSet({
+                dialogError: _("Failed to replace SPICE devices"),
+                dialogErrorDetail: fmt_to_fragments(
+                    _("Please see $0 how to reconfigure your VM manually."),
+                    <a href="https://access.redhat.com/solutions/6955095" target="_blank" rel="noopener noreferrer">
+                        https://access.redhat.com/solutions/6955095
+                    </a>),
+            });
+        }
+    }
+
+    let vmSelect = null;
+
+    if (isMultiple) {
+        const onSelect = (_ev, item) => setSelected(
+            selected.includes(item)
+                ? selected.filter(id => id !== item)
+                : [...selected, item]
+        );
+        const menuItems = spiceVMs.map(vm => <MenuItem key={selectionId(vm)}
+                                                       hasCheckbox
+                                                       itemId={selectionId(vm)}
+                                                       isSelected={selected.includes(selectionId(vm))}>{vm.name}</MenuItem>);
+        menuItems.splice(1, 0, <Divider component="li" key="divider" />);
+        menuItems.splice(2, 0, <MenuItem isDisabled key="heading">{_("Other VMs using SPICE")}</MenuItem>);
+
+        const allSelected = selected.length === spiceVMs.length;
+
+        vmSelect = (
+            <Panel variant="bordered" isScrollable className="spice-replace-dialog-panel">
+                <PanelMain>
+                    <PanelMainBody>
+                        <Menu id="replace-spice-dialog-other" selected={selected} onSelect={onSelect} isPlain>
+                            <MenuContent><MenuList>{menuItems}</MenuList></MenuContent>
+                        </Menu>
+                    </PanelMainBody>
+                </PanelMain>
+                <PanelFooter>
+                    <Button id="replace-spice-dialog-select-all" variant='link'
+                            onClick={() => setSelected(allSelected ? defaultSelected : spiceVMs.map(selectionId))}>
+                        {allSelected ? _("Deselect others") : _("Select all")}
+                    </Button>
+                </PanelFooter>
+            </Panel>
+        );
     }
 
     return (
         <Modal position="top" variant="small" isOpen onClose={Dialogs.close}
-           title={cockpit.format(_("Replace SPICE devices in VM $0"), vm.name)}
+           title={isMultiple ? _("Replace SPICE devices") : cockpit.format(_("Replace SPICE devices in VM $0"), vm.name)}
            footer={
                <>
                    <Button variant='primary'
                            id="replace-spice-dialog-confirm"
                            isDisabled={inProgress}
+                           isLoading={inProgress}
                            onClick={onReplace}>
                        {_("Replace")}
                    </Button>
@@ -77,13 +139,34 @@ export const ReplaceSpiceDialog = ({ vm }) => {
             { vm.state === 'running' && !error && <NeedsShutdownAlert idPrefix="spice-modal" /> }
             {error && <ModalError dialogError={error.dialogError} dialogErrorDetail={error.dialogErrorDetail} />}
             <TextContent>
-                <Text>{_("Reconfigure the virtual machine for a host which does not support SPICE, for host upgrades or live migration:")}</Text>
-                <TextList>
-                    <TextListItem>{_("Convert SPICE graphics console to VNC.")}</TextListItem>
-                    <TextListItem>{_("Convert QXL video card to VGA.")}</TextListItem>
-                    <TextListItem>{_("Remove SPICE audio and host devices.")}</TextListItem>
-                </TextList>
+                <Flex spaceItems={{ default: 'spaceItemsNone' }}>
+                    <FlexItem>
+                        <Text>
+                            {isMultiple
+                                ? _("Replace SPICE on selected VMs.")
+                                : _("Replace SPICE on the virtual machine.") }
+                        </Text>
+                    </FlexItem>
+                    <FlexItem>
+                        <Popover aria-label={_("SPICE conversion")}
+                                position={PopoverPosition.top}
+                                headerContent={_("SPICE conversion")}
+                                bodyContent={
+                                    <TextList className="spice-replace-dialog-popover-list">
+                                        <TextListItem>{_("Convert SPICE graphics console to VNC")}</TextListItem>
+                                        <TextListItem>{_("Convert QXL video card to VGA")}</TextListItem>
+                                        <TextListItem>{_("Remove SPICE audio and host devices")}</TextListItem>
+                                    </TextList>
+                                }>
+                            <Button variant='link' aria-label={_("Help")} icon={<HelpIcon />}> </Button>
+                        </Popover>
+                    </FlexItem>
+                </Flex>
+                <Text>
+                    {_("This is intended for a host which does not support SPICE due to upgrades or live migration.")}
+                </Text>
             </TextContent>
+            { vmSelect }
         </Modal>
     );
 };

--- a/src/components/vm/vmReplaceSpiceDialog.scss
+++ b/src/components/vm/vmReplaceSpiceDialog.scss
@@ -1,0 +1,25 @@
+.spice-replace-dialog-panel {
+    // drop excessive inside spacing
+    .pf-v5-c-panel__main-body {
+        padding-block-start: 0;
+        padding-block-end: 0;
+        padding-inline-start: 0;
+        padding-inline-end: 0;
+    }
+
+    // but separate it a bit from the text above
+    margin-block-start: var(--pf-v5-global--spacer--md);
+}
+
+.spice-replace-dialog-popover-list {
+    list-style: inside;
+}
+
+// HACK: fix blurred line between panel main body and footer; this should go into the PF overrides
+.pf-v5-c-panel.pf-m-scrollable {
+    --pf-v5-c-panel__footer--BoxShadow: 0 -1px var(--pf-v5-global--BorderColor--100);
+}
+
+#replace-spice-dialog-select-all {
+    --pf-v5-c-button--PaddingLeft: 0;
+}

--- a/src/components/vms/hostvmslist.jsx
+++ b/src/components/vms/hostvmslist.jsx
@@ -44,7 +44,7 @@ import store from "../../store.js";
 
 import "./hostvmslist.scss";
 
-const VmState = ({ vm, dismissError }) => {
+const VmState = ({ vm, vms, dismissError }) => {
     let state = null;
 
     if (vm.downloadProgress) {
@@ -60,7 +60,7 @@ const VmState = ({ vm, dismissError }) => {
             error={vm.error}
             state={state}
             valueId={`${vmId(vm.name)}-${vm.connectionName}-state`}
-            additionalState={<><VmNeedsShutdown vm={vm} /><VmUsesSpice vm={vm} /></>} />
+            additionalState={<><VmNeedsShutdown vm={vm} /><VmUsesSpice vm={vm} vms={vms} /></>} />
     );
 };
 
@@ -154,6 +154,7 @@ const HostVmsList = ({ vms, config, ui, storagePools, actions, networks, onAddEr
                                         const vmActions = (
                                             <VmActions
                                                 vm={vm}
+                                                vms={vms}
                                                 config={config}
                                                 storagePools={storagePools}
                                                 onAddErrorNotification={onAddErrorNotification}
@@ -175,6 +176,7 @@ const HostVmsList = ({ vms, config, ui, storagePools, actions, networks, onAddEr
                                                 {
                                                     title: (
                                                         <VmState vm={vm}
+                                                                 vms={vms}
                                                                  dismissError={() => store.dispatch(updateVm({
                                                                      connectionName: vm.connectionName,
                                                                      name: vm.name,

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -2370,16 +2370,23 @@ vnc_password= "{vnc_passwd}"
             else:
                 self.assertNotIn("SPICE", b.text(".pf-v5-c-console__manual-connection"))
 
-        def doReplaceSpice(vmName, expect_running=False):
+        def doReplaceSpiceSingle(vmName, expect_running=False, cancel=False):
             self.performAction(vmName, "replace-spice")
+            b.wait_text(".pf-v5-c-modal-box__title-text", f"Replace SPICE devices in VM {vmName}")
+            b.wait_in_text(".pf-v5-c-modal-box__body", "Replace SPICE on the virtual machine")
             if expect_running:
                 b.wait_visible("#spice-modal-idle-message")
             else:
-                b.wait_in_text(".pf-v5-c-modal-box__body", "Reconfigure")
                 self.assertFalse(b.is_present("#spice-modal-idle-message"))
+            self.assertFalse(b.is_present("#replace-spice-dialog-other"))
 
-            b.click("#replace-spice-dialog-confirm")
+            if cancel:
+                b.click('.pf-v5-c-modal-box__footer button:contains("Cancel")')
+            else:
+                b.click("#replace-spice-dialog-confirm")
             b.wait_not_present(".pf-v5-c-modal-box")
+            if cancel:
+                return
 
             if expect_running:
                 b.click(f"#vm-{vmName}-needs-shutdown")
@@ -2428,7 +2435,7 @@ vnc_password= "{vnc_passwd}"
             self.assertIn("channel type='spicevmc'", domainXML)
             checkConnnectInfo(expect_vnc=True, expect_spice=True)
 
-            doReplaceSpice(vmCockpit, expect_running=True)
+            doReplaceSpiceSingle(vmCockpit, expect_running=True)
 
             # "Replace SPICE" menu entry goes away (async)
             for _retry in range(15):
@@ -2464,22 +2471,94 @@ vnc_password= "{vnc_passwd}"
             return
 
         #
-        # custom spice-only VM, not running
+        # some custom spice-only VMs, not running; test mass conversion
         #
+
+        self.createVm("SpiceOne", graphics="spice", running=False)
+        self.createVm("SpiceTwo", graphics="spice", running=True)
+        self.createVm("SpiceSession", graphics="spice", connection="session", running=False)
+        # this one shouldn't be touched
+        self.createVm("VncOne", graphics="vnc", running=False)
 
         vmSpiceOnly = "SpiceOnly"
         self.createVm(vmSpiceOnly, graphics="spice", running=False)
         self.waitVmRow(vmSpiceOnly, "system")
+
+        # detail page only shows single VM conversion
         self.goToVmPage(vmSpiceOnly)
         b.wait_text(f"#vm-{vmSpiceOnly}-system-state", "Shut off")
-        doReplaceSpice(vmSpiceOnly, expect_running=False)
+        doReplaceSpiceSingle(vmSpiceOnly, expect_running=False, cancel=True)
 
+        # overview page shows mass VM conversion
+        self.goToMainPage()
+        self.performAction(vmSpiceOnly, "replace-spice")
+
+        b.wait_text(".pf-v5-c-modal-box__title-text", "Replace SPICE devices")
+        b.wait_in_text(".pf-v5-c-modal-box__body", "Replace SPICE on selected VMs")
+        # action came from vmSpiceOnly, should be at the top and selected
+        b.wait_visible(f".pf-v5-c-menu__item:contains('{vmSpiceOnly}') input:checked")
+        b.wait_visible(".pf-v5-c-menu__item input:checked")  # selector is ambigous if anything else is checked
+        # other SPICE VMs are also offered
+        menu = b.text("#replace-spice-dialog-other")
+        self.assertIn("SpiceOne", menu)
+        self.assertIn("SpiceTwo", menu)
+        self.assertIn("SpiceSession", menu)
+        self.assertNotIn("Vnc", menu)
+
+        b.wait_text("#replace-spice-dialog-select-all", "Select all")
+        b.click("#replace-spice-dialog-select-all")
+        # now there are no unchecked VMs
+        b.wait_not_present(".pf-v5-c-menu__item input:not(:checked)")
+        b.wait_text("#replace-spice-dialog-select-all", "Deselect others")
+        b.click("#replace-spice-dialog-select-all")
+        # only the first one selected now
+        b.wait_visible(f".pf-v5-c-menu__item:contains('{vmSpiceOnly}') input:checked")
+        # fails due to ambiguity if others are
+        b.wait_visible(".pf-v5-c-menu__item input:checked")
+        b.click("#replace-spice-dialog-select-all")
+        b.wait_not_present(".pf-v5-c-menu__item input:not(:checked)")
+        # uncheck SpiceTwo
+        b.click(".pf-v5-c-menu__item:contains('SpiceTwo') input")
+        b.wait_visible(".pf-v5-c-menu__item:contains('SpiceTwo') input:not(:checked)")
+
+        # ensure we don't have an alert for failed install of subVmTest1, as it would interfere with the pixel test;
+        # this is unfortunately unpredictable
+        if b.is_present(".pf-v5-c-alert-group"):
+            b.click(".pf-v5-c-alert-group .pf-v5-c-alert__action button")
+            b.wait_not_present(".pf-v5-c-alert-group")
+
+        b.assert_pixels(".pf-v5-c-modal-box", "replace-spice-multi")
+
+        b.click("#replace-spice-dialog-confirm")
+        b.wait_not_present(".pf-v5-c-modal-box")
+
+        # SpiceOnly still runs
         b.click(f"#vm-{vmSpiceOnly}-system-run")
         b.wait_text(f"#vm-{vmSpiceOnly}-system-state", "Running")
+        self.goToVmPage(vmSpiceOnly)
+        # and was converted to VNC
         checkConnnectInfo(expect_vnc=True, expect_spice=False)
 
+        # other VMs were also converted
+        self.assertNotIn("spice", m.execute("virsh dumpxml SpiceOne"))
+        self.assertNotIn("spice", self.run_admin("virsh -c qemu:///session dumpxml SpiceSession", "session"))
+        # but we unchecked SpiceTwo (this is running)
+        self.assertIn("spice", m.execute("virsh dumpxml --inactive SpiceTwo"))
+
         self.goToMainPage()
-        self.machine.execute(f"virsh destroy {vmSpiceOnly}; virsh undefine {vmSpiceOnly}")
+
+        # now test unchecking the "primary" VM
+        self.createVm("SpiceThree", graphics="spice", running=False)
+        self.waitVmRow("SpiceThree", "system")
+        self.performAction("SpiceTwo", "replace-spice")
+        b.wait_text(".pf-v5-c-modal-box__title-text", "Replace SPICE devices")
+        b.click("#replace-spice-dialog-select-all")
+        b.click(".pf-v5-c-menu__item:contains('SpiceTwo') input")
+        b.wait_visible(".pf-v5-c-menu__item:contains('SpiceTwo') input:not(:checked)")
+        b.click("#replace-spice-dialog-confirm")
+        b.wait_not_present(".pf-v5-c-modal-box")
+        self.assertNotIn("spice", m.execute("virsh dumpxml --inactive SpiceThree"))
+        self.assertIn("spice", m.execute("virsh dumpxml --inactive SpiceTwo"))
 
         # failed migration
         # we can't test this properly, as it's not possible to poke invalid XML into libvirt


### PR DESCRIPTION
When opening the SPICE dialog from the overview page and there are other
SPICE VMs, offer them for conversion as well, with a menu. Reconfigure
the dialog title and verbiage accordingly.

To make some room in the dialog, move the details of what happens into a popover.

----

[pixel diff review](https://github.com/cockpit-project/pixel-test-reference/compare/e47ae65d70b617aa594aed3964dcd948da668dc4..04230218867ee5dbd413ed03d8474617ec332f70)

This implements @garrett's [remaining design for this feature](https://github.com/cockpit-project/cockpit-machines/pull/1387#issuecomment-1895353645).

## Machines: Mass SPICE conversion

The "Replace SPICE devices" action got introduced in the [previous version](https://cockpit-project.org/blog/cockpit-310.html) to convert SPICE-using VMs to run on a host without SPICE capability. When opened from the overview, that dialog now offers you to convert multiple or all VMs in a single step.

![Screen Shot 2024-02-08 at 16 36 00](https://github.com/cockpit-project/cockpit-machines/assets/200109/ebbed4df-3ffc-469e-bf26-670a0308dec9)