### PR TITLE
Fix crash on checking for hw virtualization

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -104,9 +104,14 @@ export const App = () => {
 
     useEffect(() => {
         (async () => {
-            const hardwareVirtCheck = await cockpit.script("virt-host-validate | grep 'Checking for hardware virtualization'");
-
-            setVirtualizationEnabled(hardwareVirtCheck.includes('PASS'));
+            try {
+                const hardwareVirtCheck = await cockpit.script(
+                    "virt-host-validate qemu | grep 'Checking for hardware virtualization'");
+                setVirtualizationEnabled(hardwareVirtCheck.includes('PASS'));
+            } catch (ex) {
+                // That line doesn't exist on some architectures, so the grep may fail
+                console.debug("Failed to check for hardware virtualization:", ex);
+            }
         })();
     }, []);
 

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -35,7 +35,7 @@ def hasMonolithicDaemon(image):
 class VirtualMachinesCaseHelpers:
     def waitPageInit(self):
         virtualization_disabled_ignored = self.browser.call_js_func("localStorage.getItem", "virtualization-disabled-ignored") == "true"
-        virtualization_enabled = "PASS" in self.machine.execute("virt-host-validate | grep 'Checking for hardware virtualization'")
+        virtualization_enabled = "PASS" in self.machine.execute("virt-host-validate qemu | grep 'Checking for hardware virtualization'")
         if not virtualization_enabled and not virtualization_disabled_ignored:
             self.browser.click("#ignore-hw-virtualization-disabled-btn")
         with self.browser.wait_timeout(30):


### PR DESCRIPTION
`virt-host-validate` does not actually include "Checking for hardware virtualization" on ARM, so the page crashes due to the grep exiting with non-zero.

While at it, restrict the checks to QEMU. We aren't interested in LXC or other hypervisors.

Thanks to @yunmingyang for debugging this!

Fixes #1523