### PR TITLE
testStoragePoolsBasic flake

### DIFF
--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -1498,15 +1498,7 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
 
-        b.wait_visible("#vm-subVmTest1-disks-vdc-device")
-        b.click("#vm-subVmTest1-disks-vdc-action-kebab")
-        b.click("#delete-vm-subVmTest1-disks-vdc")
-        b.wait_visible(".pf-v5-c-modal-box")
-        b.wait_in_text(".pf-v5-c-modal-box__body .pf-v5-c-description-list", "subVmTest1")
-        b.wait_in_text("#delete-resource-modal-target", "vdc")
-        b.wait_in_text("#delete-resource-modal-file", vdc_path)
-        b.click("#delete-resource-modal-primary")
-        b.wait_not_present(".pf-v5-c-modal-box")
+        self.deleteDisk("vdc", expect_path=vdc_path)
         # Wait for underlying VM's OS to detach the disk
         testlib.wait(lambda: "vdc" not in m.execute("virsh domblklist subVmTest1"), delay=1)
         b.wait_not_present("#vm-subVmTest1-disks-vdc-device")
@@ -1517,15 +1509,7 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         b.wait_not_present("#vm-subVmTest1-disks-vdc-device")
 
         # Test detaching permanent disk of a stopped domain
-        b.click("#vm-subVmTest1-disks-vdd-action-kebab")
-        b.wait_visible("#vm-subVmTest1-disks-vdd-device")
-        b.click("#delete-vm-subVmTest1-disks-vdd")
-        b.wait_in_text("#delete-resource-modal-target", "vdd")
-        b.wait_in_text("#delete-resource-modal-file", vdd_path)
-        b.wait_visible(".pf-v5-c-modal-box")
-        b.click("#delete-resource-modal-primary")
-        b.wait_not_present("#vm-subVmTest1-disks-vdd-device")
-        b.wait_not_present(".pf-v5-c-modal-box")
+        self.deleteDisk("vdd", expect_path=vdd_path)
 
         # Test detaching several disks and the deletion dialog can be closed correctly
         m.execute("virsh vol-create-as myPoolOne diskVirtio --capacity 1M --format qcow2")
@@ -1626,12 +1610,7 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         # Test detaching of disk on non-persistent VM
         m.execute("virsh undefine subVmTest1")
         m.execute(f"virsh attach-disk --domain subVmTest1 --source {p1}/mydiskofpoolone_1 --target vdc --targetbus virtio")
-        b.click("#vm-subVmTest1-disks-vdc-action-kebab")
-        b.wait_visible("#vm-subVmTest1-disks-vdc-device")
-        b.click("#delete-vm-subVmTest1-disks-vdc")
-        b.wait_visible(".pf-v5-c-modal-box")
-        b.click("#delete-resource-modal-primary")
-        b.wait_not_present(".pf-v5-c-modal-box")
+        self.deleteDisk("vdc")
         testlib.wait(lambda: "vdc" not in m.execute("virsh domblklist subVmTest1"), delay=1)
         b.wait_not_present("#vm-subVmTest1-disks-vdc-device")
 

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -1541,9 +1541,8 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         b.wait_visible("#vm-subVmTest1-disks-vda-device")
 
         def removeDiskAndChecks(target, path, removeFile=False, removeFileFail=False, removeFileNotPresent=False):
-            b.click(f"#vm-subVmTest1-disks-{target}-action-kebab")
-            b.wait_visible(f"#vm-subVmTest1-disks-{target}-action-kebab[aria-expanded=true]")
-            b.click(f"#delete-vm-subVmTest1-disks-{target}")
+            self.dropdownAction(f"#vm-subVmTest1-disks-{target}-action-kebab",
+                                f"#delete-vm-subVmTest1-disks-{target}")
             b.wait_in_text("div[role=dialog]:contains(\"Remove disk\")", target)
             b.wait_in_text("#delete-resource-modal-target", target)
             if path:

