### PR TITLE
test: Avoid alternative truths, fix libvirt resource cleanup

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1601,7 +1601,7 @@ vnc_password= "{vnc_passwd}"
             new_fedora_28_xml = ET.tostring(root)
             self.machine.execute(f"echo '{str(new_fedora_28_xml, 'utf-8')}' > {self.test_obj.vm_tmpdir}/fedora-28.xml")
             self.machine.execute(f"mount -o bind  {self.test_obj.vm_tmpdir}/fedora-28.xml /usr/share/osinfo/os/fedoraproject.org/fedora-28.xml")
-            self.test_obj.addCleanup(self.machine.execute, "umount /usr/share/osinfo/os/fedoraproject.org/fedora-28.xml || true")
+            self.test_obj.addCleanup(self.machine.execute, "umount /usr/share/osinfo/os/fedoraproject.org/fedora-28.xml")
 
             # Fake distro with no minimum ram or storage defined
             fedora_29_xml = self.machine.execute("cat /usr/share/osinfo/os/fedoraproject.org/fedora-29.xml")
@@ -1613,7 +1613,7 @@ vnc_password= "{vnc_passwd}"
             new_fedora_29_xml = ET.tostring(root)
             self.machine.execute(f"echo '{str(new_fedora_29_xml, 'utf-8')}' > {self.test_obj.vm_tmpdir}/fedora-29.xml")
             self.machine.execute(f"mount -o bind  {self.test_obj.vm_tmpdir}/fedora-29.xml /usr/share/osinfo/os/fedoraproject.org/fedora-29.xml")
-            self.test_obj.addCleanup(self.machine.execute, "umount /usr/share/osinfo/os/fedoraproject.org/fedora-29.xml || true")
+            self.test_obj.addCleanup(self.machine.execute, "umount /usr/share/osinfo/os/fedoraproject.org/fedora-29.xml")
 
         def _fakeOsDBInfoRhel(self):
             # Fake rhel 8 images
@@ -1625,7 +1625,7 @@ vnc_password= "{vnc_passwd}"
             new_rhel_8_1_xml = ET.tostring(root)
             self.machine.execute(f"echo '{str(new_rhel_8_1_xml, 'utf-8')}' > {self.test_obj.vm_tmpdir}/rhel-8.1.xml")
             self.machine.execute(f"mount -o bind  {self.test_obj.vm_tmpdir}/rhel-8.1.xml /usr/share/osinfo/os/redhat.com/rhel-8.1.xml")
-            self.test_obj.addCleanup(self.machine.execute, "umount /usr/share/osinfo/os/redhat.com/rhel-8.1.xml || true")
+            self.test_obj.addCleanup(self.machine.execute, "umount /usr/share/osinfo/os/redhat.com/rhel-8.1.xml")
 
             rhel_8_2_xml = self.machine.execute("cat /usr/share/osinfo/os/redhat.com/rhel-8.2.xml")
             root = ET.fromstring(rhel_8_2_xml)
@@ -1635,7 +1635,7 @@ vnc_password= "{vnc_passwd}"
             new_rhel_8_2_xml = ET.tostring(root)
             self.machine.execute(f"echo '{str(new_rhel_8_2_xml, 'utf-8')}' > {self.test_obj.vm_tmpdir}/rhel-8.2.xml")
             self.machine.execute(f"mount -o bind  {self.test_obj.vm_tmpdir}/rhel-8.2.xml /usr/share/osinfo/os/redhat.com/rhel-8.2.xml")
-            self.test_obj.addCleanup(self.machine.execute, "umount /usr/share/osinfo/os/redhat.com/rhel-8.2.xml || true")
+            self.test_obj.addCleanup(self.machine.execute, "umount /usr/share/osinfo/os/redhat.com/rhel-8.2.xml")
 
             # Fake rhel 7 image
             rhel_7_1_xml = self.machine.execute("cat /usr/share/osinfo/os/redhat.com/rhel-7.1.xml")
