### PR TITLE
test: Fix TestMachinesLifecycle pixel flake due to disabled button

### DIFF
--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -104,6 +104,7 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
         if run_pixel_tests:
+            b.wait_visible("#vm-subVmTest1-add-iface-button:not(:disabled)")
             b.assert_pixels("#vm-details", "vm-details", ignore=[
                 ".memory-usage-chart",
                 ".vcpu-usage-chart",


### PR DESCRIPTION
Before taking the pixel snapshot, we need to wait until the page initializes enough and the "Add network interface" button stops being disabled.

---

Fixes [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6184-e9417cad-20240405-225932-fedora-39-cockpit-project-cockpit-machines/log.html#40) and [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6184-e9417cad-20240405-225932-fedora-39-cockpit-project-cockpit-machines/log.html#40) failure.