--- a/test/check-machines-networks
+++ b/test/check-machines-networks
@@ -770,15 +770,15 @@ class TestMachinesNetworks(machineslib.VirtualMachinesCase):
         testlib.wait(lambda: "no" == m.execute("virsh net-info test_network2 | grep 'Active:' | awk '{print $2}'").strip(), tries=5)
 
         # check "X" button of the deletion dialog
-        b.click(f"#network-test_network2-{connectionName}-action-kebab")
-        b.click(f'#delete-network-test_network2-{connectionName}')
+        self.dropdownAction(f"#network-test_network2-{connectionName}-action-kebab",
+                            f'#delete-network-test_network2-{connectionName}')
         b.wait_visible("#delete-resource-modal")
         b.click("#delete-resource-modal button[aria-label=Close]")
         b.wait_not_present("#delete-resource-modal")
 
         # Delete an inactive network
-        b.click(f"#network-test_network2-{connectionName}-action-kebab")
-        b.click(f'#delete-network-test_network2-{connectionName}')
+        self.dropdownAction(f"#network-test_network2-{connectionName}-action-kebab",
+                            f'#delete-network-test_network2-{connectionName}')
         b.wait_in_text(".pf-v5-c-modal-box__body .pf-v5-c-description-list", "test_network2")
         b.click(".pf-v5-c-modal-box__footer button:contains(Delete)")
         self.waitNetworkRow("test_network2", connectionName, False)
@@ -788,8 +788,8 @@ class TestMachinesNetworks(machineslib.VirtualMachinesCase):
         m.execute("virsh net-define /tmp/xml; virsh net-start test_network2")
         b.wait_in_text(f"#network-test_network2-{connectionName}-state", "active")
         self.toggleNetworkRow("test_network2", connectionName)
-        b.click(f"#network-test_network2-{connectionName}-action-kebab")
-        b.click(f'#delete-network-test_network2-{connectionName}')
+        self.dropdownAction(f"#network-test_network2-{connectionName}-action-kebab",
+                            f'#delete-network-test_network2-{connectionName}')
         b.wait_in_text(".pf-v5-c-modal-box__body .pf-v5-c-description-list", "test_network2")
         b.click(".pf-v5-c-modal-box__footer button:contains(Delete)")
         self.waitNetworkRow("test_network2", connectionName, False)

--- a/test/check-machines-snapshots
+++ b/test/check-machines-snapshots
@@ -329,10 +329,7 @@ class TestMachinesSnapshots(machineslib.VirtualMachinesCase):
         ).execute()
 
         # delete CD-DROM again so that the next test can use external snapshot again
-        b.click("#vm-subVmTest1-disks-sdd-action-kebab")
-        b.click("#delete-vm-subVmTest1-disks-sdd")
-        b.click("#delete-resource-modal-primary")
-        b.wait_not_present(".pf-v5-c-modal-box")
+        self.deleteDisk("sdd")
         testlib.wait(lambda: "sdd" not in m.execute("virsh domblklist subVmTest1"), delay=1)
 
         b.click("#vm-subVmTest1-system-run")

--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -757,8 +757,7 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
         b.wait_visible("#storage-pools-listing")
 
         # Check for deleting a pool whose disk is used by a VM
-        b.click("#pool-images-system-action-kebab")
-        b.click("#delete-pool-images-system")
+        self.dropdownAction("#pool-images-system-action-kebab", "#delete-pool-images-system")
         b.set_checked("#storage-pool-delete-volumes", True)
         b.wait_in_text(".pf-v5-c-backdrop .pf-v5-c-helper-text__item-text", "Pool's volumes are used by")
         b.wait_visible(".pf-v5-c-backdrop footer button[aria-disabled=true]:contains(Delete)")
@@ -768,8 +767,7 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
         b.wait_not_present(".pf-v5-c-backdrop")
 
         # Check "X" button of the dialog