@@ -1645,7 +1645,7 @@ vnc_password= "{vnc_passwd}"
             new_rhel_7_1_xml = ET.tostring(root)
             self.machine.execute(f"echo '{str(new_rhel_7_1_xml, 'utf-8')}' > {self.test_obj.vm_tmpdir}/rhel-7.1.xml")
             self.machine.execute(f"mount -o bind  {self.test_obj.vm_tmpdir}/rhel-7.1.xml /usr/share/osinfo/os/redhat.com/rhel-7.1.xml")
-            self.test_obj.addCleanup(self.machine.execute, "umount /usr/share/osinfo/os/redhat.com/rhel-7.1.xml || true")
+            self.test_obj.addCleanup(self.machine.execute, "umount /usr/share/osinfo/os/redhat.com/rhel-7.1.xml")
 
         def _fakeFedoraTree(self):
             server = self.test_obj.setup_mock_server("mock-range-server.py", ["archive.fedoraproject.org"])
@@ -2146,7 +2146,7 @@ vnc_password= "{vnc_passwd}"
             raise AssertionError("Unhandled distro for OVMF path")
 
         m.execute("mount -t tmpfs tmpfs " + ovmf_path)
-        self.addCleanup(m.execute, f"umount {ovmf_path} || true")
+        self.addCleanup(m.execute, f"if mountpoint {ovmf_path}; then umount {ovmf_path}; fi")
 
         # Reload for the new configuration to be read
         b.reload()

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1693,7 +1693,7 @@ vnc_password= "{vnc_passwd}"
             final_state = "Running" if dialog.create_and_run else "Shut off"
             # Test dowloading RHEL image shows the progress of the download
             if dialog.os_name == TestMachinesCreate.TestCreateConfig.RHEL_8_1:
-                # Check download percantage is shown as a whole number 0-100 followed by '%'
+                # Check download percentage is shown as a whole number 0-100 followed by '%'
                 if dialog.create_and_run:
                     b.wait_in_text(f"#vm-{dialog.name}-{dialog.connection}-state", "Downloading")
                     # Progress is shown in VM state in VMs list
@@ -1703,7 +1703,8 @@ vnc_password= "{vnc_passwd}"
                     # Progress is shown at VM page empty state
                     self.assertRegex(b.text(".pf-v5-c-empty-state__body .pf-v5-c-progress__status"), r"^[0-9][0-9]?%$|^100%$")
 
-                b.wait_in_text(f"#vm-{dialog.name}-{dialog.connection}-state", final_state)
+                with b.wait_timeout(60):
+                    b.wait_in_text(f"#vm-{dialog.name}-{dialog.connection}-state", final_state)
             b.wait_not_present("#create-vm-dialog")
             b.wait_text(f"#vm-{dialog.name}-{dialog.connection}-state",
                         dialog.create_and_run and "Running" or "Shut off")

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -753,11 +753,11 @@ vnc_password= "{vnc_passwd}"
                                                       create_and_run=False,
                                                       connection='session'))
         cmds = [
-            "mkdir -p '/var/lib/libvirt/pools/tmp pool'; chmod a+rwx '/var/lib/libvirt/pools/tmp pool'",
-            "virsh pool-define-as 'tmp pool' --type dir --target '/var/lib/libvirt/pools/tmp pool'",
-            "virsh pool-start 'tmp pool'",
-            "qemu-img create -f qcow2 '/var/lib/libvirt/pools/tmp pool/vmTmpDestination.qcow2' 128M",
-            "virsh pool-refresh 'tmp pool'"
+            "mkdir -p '/var/lib/libvirt/pools/tmp-pool'; chmod a+rwx '/var/lib/libvirt/pools/tmp-pool'",
+            "virsh pool-define-as 'tmp-pool' --type dir --target '/var/lib/libvirt/pools/tmp-pool'",
+            "virsh pool-start 'tmp-pool'",
+            "qemu-img create -f qcow2 '/var/lib/libvirt/pools/tmp-pool/vmTmpDestination.qcow2' 128M",
+            "virsh pool-refresh 'tmp-pool'"
         ]
         self.machine.execute("; ".join(cmds))
 
@@ -769,7 +769,7 @@ vnc_password= "{vnc_passwd}"
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='file',
                                                       location=config.NOVELL_MOCKUP_ISO_PATH,
                                                       memory_size=128, memory_size_unit='MiB',
