### PR TITLE
workflows: Move tasks-container-update to Sunday night

### DIFF
--- a/.github/workflows/tasks-container-update.yml
+++ b/.github/workflows/tasks-container-update.yml
@@ -1,7 +1,7 @@
 name: tasks-container-update
 on:
   schedule:
-    - cron: '0 2 * * 4'
+    - cron: '0 2 * * 1'
   # can be run manually on https://github.com/cockpit-project/cockpit-machines/actions
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
We previously ran tasks-container-update and cockpit-lib-update at the same time, which sometimes collides. Move it to the night between Sunday and Monday instead, so that we have the updates ready for us to inspect when we start our week.