### PR TITLE
packit: Land a new upstream release automatically to centos-stream c9s

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -7,6 +7,13 @@ downstream_package_name: cockpit-machines
 # use the nicely formatted release description from our upstream release, instead of git shortlog
 copy_upstream_release_description: true
 
+packages:
+  cockpit-machines-fedora:
+    specfile_path: cockpit-machines.spec
+  cockpit-machines-centos:
+    specfile_path: cockpit-machines.spec
+    pkg_tool: centpkg
+
 srpm_build_deps:
 - npm
 - make
@@ -49,10 +56,17 @@ jobs:
 
   - job: propose_downstream
     trigger: release
+    packages: [cockpit-machines-fedora]
     dist_git_branches:
       - fedora-development
       - fedora-39
       - fedora-40
+
+  - job: propose_downstream
+    trigger: release
+    packages: [cockpit-machines-centos]
+    dist_git_branches:
+      - c9s
 
   - job: koji_build
     trigger: commit


### PR DESCRIPTION
This packit job only makes sure the changes happen in dist-git - no builds.

Relevant documentation: https://packit.dev/docs/configuration/upstream/propose_downstream