-                                                      storage_pool="tmp pool",
+                                                      storage_pool="tmp-pool",
                                                       storage_volume="vmTmpDestination.qcow2",
                                                       create_and_run=True,))
 

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -1238,7 +1238,8 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
 
         # Ensure that adding disks with custom path is possible when no storage pools are present
         # https://bugzilla.redhat.com/show_bug.cgi?id=1985228
-        m.execute("for pool in $(virsh pool-list --all --name); do virsh pool-destroy $pool || true; virsh pool-undefine $pool; done")
+        m.execute("for pool in $(virsh pool-list --name); do virsh pool-destroy $pool; done")
+        m.execute("for pool in $(virsh pool-list --all --name); do virsh pool-undefine $pool; done")
         b.wait_visible("#vm-details[data-pools-count='0']")
         b.click(prefix)
         b.click(f"{prefix}-custompath")

--- a/test/check-machines-filesystems
+++ b/test/check-machines-filesystems
@@ -70,7 +70,7 @@ class TestMachinesFilesystems(machineslib.VirtualMachinesCase):
         b.wait_in_text("tr[data-row-id='vm-subVmTest1-filesystem-/tmp/dir1/-dir1'] td[data-label='Mount tag']", "dir1")
 
         domain_xml = "virsh -c qemu:///system dumpxml subVmTest1"
-        xmllint_element = f"{domain_xml} | xmllint --xpath 'string(//domain/{{prop}})' - 2>&1 || true"
+        xmllint_element = f"{domain_xml} | xmllint --xpath 'string(//domain/{{prop}})' -"
 
         self.assertEqual('/tmp/dir1/', self.machine.execute(xmllint_element.format(prop='devices/filesystem/source/@dir')).strip())
         self.assertEqual('dir1', self.machine.execute(xmllint_element.format(prop='devices/filesystem/target/@dir')).strip())

--- a/test/check-machines-hostdevs
+++ b/test/check-machines-hostdevs
@@ -190,8 +190,8 @@ class TestMachinesHostDevs(machineslib.VirtualMachinesCase):
                 m.execute("diff /tmp/vmdir/vmxml1 /tmp/vmdir/vmxml2 | sed -e 's/^>//;1d' > /tmp/vmdir/vmdiff")
 
                 if self.dev_type == "usb_device":
-                    vendor_id = m.execute("cat /tmp/vmdir/vmdiff | xmllint --xpath 'string(//hostdev/source/vendor/@id)' - 2>&1 || true").strip()
-                    product_id = m.execute("cat /tmp/vmdir/vmdiff | xmllint --xpath 'string(//hostdev/source/product/@id)' - 2>&1 || true").strip()
+                    vendor_id = m.execute("cat /tmp/vmdir/vmdiff | xmllint --xpath 'string(//hostdev/source/vendor/@id)' -").strip()
+                    product_id = m.execute("cat /tmp/vmdir/vmdiff | xmllint --xpath 'string(//hostdev/source/product/@id)' -").strip()
 
                     output = self.run_admin(f"virsh -c qemu:///{connectionName} nodedev-list --cap {self.dev_type}", connectionName)
                     devices = output.splitlines()
@@ -199,17 +199,17 @@ class TestMachinesHostDevs(machineslib.VirtualMachinesCase):
                     for dev in devices:
                         if self.dev_type == "usb_device":
                             self.run_admin(f"virsh -c qemu:///{connectionName} nodedev-dumpxml --device {dev} > /tmp/vmdir/nodedevxml", connectionName)
-                            vendor = m.execute(f"xmllint --xpath 'string(//device/capability/vendor[starts-with(@id, \"{vendor_id}\")])' - 2>&1 < /tmp/vmdir/nodedevxml || true")
-                            product = m.execute(f"xmllint --xpath 'string(//device/capability/product[starts-with(@id, \"{product_id}\")])' < /tmp/vmdir/nodedevxml - 2>&1 || true")
+                            vendor = m.execute(f"xmllint --xpath 'string(//device/capability/vendor[starts-with(@id, \"{vendor_id}\")])' - 2>&1 < /tmp/vmdir/nodedevxml")
+                            product = m.execute(f"xmllint --xpath 'string(//device/capability/product[starts-with(@id, \"{product_id}\")])' < /tmp/vmdir/nodedevxml - 2>&1")
 
                             if vendor.strip() == self._vendor and product.strip() == self._model:
                                 return
 
                 elif self.dev_type == "pci":
