### PR TITLE
Add TPM when switching to EFI

### DIFF
--- a/src/components/vm/overview/firmware.jsx
+++ b/src/components/vm/overview/firmware.jsx
@@ -27,7 +27,7 @@ import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip";
 import { useDialogs, DialogsContext } from 'dialogs.jsx';
 
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
-import { domainSetOSFirmware, domainCanInstall } from "../../../libvirtApi/domain.js";
+import { domainAddTPM, domainCanInstall, domainSetOSFirmware } from "../../../libvirtApi/domain.js";
 import { supportsUefiXml, labelForFirmwarePath } from './helpers.jsx';
 
 const _ = cockpit.gettext;
@@ -61,6 +61,10 @@ class FirmwareModal extends React.Component {
                 objPath: vm.id,
                 loaderType: stateToXml(this.state.firmware)
             });
+
+            if (this.state.firmware == 'efi' && !vm.hasTPM && vm.capabilities.supportsTPM)
+                await domainAddTPM({ connectionName: vm.connectionName, vmName: vm.name });
+
             Dialogs.close();
         } catch (exc) {
             this.dialogErrorSet(_("Failed to change firmware"), exc.message);

--- a/src/components/vm/overview/firmware.jsx
+++ b/src/components/vm/overview/firmware.jsx
@@ -42,7 +42,7 @@ class FirmwareModal extends React.Component {
         super(props);
         this.state = {
             dialogError: null,
-            firmware: xmlToState(props.firmware),
+            firmware: xmlToState(props.vm.firmware),
         };
         this.dialogErrorSet = this.dialogErrorSet.bind(this);
         this.save = this.save.bind(this);
@@ -54,7 +54,8 @@ class FirmwareModal extends React.Component {
 
     save() {
         const Dialogs = this.context;
-        domainSetOSFirmware({ connectionName: this.props.connectionName, objPath: this.props.vmId, loaderType: stateToXml(this.state.firmware) })
+        const vm = this.props.vm;
+        domainSetOSFirmware({ connectionName: vm.connectionName, objPath: vm.id, loaderType: stateToXml(this.state.firmware) })
                 .then(Dialogs.close, exc => this.dialogErrorSet(_("Failed to change firmware"), exc.message));
     }
 
@@ -92,9 +93,7 @@ class FirmwareModal extends React.Component {
 }
 
 FirmwareModal.propTypes = {
-    connectionName: PropTypes.string.isRequired,
-    vmId: PropTypes.string.isRequired,
-    firmware: PropTypes.string,
+    vm: PropTypes.object.isRequired,
 };
 
 export const FirmwareLink = ({ vm, loaderElems, idPrefix }) => {
@@ -107,10 +106,6 @@ export const FirmwareLink = ({ vm, loaderElems, idPrefix }) => {
             if (valueElem && valueElem[0].parentNode == loader)
                 return valueElem[0].textContent;
         });
-    }
-
-    function open() {
-        Dialogs.show(<FirmwareModal connectionName={vm.connectionName} vmId={vm.id} firmware={vm.firmware} />);
     }
 
     let firmwareLinkWrapper;
@@ -136,7 +131,8 @@ export const FirmwareLink = ({ vm, loaderElems, idPrefix }) => {
         const firmwareLink = disabled => {
             return (
                 <span id={`${idPrefix}-firmware-tooltip`}>
-                    <Button variant="link" isInline id={`${idPrefix}-firmware`} isDisabled={disabled} onClick={open}>
+                    <Button variant="link" isInline id={`${idPrefix}-firmware`} isDisabled={disabled}
+                            onClick={() => Dialogs.show(<FirmwareModal vm={vm} />)}>
                         {currentFirmware}
                     </Button>
                 </span>

--- a/src/components/vm/overview/firmware.jsx
+++ b/src/components/vm/overview/firmware.jsx
@@ -52,11 +52,19 @@ class FirmwareModal extends React.Component {
         this.setState({ dialogError: text, dialogErrorDetail: detail });
     }
 
-    save() {
+    async save() {
         const Dialogs = this.context;
         const vm = this.props.vm;
-        domainSetOSFirmware({ connectionName: vm.connectionName, objPath: vm.id, loaderType: stateToXml(this.state.firmware) })
-                .then(Dialogs.close, exc => this.dialogErrorSet(_("Failed to change firmware"), exc.message));
+        try {
+            await domainSetOSFirmware({
+                connectionName: vm.connectionName,
+                objPath: vm.id,
+                loaderType: stateToXml(this.state.firmware)
+            });
+            Dialogs.close();
+        } catch (exc) {
+            this.dialogErrorSet(_("Failed to change firmware"), exc.message);
+        }
     }
 
     render() {

--- a/src/libvirt-xml-parse.js
+++ b/src/libvirt-xml-parse.js
@@ -197,6 +197,14 @@ export function getDomainCapSupportsSpice(capsXML) {
     return hasSpiceGraphics || hasSpiceChannel;
 }
 
+export function getDomainCapSupportsTPM(capsXML) {
+    const domainCapsElem = getElem(capsXML);
+    const tpmCapsElems = domainCapsElem.getElementsByTagName("tpm")?.[0]
+            ?.getElementsByTagName("enum")?.[0]
+            ?.getElementsByTagName("value");
+    return tpmCapsElems?.length > 0;
+}
+
 export function getSingleOptionalElem(parent, name) {
     const subElems = parent.getElementsByTagName(name);
     return subElems.length > 0 ? subElems[0] : undefined; // optional
@@ -262,6 +270,7 @@ export function parseDomainDumpxml(connectionName, domXml, objPath) {
     const watchdog = parseDumpxmlForWatchdog(devicesElem);
     const vsock = parseDumpxmlForVsock(devicesElem);
     const hasSpice = parseDumpxmlForSpice(devicesElem);
+    const hasTPM = parseDumpxmlForTPM(devicesElem);
 
     const hasInstallPhase = parseDumpxmlMachinesMetadataElement(metadataElem, 'has_install_phase') === 'true';
     const installSourceType = parseDumpxmlMachinesMetadataElement(metadataElem, 'install_source_type');
@@ -306,6 +315,7 @@ export function parseDomainDumpxml(connectionName, domXml, objPath) {
         vsock,
         metadata,
         hasSpice,
+        hasTPM,
     };
 }
 
@@ -547,6 +557,10 @@ function parseDumpxmlForSpice(devicesElem) {
 
     logDebug("parseDumpxmlForSpice: no SPICE elements found in", devicesElem.children);
     return false;
+}
+
+function parseDumpxmlForTPM(devicesElem) {
+    return devicesElem.getElementsByTagName('tpm').length > 0;
 }
 
 export function parseDumpxmlForFilesystems(devicesElem) {

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -46,6 +46,7 @@ fi
 EXCLUDES="$EXCLUDES
           TestMachinesCreate.testConfigureBeforeInstall
           TestMachinesCreate.testConfigureBeforeInstallBios
+          TestMachinesCreate.testConfigureBeforeInstallBiosTPM
           TestMachinesCreate.testCreateBasicValidation
           TestMachinesCreate.testCreateNameGeneration
           TestMachinesCreate.testCreateDownloadRhel

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -2126,6 +2126,9 @@ vnc_password= "{vnc_passwd}"
         # Attach some interface
         m.execute("virsh attach-interface --persistent VmNotInstalled bridge virbr0")
 
+        # BIOS machine doesn't have TPM by default
+        self.assertNotIn("tpm", m.execute("virsh dumpxml VmNotInstalled"))
+
         # Change the os boot firmware configuration
         b.wait_in_text("#vm-VmNotInstalled-firmware", "BIOS")
         b.click("#vm-VmNotInstalled-firmware")
@@ -2134,6 +2137,13 @@ vnc_password= "{vnc_passwd}"
         b.click("#firmware-dialog-apply")
         b.wait_not_present(".pf-v5-c-modal-box__body")
         b.wait_in_text("#vm-VmNotInstalled-firmware", "UEFI")
+        self.assertIn("<os firmware='efi'>", m.execute("virsh dumpxml VmNotInstalled"))
+
+        # auto-enabled software TPM (doesn't work on RHEL 8 or arch)
+        if not m.image.startswith("rhel-8") and not m.image.startswith("centos-8") and m.image != 'arch':
+            tpm_xml = m.execute("virsh dumpxml VmNotInstalled | xmllint --xpath /domain/devices/tpm -")
+            self.assertIn('model="tpm-crb"', tpm_xml)
+            self.assertIn('type="emulator"', tpm_xml)
 
         # Temporarily delete the OVMF binary and check the firmware options again
         if "fedora" in m.image or "rhel" in m.image or "centos" in m.image:
@@ -2243,6 +2253,56 @@ vnc_password= "{vnc_passwd}"
         # no explicit "firmware=" field
         self.assertIn("<os>", domainXML)
         self.assertNotIn("efi", domainXML)
+
+    @testlib.skipImage("does not support virt-xml --tpm", "rhel-8*", "centos-8*")
+    @testlib.skipImage("does not support TPM 2.0", "arch")
+    def testConfigureBeforeInstallBiosTPM(self):
+        m = self.machine
+        b = self.browser
+        TestMachinesCreate.CreateVmRunner(self)
+
+        # create VM with BIOS
+        vmName = "subVmTest1"
+        self.login_and_go("/machines")
+        self.waitPageInit()
+        dialog = TestMachinesCreate.VmDialog(self, sourceType='file',
+                                             name=vmName,
+                                             location=TestMachinesCreate.TestCreateConfig.NOVELL_MOCKUP_ISO_PATH,
+                                             memory_size=128, memory_size_unit='MiB',
+                                             storage_size=256, storage_size_unit='MiB',
+                                             create_and_run=False)
+        dialog.open().fill()
+        b.click(".pf-v5-c-modal-box__footer #create-and-edit")
+        b.wait_not_present("#create-vm-dialog")
+        b.wait_in_text(f"#vm-{vmName}-firmware", "BIOS")
+
+        # manually add TPM to BIOS
+        m.execute(f"virt-xml --add-device --tpm default {vmName}")
+        self.assertIn("tpm", m.execute(f"virsh dumpxml {vmName}"))
+        # this doesn't change the UI, so we have to reload to ensure that the UI picks up the change
+        # otherwise this is a race condition
+        b.reload()
+        b.enter_page('/machines')
+
+        # Change the os boot firmware to EFI
+        b.click(f"#vm-{vmName}-firmware")
+        b.wait_visible(".pf-v5-c-modal-box__body")
+        b.select_from_dropdown(".pf-v5-c-modal-box__body select", "efi")
+        b.click("#firmware-dialog-apply")
+        b.wait_not_present(".pf-v5-c-modal-box__body")
+        b.wait_in_text(f"#vm-{vmName}-firmware", "UEFI")
+
+        # did not add a second TPM; that would fail in the dialog anyway, but let's double-check the backend
+        out = m.execute(f"virsh dumpxml {vmName} | xmllint --xpath /domain/devices/tpm - | grep --count '<tpm'")
+        self.assertEqual(out.strip(), "1")
+
+        # Install the VM
+        b.click(f"#vm-{vmName}-system-install")
+        b.wait_in_text(f"#vm-{vmName}-system-state", "Running")
+
+        # AppArmor policy fixed in later versions, don't bother with reporting
+        if m.image == 'debian-stable':
+            self.allow_journal_messages('.*apparmor="DENIED".*name="/etc/ssl/openssl.cnf".*comm="swtpm".*')
 
     def testCreateDownloadRhel(self):
         runner = TestMachinesCreate.CreateVmRunner(self, rhel_download=True)


### PR DESCRIPTION
This is useful for OSes which default to BIOS. It matches what `virt-install --boot uefi` does. This fixes e.g. secure boot on Fedora VMs.
    
https://issues.redhat.com/browse/RHEL-24522

  - [x] Check with libvirt team how important that tpm0 alias is: https://bugzilla.redhat.com/show_bug.cgi?id=2264820
  - [x] Fix [arch failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1448-20240219-075552-38070e0e-arch/log.html), i.e. ignore "not supported"