### PR TITLE
Validate TEST_AUDIT_NO_SELINUX

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -14,6 +14,9 @@ $DNF libvirt-daemon-driver-storage-iscsi-direct || true
 rpm -q selinux-policy cockpit-bridge cockpit-machines
 rpm -qa | grep -E 'virt|qemu' | sort
 
+# Show test configuration
+echo "TEST_AUDIT_NO_SELINUX: ${TEST_AUDIT_NO_SELINUX:-}"
+
 # allow test to set up things on the machine
 mkdir -p /root/.ssh
 curl https://raw.githubusercontent.com/cockpit-project/bots/main/machine/identity.pub  >> /root/.ssh/authorized_keys


### PR DESCRIPTION
Debugging why the bodhi test failure https://artifacts.dev.testing-farm.io/8ce2302a-ee98-4b69-bc0f-4974597020fc/ happened. #1530 happened before the release.