### PR TITLE
cockpit-ci: Add container definition file

### DIFF
--- a/.cockpit-ci/container
+++ b/.cockpit-ci/container
@@ -1,0 +1,1 @@
+quay.io/cockpit/tasks:2024-03-05


### PR DESCRIPTION
`job-runner` uses this file to determine in which container to run a task. The next task refresh will break cockpit-machines due to updating ruff to 0.3.1, which introduces a few "Use f-string instead of `format` call" failures. Pin the container to 2024-03-05 to avoid that. We will use this to exercise and demonstrate how to fix the issues and update the container in a single PR, and also how to automate the container updates.