### PR TITLE
cockpit-ci: Bump tasks container to 2024-03-11

### DIFF
--- a/.cockpit-ci/container
+++ b/.cockpit-ci/container
@@ -1,1 +1,1 @@
-quay.io/cockpit/tasks:2024-03-05
+quay.io/cockpit/tasks:2024-03-11

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1549,9 +1549,10 @@ vnc_password= "{vnc_passwd}"
 
             self.machine.execute(f"touch {TestMachinesCreate.TestCreateConfig.NOVELL_MOCKUP_ISO_PATH}")
             self.machine.execute(f"qemu-img create {TestMachinesCreate.TestCreateConfig.VALID_DISK_IMAGE_PATH} 500M")
-            test_obj.addCleanup(test_obj.machine.execute, "rm -f {0} {1}".format(
-                TestMachinesCreate.TestCreateConfig.NOVELL_MOCKUP_ISO_PATH,
-                TestMachinesCreate.TestCreateConfig.VALID_DISK_IMAGE_PATH))
+            test_obj.addCleanup(
+                test_obj.machine.execute,
+                f"rm -f {TestMachinesCreate.TestCreateConfig.NOVELL_MOCKUP_ISO_PATH} "
+                f"{TestMachinesCreate.TestCreateConfig.VALID_DISK_IMAGE_PATH}")
 
             if rhel_download:
                 self._fakeOsDBInfoRhel()

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -175,7 +175,7 @@ class VirtualMachinesCaseHelpers:
         if ptyconsole:
             console = "pty,target.type=virtio "
         else:
-            console = "file,target.type=serial,source.path={} ".format(args["logfile"])
+            console = f"file,target.type=serial,source.path={args['logfile']} "
 
         command = [f"virt-install --connect qemu:///{connection} --name {name} "
                    f"--os-variant {os} "


### PR DESCRIPTION
I do the initial push *without* ruff changes. This should fail. I'd like to see a demonstration of that. **Update**: It did [fail as expected](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1492-15e225f7-20240312-105634-fedora-39/log.html).

Afterwards I'll push the [ruff fixes](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6072-20240312-105017-1a48d3c5-fedora-39-cockpit-project-cockpit-machines/log.html)