### PR TITLE
Port from ip to ipaddr.js NPM module

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "gettext-parser": "8.0.0",
     "htmlparser": "1.7.7",
-    "ip": "1.1.8",
+    "ipaddr.js": "2.1.0",
     "jed": "1.1.1",
     "sass": "1.71.0",
     "sizzle": "2.3.10",


### PR DESCRIPTION
`ip` is a node.js module, and was never meant for running in a browser. It magically happened to work until version 1.1.8 despite it doing things like `require('buffer')` (i.e. not an ESM).

In version 2.0.1 this broke completely as it tries to `require('os')`. Replace this with https://www.npmjs.com/package/ipaddr.js which has a comparable API and size (the actually bundled library is 12 KB for both modules).

Closes #1451