-        b.click("#pool-images-system-action-kebab")
-        b.click("#delete-pool-images-system")
+        self.dropdownAction("#pool-images-system-action-kebab", "#delete-pool-images-system")
         b.click(".pf-v5-c-backdrop button[aria-label=Close]")
         b.wait_not_present(".pf-v5-c-backdrop")
 
@@ -783,8 +781,7 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
         m.execute(f'chattr +a {args["image"]}')
         self.addCleanup(m.execute, f'chattr -a {args["image"]}')
 
-        b.click("#pool-images-system-action-kebab")
-        b.click("#delete-pool-images-system")
+        self.dropdownAction("#pool-images-system-action-kebab", "#delete-pool-images-system")
         b.set_checked("#storage-pool-delete-volumes", True)
         b.wait_visible("#storage-pool-delete-modal")
         b.click("#storage-pool-delete-modal .pf-v5-c-modal-box__footer button:nth-child(1)")
@@ -894,8 +891,8 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
 
             def delete(self):
                 # Expand and click the delete button
-                b.click(f"#pool-{self.name}-{self.connection}-action-kebab")
-                b.click(f"#delete-pool-{self.name}-{self.connection}")
+                self.test_obj.dropdownAction(f"#pool-{self.name}-{self.connection}-action-kebab",
+                                             f"#delete-pool-{self.name}-{self.connection}")
                 # Check if deletion dialog is shown
                 b.wait_visible("div.pf-v5-c-modal-box")
                 # Checks for the deletion dialog
@@ -1075,8 +1072,7 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
         b.wait_not_in_text("#pool-images-system-volume-forDeletion-usedby", "subVmTest1")
 
         # Check for deleting a pool whose disk is used by a VM
-        b.click("#pool-images-system-action-kebab")
-        b.click("#delete-pool-images-system")
+        self.dropdownAction("#pool-images-system-action-kebab", "#delete-pool-images-system")
         b.set_checked("#storage-pool-delete-volumes", True)
         b.wait_in_text(".pf-v5-c-backdrop .pf-v5-c-helper-text__item-text", "Pool's volumes are used by")
         b.wait_visible(".pf-v5-c-backdrop footer button[aria-disabled=true]:contains(Delete)")
@@ -1086,8 +1082,7 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
         b.wait_not_present(".pf-v5-c-backdrop")
 
         # Check "X" button of the dialog
-        b.click("#pool-images-system-action-kebab")
-        b.click("#delete-pool-images-system")
+        self.dropdownAction("#pool-images-system-action-kebab", "#delete-pool-images-system")
         b.click(".pf-v5-c-backdrop button[aria-label=Close]")
         b.wait_not_present(".pf-v5-c-backdrop")
 
@@ -1105,8 +1100,7 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
 
         m.execute(f'chattr +a {args["image"]}')
         self.addCleanup(m.execute, f'chattr -a {args["image"]}')
-        b.click("#pool-images-system-action-kebab")
-        b.click("#delete-pool-images-system")
+        self.dropdownAction("#pool-images-system-action-kebab", "#delete-pool-images-system")
         b.set_checked("#storage-pool-delete-volumes", True)
         b.click(".pf-v5-c-backdrop footer button[aria-disabled=false]:contains(Delete)")
         b.assert_pixels("#storage-pool-delete-modal", "storage-pool-delete-modal-error")

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -41,6 +41,14 @@ class VirtualMachinesCaseHelpers:
         with self.browser.wait_timeout(30):
             self.browser.wait_in_text("body", "Virtual machines")
 
+    # TODO: generic, move to testlib.py?
+    def dropdownAction(self, kebab_selector, menu_selector):
+        b = self.browser
+        b.click(kebab_selector)
+        b.wait_visible(f"{kebab_selector}[aria-expanded=true]")
+        b.click(menu_selector)
+        b.wait_not_present(f"{kebab_selector}[aria-expanded=true]")
+
     def performAction(self, vmName, action, checkExpectedState=True, connectionName="system", logPath=None):
         b = self.browser
         m = self.machine