-                    domain = int(m.execute("cat /tmp/vmdir/vmdiff | xmllint --xpath 'string(//hostdev/source/address/@domain)' - 2>&1 || true"), base=16)
-                    bus = int(m.execute("cat /tmp/vmdir/vmdiff | xmllint --xpath 'string(//hostdev/source/address/@bus)' - 2>&1 || true"), base=16)
-                    slot = int(m.execute("cat /tmp/vmdir/vmdiff | xmllint --xpath 'string(//hostdev/source/address/@slot)' - 2>&1 || true"), base=16)
-                    func = int(m.execute("cat /tmp/vmdir/vmdiff | xmllint --xpath 'string(//hostdev/source/address/@function)' - 2>&1 || true"), base=16)
+                    domain = int(m.execute("cat /tmp/vmdir/vmdiff | xmllint --xpath 'string(//hostdev/source/address/@domain)' -"), base=16)
+                    bus = int(m.execute("cat /tmp/vmdir/vmdiff | xmllint --xpath 'string(//hostdev/source/address/@bus)' -"), base=16)
+                    slot = int(m.execute("cat /tmp/vmdir/vmdiff | xmllint --xpath 'string(//hostdev/source/address/@slot)' -"), base=16)
+                    func = int(m.execute("cat /tmp/vmdir/vmdiff | xmllint --xpath 'string(//hostdev/source/address/@function)' -"), base=16)
 
                     slot_parts = re.split(r":|\.", self._slot)
 
@@ -233,11 +233,11 @@ class TestMachinesHostDevs(machineslib.VirtualMachinesCase):
         dialog = HostDevAddDialog(self, fail_message="No host device selected")
         dialog.open()
         dialog.add()
-        testlib.wait(lambda: "true" == m.execute(f"virsh -c qemu:///{connectionName} dumpxml subVmTest1 | grep -A 5 hostdev || echo true").strip())
+        m.execute(f"while virsh -c qemu:///{connectionName} dumpxml subVmTest1 | grep -A 5 hostdev; do sleep 1; done")
         # Check no host devices attached after shutting off the VM
         self.performAction("subVmTest1", "forceOff", connectionName=connectionName)
         b.wait_in_text(f"#vm-subVmTest1-{connectionName}-state", "Shut off")
-        testlib.wait(lambda: "true" == m.execute("virsh -c qemu:///{connectionName} dumpxml subVmTest1 | grep -A 5 hostdev || echo true").strip())
+        m.execute(f"while virsh -c qemu:///{connectionName} dumpxml subVmTest1 | grep -A 5 hostdev; do sleep 1; done")
 
         output = self.run_admin(f"virsh -c qemu:///{connectionName} nodedev-list --cap usb_device", connectionName)
         if output.strip() != "":

--- a/test/check-machines-networks
+++ b/test/check-machines-networks
@@ -234,7 +234,7 @@ class TestMachinesNetworks(machineslib.VirtualMachinesCase):
 
                 # Verify libvirt XML
                 net_xml = f"virsh -c qemu:///system net-dumpxml {self.name}"
-                xmllint_element = f"{net_xml} | xmllint --xpath 'string(//network/{{prop}})' - 2>&1 || true"
+                xmllint_element = f"{net_xml} | xmllint --xpath 'string(//network/{{prop}})' -"
 
                 self.test_obj.assertEqual(self.name, m.execute(xmllint_element.format(prop='name')).strip())
                 if (self.forward_mode == "none"):

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -466,7 +466,7 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
         def verify(self):
             dom_xml = "virsh -c qemu:///system dumpxml --domain subVmTest1"
             mac_string = f'"{self.mac}"'
