### PR TITLE
Rename to "Pre-formatted block device"

### DIFF
--- a/src/components/storagePools/createStoragePoolDialog.jsx
+++ b/src/components/storagePools/createStoragePoolDialog.jsx
@@ -60,7 +60,7 @@ const StoragePoolTypeRow = ({ onValueChanged, dialogValues, libvirtVersion, pool
         { type: 'iscsi', detail: _("iSCSI target") },
         { type: 'disk', detail: _("Physical disk device") },
         { type: 'logical', detail: _("LVM volume group") },
-        { type: 'fs', detail: _("Pre-formatted Block Device") },
+        { type: 'fs', detail: _("Pre-formatted block device") },
     ];
     // iscsi-direct exists since 4.7.0
     if (libvirtVersion && libvirtVersion >= 4007000)


### PR DESCRIPTION
Rename "Pre-formatted Block Device" to "Pre-formatted block device, and conform with PatternFly and Cockpit standards.
![fs-create1_02](https://github.com/cockpit-project/cockpit-machines/assets/116320458/fdcc5b3a-7e0f-4077-b450-458a6ab0ca68)
