### PR TITLE
Fix debug logging of install_machine.py arguments

### DIFF
--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -299,7 +299,7 @@ export async function domainCreate({
         sshKeys,
     };
 
-    logDebug(`CREATE_VM(${vmName}): install_machine.py '${args}'`);
+    logDebug(`CREATE_VM(${vmName}): install_machine.py '${JSON.stringify(args)}'`);
 
     const hashPasswords = async args => {
         if (args.sourceType === CLOUD_IMAGE) {


### PR DESCRIPTION
Stringifying `args` just ends up as `[Object object]`, which is useless.

---

Now it is correct and useful for reproducing/debugging:
```
CREATE_VM(test1): install_machine.py '{"connectionName":"system","memorySize":1024,"os":"centos7.0","profile":"jeos","rootPassword":"","source":"","sourceType":"os","startVm":true,"storagePool":"NewVolumeQCOW2","storageSize":10,"storageVolume":"","type":"create","unattended":"","userLogin":"","userPassword":"","vmName":"test1","sshKeys":[]}'
```