### PR TITLE
fmf: Drop explicit start of virtinterfaced.socket

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -72,7 +72,6 @@ firewall-cmd --add-service=cockpit
 
 if [ "${PLATFORM_ID:-}" != "platform:el8" ]; then
     # https://gitlab.com/libvirt/libvirt/-/issues/219
-    systemctl start virtinterfaced.socket
     systemctl start virtnetworkd.socket
     systemctl start virtnodedevd.socket
     systemctl start virtstoraged.socket


### PR DESCRIPTION
We don't do anything with that service.