### PR TITLE
snapshots: Optionally inform about creating internal snapshots

### DIFF
--- a/src/components/vm/snapshots/vmSnapshotsCard.jsx
+++ b/src/components/vm/snapshots/vmSnapshotsCard.jsx
@@ -20,7 +20,7 @@ import React from 'react';
 
 import cockpit from 'cockpit';
 import { useDialogs, DialogsContext } from 'dialogs.jsx';
-import { vmId, localize_datetime, vmSupportsExternalSnapshots } from "../../../helpers.js";
+import { vmId, localize_datetime, vmNoExternalSnapshotsReason } from "../../../helpers.js";
 import { CreateSnapshotModal } from "./vmSnapshotsCreateModal.jsx";
 import { ListingTable } from "cockpit-components-table.jsx";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
@@ -31,6 +31,8 @@ import { DeleteResourceButton } from '../../common/deleteResource.jsx';
 import { RevertSnapshotModal } from './vmSnapshotsRevertModal.jsx';
 import { snapshotDelete, snapshotGetAll } from '../../../libvirtApi/snapshot.js';
 
+import VMS_CONFIG from "../../../config.js";
+
 import './vmSnapshotsCard.scss';
 
 const _ = cockpit.gettext;
@@ -39,12 +41,18 @@ export const VmSnapshotsActions = ({ vm, config, storagePools }) => {
     const Dialogs = useDialogs();
     const id = vmId(vm.name);
 
-    const isExternal = vmSupportsExternalSnapshots(config, vm, storagePools);
+    const preferExternalDocURL = VMS_CONFIG.PreferExternalSnapshotsDocURL;
+    const noExternalReason = vmNoExternalSnapshotsReason(config, vm, storagePools);
+
+    // If possible, we make external snapshots.
+    const isExternal = !noExternalReason;
 
     function open() {
         Dialogs.show(<CreateSnapshotModal idPrefix={`${id}-create-snapshot`}
-                                          isExternal={isExternal}
                                           storagePools={storagePools}
+                                          noExternalReason={noExternalReason}
+                                          preferExternalDocURL={preferExternalDocURL}
+                                          isExternal={isExternal}
                                           vm={vm} />);
     }
 

--- a/src/config.js
+++ b/src/config.js
@@ -39,6 +39,7 @@ const VMS_CONFIG = {
     },
 
     StorageMigrationSupported: true,
+    PreferExternalSnapshotsDocURL: null,
 };
 
 function try_fields(dict, fields, def) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -880,30 +880,30 @@ export function getStoragePoolPath(storagePools, poolName, connectionName) {
     return pool?.target?.path;
 }
 
-export function vmSupportsExternalSnapshots(config, vm, storagePools) {
+export function vmNoExternalSnapshotsReason(config, vm, storagePools) {
     // External snapshot should only be used if the VM's os types/architecture allow it
     // and if snapshot features are present among guest capabilities:
     // https://libvirt.org/formatcaps.html#guest-capabilities
     if (!config.capabilities?.guests.some(guest => guest.osType === vm.osType &&
                                                    guest.arch === vm.arch &&
                                                    guest.features.externalSnapshot)) {
-        logDebug(`vmSupportsExternalSnapshots: vm ${vm.name} has no external snapshot support`);
-        return false;
+        logDebug(`vmNoExternalSnapshotsReason: vm ${vm.name} has no external snapshot support`);
+        return "not-implemented";
     }
 
     // If at leat one disk has internal snapshot preference specified, use internal snapshot for all disk,
     // as mixing internal and external is not allowed
     const disks = Object.values(vm.disks);
     if (disks.some(disk => disk.snapshot === "internal")) {
-        logDebug(`vmSupportsExternalSnapshots: vm ${vm.name} has internal snapshot preference specified`);
-        return false;
+        logDebug(`vmNoExternalSnapshotsReason: vm ${vm.name} has internal snapshot preference specified`);
+        return "explicit-internal";
     }
 
     // Currently external snapshots work only for disks of type "file"
     if (!disks.every(disk => disk.type === "file")) {
-        logDebug(`vmSupportsExternalSnapshots: vm ${vm.name} has unsupported disk type`);
-        return false;
+        logDebug(`vmNoExternalSnapshotsReason: vm ${vm.name} has unsupported disk type`);
+        return "non-file-volume";
     }
 
-    return true;
+    return null;
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -29,6 +29,9 @@
   "config": {
       "StorageMigrationSupported": {
           "rhel": false
+      },
+      "PreferExternalSnapshotsDocURL": {
+          "rhel": "https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/configuring_and_managing_virtualization"
       }
   }
 }

--- a/test/check-machines-snapshots
+++ b/test/check-machines-snapshots
@@ -153,6 +153,10 @@ class TestMachinesSnapshots(machineslib.VirtualMachinesCase):
             def open(self):
                 b.click("#vm-subVmTest1-add-snapshot-button")
                 b.wait_in_text(".pf-v5-c-modal-box .pf-v5-c-modal-box__header .pf-v5-c-modal-box__title", "Create snapshot")
+                if not self.expect_external and "rhel" in m.image:
+                    b.wait_in_text(".pf-v5-c-modal-box", "deprecated \"internal\" format")
+                else:
+                    b.wait_not_in_text(".pf-v5-c-modal-box", "deprecated \"internal\" format")
 
             def fill(self):
                 if self.name is not None:


### PR DESCRIPTION
This is based on and meant to go together with the RHEL product documentation.

https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/configuring_and_managing_virtualization/creating-virtual-machine-snapshots_configuring-and-managing-virtualization

That documentation explicitly calls out internal snapshots as deprecated and strongly advises against using them in production environments.

However, it also says that "Internal snapshots might work for your use case, but Red Hat does not provide full testing and support for them. ", external snapshots don't work in all cases, and [upstream libvirt does not consider them deprecated ](https://lists.libvirt.org/archives/list/users@lists.libvirt.org/message/HKKSQLTW75KFYYQIM65U7LLTF34W4PNH/
) so Cockpit should probably not fully prevent their use on RHEL. (And there are no requests to us for preventing them.)

Thus, let's have a little notice in the creation dialog with a link to the product documentation.

![image](https://github.com/cockpit-project/cockpit-machines/assets/3228183/f528845e-7d0a-4999-bbbc-d9486cef2a59)
