### PR TITLE
workflows: Run cockpit-lib-update.yml in "self" environment

### DIFF
--- a/.github/workflows/cockpit-lib-update.yml
+++ b/.github/workflows/cockpit-lib-update.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
 jobs:
   cockpit-lib-update:
+    environment: self
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       pull-requests: write
       statuses: write
     steps:
@@ -24,6 +24,8 @@ jobs:
 
       - name: Clone repository
         uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Run cockpit-lib-update
         run: |


### PR DESCRIPTION
The updated branch needs to be pushed with SSH instead of https and the GitHub token, so that the reposchutz workflow can run. This is the same approach as podman's and cockpit's workflows already do.

---

See #1535. I landed #1520 and previous updates with my Spethial Project Admin Hammer :hammer_and_pick: , but let's fix this properly.