### PR TITLE
Fix disk "Used" value

### DIFF
--- a/src/components/storagePools/storagePool.jsx
+++ b/src/components/storagePools/storagePool.jsx
@@ -48,11 +48,11 @@ export const getStoragePoolRow = ({ storagePool, vms, onAddErrorNotification }) 
             { storagePool.name }
         </span>
     );
-    const allocation = parseFloat(convertToUnit(storagePool.allocation, units.B, units.GiB).toFixed(2));
+    const physical = parseFloat(convertToUnit(storagePool.physical, units.B, units.GiB).toFixed(2));
     const capacity = parseFloat(convertToUnit(storagePool.capacity, units.B, units.GiB).toFixed(2));
-    const sizeLabel = String(cockpit.format("$0 / $1 GiB", allocation, capacity));
+    const sizeLabel = String(cockpit.format("$0 / $1 GiB", physical, capacity));
     const size = (
-        <Progress value={Number(storagePool.allocation)}
+        <Progress value={Number(storagePool.physical)}
                   min={0}
                   max={Number(storagePool.capacity)}
                   label={sizeLabel}

--- a/src/components/storagePools/storagePoolVolumesTab.jsx
+++ b/src/components/storagePools/storagePoolVolumesTab.jsx
@@ -90,12 +90,12 @@ export class StoragePoolVolumesTab extends React.Component {
         const rows = volumes
                 .sort(sortFunction)
                 .map(volume => {
-                    const allocation = parseFloat(convertToUnit(volume.allocation, units.B, units.GiB).toFixed(2));
+                    const physical = parseFloat(convertToUnit(volume.physical, units.B, units.GiB).toFixed(2));
                     const capacity = parseFloat(convertToUnit(volume.capacity, units.B, units.GiB).toFixed(2));
                     const columns = [
                         { title: <div id={`${storagePoolIdPrefix}-volume-${volume.name}-name`}>{volume.name}</div> },
                         { title: <div id={`${storagePoolIdPrefix}-volume-${volume.name}-usedby`}>{(isVolumeUsed[volume.name] || []).join(', ')}</div>, },
-                        { title: <div id={`${storagePoolIdPrefix}-volume-${volume.name}-size`}>{`${allocation} / ${capacity} GB`}</div> },
+                        { title: <div id={`${storagePoolIdPrefix}-volume-${volume.name}-size`}>{`${physical} / ${capacity} GB`}</div> },
                     ];
                     return { columns, selected: volume.selected, props: { key: volume.name } };
                 });

--- a/src/components/vm/disks/vmDisksCard.jsx
+++ b/src/components/vm/disks/vmDisksCard.jsx
@@ -94,7 +94,7 @@ export class VmDisksCardLibvirt extends React.Component {
                         if (!vm.disks[target] || (vm.disks[target].type !== 'volume' && !vm.disksStats[target])) {
                             return false; // not yet retrieved, can't decide about disk stats support
                         }
-                        return vm.disks[target].type == 'volume' || !isNaN(vm.disksStats[target].capacity) || !isNaN(vm.disksStats[target].allocation);
+                        return vm.disks[target].type == 'volume' || !isNaN(vm.disksStats[target].capacity) || !isNaN(vm.disksStats[target].physical);
                     });
         }
 
@@ -104,11 +104,11 @@ export class VmDisksCardLibvirt extends React.Component {
     prepareDiskData(disk, diskStats, idPrefix, storagePools) {
         diskStats = diskStats || {};
 
-        let used = diskStats.allocation;
+        let used = diskStats.physical;
         let capacity = diskStats.capacity;
 
         /*
-         * For disks of type `volume` allocation and capacity stats are not
+         * For disks of type `volume` physical and capacity stats are not
          * fetched with the virConnectGetAllDomainStats API so we need to get
          * them from the volume.
          *
@@ -125,7 +125,7 @@ export class VmDisksCardLibvirt extends React.Component {
 
             if (volume) {
                 capacity = volume.capacity;
-                used = volume.allocation;
+                used = volume.physical;
             }
         }
 

--- a/src/libvirt-xml-parse.js
+++ b/src/libvirt-xml-parse.js
@@ -1086,6 +1086,8 @@ export function parseStoragePoolDumpxml(connectionName, storagePoolXml, objPath)
     result.capacity = storagePoolElem.getElementsByTagName('capacity')[0].childNodes[0].nodeValue;
     result.available = storagePoolElem.getElementsByTagName('available')[0].childNodes[0].nodeValue;
     result.allocation = storagePoolElem.getElementsByTagName('allocation')[0].childNodes[0].nodeValue;
+    const physicalElem = storagePoolElem.getElementsByTagName('physical')[0];
+    result.physical = physicalElem ? physicalElem.childNodes[0].nodeValue : NaN;
 
     // Fetch path property if target is contained for this type of pool
     if (['dir', 'fs', 'netfs', 'logical', 'disk', 'iscsi', 'scsi', 'mpath', 'zfs'].indexOf(result.type) > -1) {


### PR DESCRIPTION
Showing "allocation" in the UI doesn't make much sense. According to the manpage [1] it describes "offset of highest written sector in bytes". Showing the "physical size of source file in bytes" is much more useful.

Thanks to @shodanshok for figuring this out!

Fixes #1423

[1] https://www.libvirt.org/manpages/virsh.html

---

This was one of these "looks like a quick fix" issues, but it's not -- this is definitively not working yet, but I want to see if we get a more meaningful test failure than just the unexpected "error: input is not a number" -- i.e. where we cover this.