### PR TITLE
test: Drop some unused constants and methods; pyproject: Add vulture suppressions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,15 @@ mark-parentheses = false
 
 [tool.ruff.lint.isort]
 known-first-party = ["cockpit"]
+
+[tool.vulture]
+ignore_names = [
+   "do_*",
+   "test[A-Z0-9]*",
+   # testlib API
+   "provision",
+   # RangeHTTPRequestHandler API
+   "copyfile",
+   # ssl.SSLContext API
+   "check_hostname",
+]

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -923,7 +923,6 @@ vnc_password= "{vnc_passwd}"
         VALID_DISK_IMAGE_PATH = '/var/lib/libvirt/images/example.img'
         NOVELL_MOCKUP_ISO_PATH = '/var/lib/libvirt/novell.iso'
         PATH_WITH_SPACE = '/var/lib/libvirt/novell with spaces.iso'
-        NOT_EXISTENT_PATH = '/tmp/not-existent.iso'
         ISO_URL = 'https://archive.fedoraproject.org/pub/archive/fedora/linux/releases/28/Server/x86_64/os/images/boot.iso'
         TREE_URL = 'https://archive.fedoraproject.org/pub/archive/fedora/linux/releases/28/Server/x86_64/os'
 
@@ -934,14 +933,12 @@ vnc_password= "{vnc_passwd}"
         FEDORA_28_SHORTID = 'fedora28'
 
         FEDORA_29 = 'Fedora 29'
-        FEDORA_29_SHORTID = 'fedora29'
 
         RHEL_8_1 = 'Red Hat Enterprise Linux 8.1 (Ootpa)'
         RHEL_8_1_SHORTID = 'rhel8.1'
         RHEL_8_2 = 'Red Hat Enterprise Linux 8.2 (Ootpa)'
         RHEL_8_2_SHORTID = 'rhel8.2'
         RHEL_7_1 = 'Red Hat Enterprise Linux 7.1'
-        RHEL_7_1_SHORTID = 'rhel7.1'
 
         CENTOS_7 = 'CentOS 7'
 
@@ -1663,19 +1660,6 @@ vnc_password= "{vnc_passwd}"
         def _fakeRhelDownload(self):
             server = self.test_obj.setup_mock_server("mock-rhsm-rest", ["sso.redhat.com", "api.access.redhat.com"])
             self.test_obj.addCleanup(self.machine.execute, f"kill {server}")
-
-        def _assertVmStates(self, name, connection, before, after):
-            b = self.browser
-            selector = f"#vm-{name}-{connection}-state"
-
-            b.wait_in_text(selector, before)
-
-            # Make sure that the initial state goes away and then try to check what the new state is
-            # because we might end up checking the text for the new state the momment it disappears
-            # HACK: Ensure that the selector exists to avoid a quadratic timeout loop; see
-            # https://github.com/cockpit-project/cockpit/pull/16200
-            testlib.wait(lambda: b.is_present(selector) and b.text(selector) != before, tries=30, delay=3)
-            b.wait_in_text(selector, after)
 
         def _create(self, dialog):
             b = self.browser

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -290,13 +290,13 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
         self.createVm("subVmTest3")
         m.execute("virsh destroy subVmTest2; virsh destroy subVmTest3; virsh net-destroy default")
 
-        def tryRunDomain(index, name, connection):
+        def tryRunDomain(name, connection):
             self.waitVmRow(name)
 
             b.click(f"#vm-{name}-{connection}-run")
 
         # Try to run subVmTest1 - it will fail because of inactive default network
-        tryRunDomain(1, 'subVmTest1', 'system')
+        tryRunDomain('subVmTest1', 'system')
         b.wait_visible("#vm-subVmTest1-system-state-error")
         if run_pixel_tests:
             b.assert_pixels("tr[data-row-id=vm-subVmTest1-system]", "vm-state-error")
@@ -305,7 +305,7 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
         b.click('#vm-subVmTest1-system-state-error button[aria-label=Close]')
 
         # Try to run subVmTest2
-        tryRunDomain(2, 'subVmTest2', 'system')
+        tryRunDomain('subVmTest2', 'system')
         b.click('#vm-subVmTest2-system-state-error button:contains("view more")')
         b.wait_in_text(".pf-v5-c-popover", "VM subVmTest2 failed to start")
         b.click('#vm-subVmTest2-system-state-error button[aria-label=Close]')

--- a/test/check-machines-virtualization
+++ b/test/check-machines-virtualization
@@ -65,9 +65,6 @@ class TestMachinesVirtualization(machineslib.VirtualMachinesCase):
         def stopLibvirtService():
             m.execute(f"systemctl stop {libvirtServiceName}")
 
-        def startLibvirtSocket():
-            m.execute(f"systemctl start {libvirtServiceName}")
-
         def hack_libvirtd_crash():
             # work around libvirtd crashing when stopped too quickly; https://bugzilla.redhat.com/show_bug.cgi?id=1828207
             m.execute("virsh domifaddr 1")

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -33,8 +33,6 @@ def hasMonolithicDaemon(image):
 
 
 class VirtualMachinesCaseHelpers:
-    created_pool = False
-
     def waitPageInit(self):
         virtualization_disabled_ignored = self.browser.call_js_func("localStorage.getItem", "virtualization-disabled-ignored") == "true"
         virtualization_enabled = "PASS" in self.machine.execute("virt-host-validate | grep 'Checking for hardware virtualization'")


### PR DESCRIPTION
See [current failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6048-20240311-125835-b465e9b2-ubuntu-stable-cockpit-project-cockpit-machines/log.html) after today's rollout of a  new tasks container. Plus, testing from bots doesn't currently respect `.cockpit-ci/container` (fixing that is high on the pilot board!)