@@ -48,9 +56,7 @@ class VirtualMachinesCaseHelpers:
         if logPath:
             m.write(logPath, '')
 
-        b.click(f"#vm-{vmName}-{connectionName}-action-kebab")
-        b.wait_visible(".pf-v5-c-menu")
-        b.click(f"#vm-{vmName}-{connectionName}-{action}")
+        self.dropdownAction(f"#vm-{vmName}-{connectionName}-action-kebab", f"#vm-{vmName}-{connectionName}-{action}")
         if action in ["reboot", "forceReboot"] and logPath:
             # https://bugzilla.redhat.com/show_bug.cgi?id=2221144
             # The VM should not be rebooted when the confirmation dialog is shown
@@ -246,8 +252,7 @@ class VirtualMachinesCaseHelpers:
         b = self.browser
 
         b.wait_visible(f"#vm-{vm_name}-disks-{target}-device")
-        b.click(f"#vm-{vm_name}-disks-{target}-action-kebab")
-        b.click(f"#delete-vm-{vm_name}-disks-{target}")
+        self.dropdownAction(f"#vm-{vm_name}-disks-{target}-action-kebab", f"#delete-vm-{vm_name}-disks-{target}")
         b.wait_visible(".pf-v5-c-modal-box")
         b.wait_in_text("#delete-resource-modal-target", target)
         if expect_path:
@@ -259,8 +264,7 @@ class VirtualMachinesCaseHelpers:
     def deleteIface(self, iface, mac=None, vm_name=None):
         b = self.browser
 
-        b.click(f"#vm-subVmTest1-iface-{iface}-action-kebab")
-        b.click(f"#delete-vm-subVmTest1-iface-{iface}")
+        self.dropdownAction(f"#vm-subVmTest1-iface-{iface}-action-kebab", f"#delete-vm-subVmTest1-iface-{iface}")
         b.wait_in_text(".pf-v5-c-modal-box .pf-v5-c-modal-box__header .pf-v5-c-modal-box__title", "Remove network interface?")
         if mac and vm_name:
             b.wait_in_text(".pf-v5-c-modal-box__body .pf-v5-c-description-list", f"{mac} will be removed from {vm_name}")

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -242,13 +242,16 @@ class VirtualMachinesCaseHelpers:
         else:
             return m.execute(cmd)
 
-    def deleteDisk(self, target, vm_name="subVmTest1"):
+    def deleteDisk(self, target, vm_name="subVmTest1", expect_path=None):
         b = self.browser
 
         b.wait_visible(f"#vm-{vm_name}-disks-{target}-device")
         b.click(f"#vm-{vm_name}-disks-{target}-action-kebab")
         b.click(f"#delete-vm-{vm_name}-disks-{target}")
         b.wait_visible(".pf-v5-c-modal-box")
+        b.wait_in_text("#delete-resource-modal-target", target)
+        if expect_path:
+            b.wait_in_text("#delete-resource-modal-file", expect_path)
         b.click("#delete-resource-modal-primary")
         b.wait_not_present(".pf-v5-c-modal-box")
         b.wait_not_present(f"#vm-{vm_name}-disks-{target}-device")

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -46,6 +46,9 @@ class VirtualMachinesCaseHelpers:
         b = self.browser
         b.click(kebab_selector)
         b.wait_visible(f"{kebab_selector}[aria-expanded=true]")
+        # HACK: PF bug: Dropdown open state is bouncing
+        time.sleep(0.2)
+        b.wait_visible(f"{kebab_selector}[aria-expanded=true]")
         b.click(menu_selector)
         b.wait_not_present(f"{kebab_selector}[aria-expanded=true]")
 


