### PR TITLE
Move eslint/stylelint to static-code tests

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -41,7 +41,7 @@ set to upload code changes to `~/.local/share/cockpit/` instead of
 Cockpit Machines uses [ESLint](https://eslint.org/) to automatically check
 JavaScript code style in `.jsx` and `.js` files.
 
-eslint is executed within every build.
+eslint is executed as part of `test/static-code`, aka. `make codecheck`.
 
 For developer convenience, the ESLint can be started explicitly by:
 
@@ -58,7 +58,7 @@ Rules configuration can be found in the `.eslintrc.json` file.
 Cockpit uses [Stylelint](https://stylelint.io/) to automatically check CSS code
 style in `.css` and `scss` files.
 
-styleint is executed within every build.
+styleint is executed as part of `test/static-code`, aka. `make codecheck`.
 
 For developer convenience, the Stylelint can be started explicitly by:
 
@@ -69,12 +69,6 @@ Violations of some rules can be fixed automatically by:
     $ npm run stylelint:fix
 
 Rules configuration can be found in the `.stylelintrc.json` file.
-
-During fast iterative development, you can also choose to not run eslint/stylelint.
-This speeds up the build and avoids build failures due to e. g. ill-formatted
-css or other issues:
-
-    $ make LINT=0
 
 # Running tests locally
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = bc12d5e116b56ebc5509fde7191a2ac5c09b1018 # 310.1 + 17 commits
+COCKPIT_REPO_COMMIT = 1a28b31828e309aa2aba6076b1bcc5ee841ac8ea # 310.1 + 30 commits
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'

--- a/build.js
+++ b/build.js
@@ -11,16 +11,12 @@ import { cockpitCompressPlugin } from './pkg/lib/esbuild-compress-plugin.js';
 import { cockpitPoEsbuildPlugin } from './pkg/lib/cockpit-po-plugin.js';
 import { cockpitRsyncEsbuildPlugin } from './pkg/lib/cockpit-rsync-plugin.js';
 import { cleanPlugin } from './pkg/lib/esbuild-cleanup-plugin.js';
-import { eslintPlugin } from './pkg/lib/esbuild-eslint-plugin.js';
-import { stylelintPlugin } from './pkg/lib/esbuild-stylelint-plugin.js';
 import { esbuildStylesPlugins } from './pkg/lib/esbuild-common.js';
 
 const useWasm = os.arch() !== 'x64';
 const esbuild = (await import(useWasm ? 'esbuild-wasm' : 'esbuild'));
 
 const production = process.env.NODE_ENV === 'production';
-// linters dominate the build time, so disable them for production builds by default, but enable in watch mode
-const lintDefault = process.env.LINT ? process.env.LINT === '0' : production;
 /* List of directories to use when resolving import statements */
 const nodePaths = ['pkg/lib'];
 const outdir = 'dist';
@@ -31,8 +27,6 @@ const packageJson = JSON.parse(fs.readFileSync('package.json'));
 const parser = (await import('argparse')).default.ArgumentParser();
 parser.add_argument('-r', '--rsync', { help: "rsync bundles to ssh target after build", metavar: "HOST" });
 parser.add_argument('-w', '--watch', { action: 'store_true', help: "Enable watch mode", default: process.env.ESBUILD_WATCH === "true" });
-parser.add_argument('-e', '--no-eslint', { action: 'store_true', help: "Disable eslint linting", default: lintDefault });
-parser.add_argument('-s', '--no-stylelint', { action: 'store_true', help: "Disable stylelint linting", default: lintDefault });
 const args = parser.parse_args();
 
 if (args.rsync)
@@ -56,8 +50,6 @@ function notifyEndPlugin() {
         }
     };
 }
-
-const cwd = process.cwd();
 
 // similar to fs.watch(), but recursively watches all subdirectories
 function watch_dirs(dir, on_change) {
@@ -98,8 +90,6 @@ const context = await esbuild.context({
     target: ['es2020'],
     plugins: [
         cleanPlugin(),
-        ...args.no_stylelint ? [] : [stylelintPlugin({ filter: new RegExp(cwd + '/src/.*\\.(css?|scss?)$') })],
-        ...args.no_eslint ? [] : [eslintPlugin({ filter: new RegExp(cwd + '/src/.*\\.(jsx?|js?)$') })],
         // Esbuild will only copy assets that are explicitly imported and used
         // in the code. This is a problem for index.html and manifest.json which are not imported
         copy({

--- a/test/run
+++ b/test/run
@@ -8,9 +8,6 @@ TEST_SCENARIO="${TEST_SCENARIO:-}"
 [ "${TEST_SCENARIO}" = "${TEST_SCENARIO##firefox}" ] || export TEST_BROWSER=firefox
 export RUN_TESTS_OPTIONS=--track-naughties
 
-# linters are off by default for production builds, but we want to run them in CI
-export LINT=1
-
 TEST_SCENARIO=${TEST_SCENARIO:-}
 
 if [ "$TEST_SCENARIO" == "devel" ]; then


### PR DESCRIPTION
stylelint 16 causes a deadlock/crash in esbuild [1]. There's no movement on that issue, and we want stylelint 16 to be able to support the Browser Baseline 2023.

Follow https://github.com/cockpit-project/cockpit/commit/1a28b31828e and move the linters into test/static-code. This also starts to lint files which are outside of esbuild's realm, such as documentation and examples.

[1] https://github.com/evanw/esbuild/issues/3542

Taken from https://github.com/cockpit-project/starter-kit/commit/15be8835955f8