-            xmllint_element = f"{dom_xml} | xmllint --xpath 'string(//domain/devices/interface[starts-with(mac/@address,{mac_string})]/{{prop}})' - 2>&1 || true"
+            xmllint_element = f"{dom_xml} | xmllint --xpath 'string(//domain/devices/interface[starts-with(mac/@address,{mac_string})]/{{prop}})' -"
 
             if self.source_type == "network":
                 self.assertEqual(
@@ -730,7 +730,7 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
             # Verify libvirt XML
             dom_xml = "virsh -c qemu:///system dumpxml --domain subVmTest1"
             mac_string = f'"{self.mac}"'
-            xmllint_element = f"{dom_xml} | xmllint --xpath 'string(//domain/devices/interface[starts-with(mac/@address,{mac_string})]/{{prop}})' - 2>&1 || true"
+            xmllint_element = f"{dom_xml} | xmllint --xpath 'string(//domain/devices/interface[starts-with(mac/@address,{mac_string})]/{{prop}})' -"
 
             if (self.source_type == "network"):
                 self.assertEqual("network", self.machine.execute(xmllint_element.format(prop='@type')).strip())

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -251,7 +251,7 @@ class TestMachinesSettings(machineslib.VirtualMachinesCase):
 
         # Verify libvirt XML
         dom_xml = "virsh dumpxml subVmTest1"
-        xmllint_element = f"{dom_xml} | xmllint --xpath 'string(//domain/{{prop}})' - 2>&1 || true"
+        xmllint_element = f"{dom_xml} | xmllint --xpath 'string(//domain/{{prop}})' -"
         self.assertEqual("coreduo", m.execute(xmllint_element.format(prop='cpu/model')).strip())
 
         # Host-model gets expanded  to custom mode when the VM is running
@@ -481,10 +481,10 @@ class TestMachinesSettings(machineslib.VirtualMachinesCase):
 
         dom_xml = "virsh -c qemu:///system dumpxml subVmTest1"
 
-        xmllint_elem = f"{dom_xml} | xmllint --xpath 'string(//domain/cpu/@mode)' - 2>&1 || true"
+        xmllint_elem = f"{dom_xml} | xmllint --xpath 'string(//domain/cpu/@mode)' -"
         testlib.wait(lambda: cpu_model in m.execute(xmllint_elem).strip())
 
-        xmllint_elem = f"{dom_xml} | xmllint --xpath 'string(//domain/vcpu)' - 2>&1 || true"
+        xmllint_elem = f"{dom_xml} | xmllint --xpath 'string(//domain/vcpu)' -"
         testlib.wait(lambda: "3" in m.execute(xmllint_elem).strip())
 
         virsh_output = m.execute("virsh dumpxml subVmTest1 | xmllint --xpath '/domain/devices/watchdog/@action' -").strip()

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -597,14 +597,12 @@ class TestMachinesSettings(machineslib.VirtualMachinesCase):
             b.wait_not_present("#vm-subVmTest1-watchdog-modal")
 
             b.wait_in_text("#vm-subVmTest1-watchdog-state", "none")
-            # check no watchdog is present in VM's xml (also xmllint is expected to return non-zero code)
-            virsh_output = m.execute("virsh dumpxml subVmTest1 | xmllint --xpath '/domain/devices/watchdog' - 2>&1 || true").strip()
-            self.assertEqual(virsh_output, 'XPath set is empty')
+            # check no watchdog is present in VM
+            self.assertNotIn("watchdog", m.execute("virsh dumpxml subVmTest1"))
 
             if live:
-                # check no watchdog is present in VM's xml (also xmllint is expected to return non-zero code)
-                virsh_output = m.execute("virsh dumpxml subVmTest1 --inactive | xmllint --xpath '/domain/devices/watchdog' - 2>&1 || true").strip()
-                self.assertEqual(virsh_output, 'XPath set is empty')
+                # check no watchdog is present in VM
+                self.assertNotIn("watchdog", m.execute("virsh dumpxml subVmTest1 --inactive"))
 
         args = self.createVm("subVmTest1", running=False)
 
@@ -824,14 +822,12 @@ class TestMachinesSettings(machineslib.VirtualMachinesCase):
             b.wait_not_present("#vm-subVmTest1-vsock-modal")
 
             b.wait_in_text("#vm-subVmTest1-vsock-address", "none")
-            # check no vsock is present in VM's xml (also xmllint is expected to return non-zero code)
-            virsh_output = m.execute("virsh dumpxml subVmTest1 | xmllint --xpath '/domain/devices/vsock' - 2>&1 || true").strip()
-            self.assertEqual(virsh_output, 'XPath set is empty')
+            # check no vsock is present in VM
+            self.assertNotIn("vsock", m.execute("virsh dumpxml subVmTest1"))
 
             if live:
-                # check no vsock is present in VM's xml (also xmllint is expected to return non-zero code)
-                virsh_output = m.execute("virsh dumpxml subVmTest1 --inactive | xmllint --xpath '/domain/devices/vsock' - 2>&1 || true").strip()
-                self.assertEqual(virsh_output, 'XPath set is empty')
+                # check no vsock is present in VM
+                self.assertNotIn("vsock", m.execute("virsh dumpxml subVmTest1 --inactive"))
 
         self.createVm("subVmTest1", running=False)
 

--- a/test/check-machines-snapshots
+++ b/test/check-machines-snapshots
@@ -206,7 +206,7 @@ class TestMachinesSnapshots(machineslib.VirtualMachinesCase):
             def verify_backend(self):
                 # Verify libvirt XML
                 snap_xml = f"virsh -c qemu:///system snapshot-dumpxml --domain subVmTest1 --snapshotname {self.name}"
-                xmllint_element = f"{snap_xml} | xmllint --xpath 'string(//domainsnapshot/{{prop}})' - 2>&1 || true"
+                xmllint_element = f"{snap_xml} | xmllint --xpath 'string(//domainsnapshot/{{prop}})' -"
 
                 if (self.name):
                     self.test_obj.assertEqual(self.name, m.execute(xmllint_element.format(prop='name')).strip())

--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -323,7 +323,7 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
 
                 # Verify libvirt XML
                 pool_xml = f"virsh -c qemu:///system pool-dumpxml {self.name}"
-                xmllint_element = f"{pool_xml} | xmllint --xpath 'string(//pool/{{prop}})' - 2>&1 || true"
+                xmllint_element = f"{pool_xml} | xmllint --xpath 'string(//pool/{{prop}})' -"
 
                 self.test_obj.assertEqual(self.name, m.execute(xmllint_element.format(prop='name')).strip())
                 if (self.target):
@@ -519,7 +519,6 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
         m.execute("systemctl restart nfs-server")
         m.execute(f"virsh pool-define-as nfs-pool --type netfs --target {nfs_pool} --source-host 127.0.0.1 --source-path {mnt_exports}")
         m.execute("virsh pool-start nfs-pool")
-        self.addCleanup(m.execute, "virsh pool-destroy nfs-pool || true")  # Destroy pool as it block removal of `nfs_pool`
 
         # Prepare disk/block pool
         dev = self.add_ram_disk(10)
@@ -607,7 +606,7 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
 
                 # Verify libvirt XML
                 vol_xml = f"virsh -c qemu:///system vol-dumpxml --pool {self.pool_name} --vol {self.vol_name}"
-                xmllint_element = f"{vol_xml} | xmllint --xpath 'string(//volume/{{prop}})' - 2>&1 || true"
+                xmllint_element = f"{vol_xml} | xmllint --xpath 'string(//volume/{{prop}})' -"
 
                 self.test_obj.assertEqual(self.vol_name, m.execute(xmllint_element.format(prop='name')).strip())
 

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -424,8 +424,6 @@ class VirtualMachinesCase(testlib.MachineCase, VirtualMachinesCaseHelpers, stora
         if m.image == 'arch':
             self.allow_journal_messages(r".* couldn't get all properties of org.freedesktop.NetworkManager.Device at /org/freedesktop/NetworkManager/Devices/\d+: Timeout was reached")
 
-        m.execute("virsh net-define /etc/libvirt/qemu/networks/default.xml || true")
-
         # avoid error noise about resources getting cleaned up
         self.addCleanup(lambda: not self.browser.cdp.valid or self.browser.logout())
 


### PR DESCRIPTION
These days we often get a [mess like this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1419-20240203-101153-37c84643-fedora-39-firefox/log.html) or [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1419-20240203-101153-37c84643-debian-stable/log.html). This should help a lot to pinpoint the offenders.

 - [x] builds on top of PR #1419
 - [x] [real race condition](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1420-20240203-150412-f6f2d772-fedora-39/log.html#26-2): VM goes away during iteration