### PR DESCRIPTION
Remaining top flake on the weather report, fails [like this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1539-1695d83f-20240405-095751-ubuntu-2204/log.html#82). Initial analysis: https://github.com/cockpit-project/cockpit-machines/pull/1539#issuecomment-2039647747 There and with commit 0a23d3f0d8ca8bd38880de6f420fdf03e24e1a8b we can ascertain that the click failure is *not* due to the kebab entry being disabled.

Next theory: the `isActionOpen` bounces between true/false/true? It seems to survive is_present and even is_visible, but not the immediately following ph_mouse(). An updated debug log confirms that:

```
> log: XXX VmDisksCard open actions [] for vda is open {"type":"boolean","value":false}
> log: XXX VmDisksCard open actions [] for vdc is open {"type":"boolean","value":false}
> log: XXX DiskActions for subVmTest1 vm state shut off disk vda disabled {"type":"boolean","value":false} is open {"type":"boolean","value":false}
> log: XXX DiskActions for subVmTest1 vm state shut off disk vdc disabled {"type":"boolean","value":false} is open {"type":"boolean","value":false}
<- {'type': 'undefined'}
-> wait: ph_is_present("#vm-subVmTest1-disks-vdc-action-kebab:not([disabled]):not([aria-disabled=true])")
<- {'type': 'undefined'}
-> wait: ph_is_visible("#vm-subVmTest1-disks-vdc-action-kebab:not([disabled]):not([aria-disabled=true])")
<- {'type': 'undefined'}
-> ph_mouse("#vm-subVmTest1-disks-vdc-action-kebab:not([disabled]):not([aria-disabled=true])","click",0,0,0,false,false,false,false)
> log: XXX VmDisksCard open actions ["vdc"] for vda is open {"type":"boolean","value":false}
> log: XXX VmDisksCard open actions ["vdc"] for vdc is open {"type":"boolean","value":true}
> log: XXX DiskActions for subVmTest1 vm state shut off disk vda disabled {"type":"boolean","value":false} is open {"type":"boolean","value":false}
> log: XXX DiskActions for subVmTest1 vm state shut off disk vdc disabled {"type":"boolean","value":false} is open {"type":"boolean","value":true}
<- {'type': 'undefined'}
-> wait: ph_is_present("#delete-vm-subVmTest1-disks-vdc:not([disabled]):not([aria-disabled=true])")
<- {'type': 'undefined'}
-> wait: ph_is_visible("#delete-vm-subVmTest1-disks-vdc:not([disabled]):not([aria-disabled=true])")
<- {'type': 'undefined'}
-> ph_mouse("#delete-vm-subVmTest1-disks-vdc:not([disabled]):not([aria-disabled=true])","click",0,0,0,false,false,false,false)
> log: XXX VmDisksCard open actions ["vdc"] for vda is open {"type":"boolean","value":false}
```
:arrow_up: this is wrong, and bouncing.
```
> log: XXX VmDisksCard open actions ["vdc"] for vdc is open {"type":"boolean","value":true}
> log: XXX DiskActions for subVmTest1 vm state shut off disk vda disabled {"type":"boolean","value":false} is open {"type":"boolean","value":false}
> log: XXX DiskActions for subVmTest1 vm state shut off disk vdc disabled {"type":"boolean","value":false} is open {"type":"boolean","value":true}
<- {'exceptionDetails': {'text': '#delete-vm-subVmTest1-disks-vdc:not([disabled]):not([aria-disabled=true]) not found'}}
```

The bouncing always happens, it's just that most of the time the `ph_mouse()` doesn't happen at a time where it matters. The bouncing also doesn't happen interactively on a steady state -- but there are several renderings when opening the details page. These actions happen right after one another:
```
        self.goToVmPage("subVmTest1")
        self.deleteDisk("vdc")
```
so apparently the renders from the goToVmPage() aren't done yet?

This is some emergent behaviour, and really hard to pinpoint the bug to any specific location :cry: 