### PR TITLE
packit: Split copr_build and tests for fedora/centos

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -25,19 +25,31 @@ actions:
 jobs:
   - job: copr_build
     trigger: pull_request
+    packages: [cockpit-machines-fedora]
     targets:
     - fedora-39
     - fedora-40
     - fedora-development
+
+  - job: copr_build
+    trigger: pull_request
+    packages: [cockpit-machines-centos]
+    targets:
     - centos-stream-8
     - centos-stream-9
 
   - job: tests
+    packages: [cockpit-machines-fedora]
     trigger: pull_request
     targets:
       - fedora-39
       - fedora-40
       - fedora-development
+
+  - job: tests
+    packages: [cockpit-machines-centos]
+    trigger: pull_request
+    targets:
       - centos-stream-8
       - centos-stream-9
 


### PR DESCRIPTION
Commit db7e195812a7d125e6d introduced the two -fedora and -centos package variants. Since then, *all* copr_build and test jobs got duplicated, which is a waste. Split them up properly.

---

See e.g. #1558 or any other recent PR. They get duplicated builds and tests:

![image](https://github.com/cockpit-project/cockpit-machines/assets/200109/79085b45-b3b3-4469-81d1-2623cf2e4e26)
![image](https://github.com/cockpit-project/cockpit-machines/assets/200109/7166d078-ff07-484c-82d5-166ca4b276c7)
