### PR TITLE
snapshots: Skip empty media drives for external snapshots

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -899,8 +899,8 @@ export function vmSupportsExternalSnapshots(config, vm, storagePools) {
         return false;
     }
 
-    // Currently external snapshots work only for disks of type "file" with a source.
-    if (!disks.every(disk => (disk.type === "file" && disk.source?.file))) {
+    // Currently external snapshots work only for disks of type "file"
+    if (!disks.every(disk => disk.type === "file")) {
         logDebug(`vmSupportsExternalSnapshots: vm ${vm.name} has unsupported disk type`);
         return false;
     }

--- a/src/libvirt-xml-create.js
+++ b/src/libvirt-xml-create.js
@@ -263,15 +263,24 @@ export function getSnapshotXML(name, description, disks, memoryPath, isExternal,
 
         const disksElem = doc.createElement('disks');
         disks.forEach(disk => {
-            // Disk can have attribute "snapshot" set to "no", which means no snapshot should be created of the said disk
-            // This cannot be configured through cockpit, but we should uphold it nevertheless
-            // see "snapshot" attribute of <disk> element at https://libvirt.org/formatdomain.html#hard-drives-floppy-disks-cdroms
-            if (disk.snapshot !== "no") {
-                const diskElem = doc.createElement('disk');
-                diskElem.setAttribute('name', disk.target);
-                diskElem.setAttribute('snapshot', 'external');
-                disksElem.appendChild(diskElem);
-            }
+            // Disk can have attribute "snapshot" set to "no", which
+            // means no snapshot should be created of the said disk
+            // This cannot be configured through cockpit, but we
+            // should uphold it nevertheless.
+            //
+            // See "snapshot" attribute of <disk> element at
+            // https://libvirt.org/formatdomain.html#hard-drives-floppy-disks-cdroms
+            if (disk.snapshot == "no")
+                return;
+
+            // Skip disks without source, such as empty media drives.
+            if (isExternal && disk.type == "file" && !disk.source.file)
+                return;
+
+            const diskElem = doc.createElement('disk');
+            diskElem.setAttribute('name', disk.target);
+            diskElem.setAttribute('snapshot', 'external');
+            disksElem.appendChild(diskElem);
         });
         snapElem.appendChild(disksElem);
     }

--- a/test/check-machines-snapshots
+++ b/test/check-machines-snapshots
@@ -146,6 +146,7 @@ class TestMachinesSnapshots(machineslib.VirtualMachinesCase):
                 if self.xfail is None:
                     self.verify_frontend()
                     self.verify_backend()
+                    self.revert()
                     if self.remove:
                         self.cleanup()
 
@@ -237,6 +238,11 @@ class TestMachinesSnapshots(machineslib.VirtualMachinesCase):
                     print(m.execute(snap_xml))
                     print("------ end snapshot XML -------")
                     raise
+
+            def revert(self):
+                b.click(f"#vm-subVmTest1-snapshot-{self.snap_num}-revert")
+                b.click('.pf-v5-c-modal-box__footer button:contains("Revert")')
+                b.wait_not_present('.pf-v5-c-modal-box__footer button:contains("Revert")')
 
             def cleanup(self):
                 b.click(f"#delete-vm-subVmTest1-snapshot-{self.snap_num}")

--- a/test/check-machines-snapshots
+++ b/test/check-machines-snapshots
@@ -241,8 +241,9 @@ class TestMachinesSnapshots(machineslib.VirtualMachinesCase):
 
             def revert(self):
                 b.click(f"#vm-subVmTest1-snapshot-{self.snap_num}-revert")
+                b.wait_visible(".pf-v5-c-modal-box")
                 b.click('.pf-v5-c-modal-box__footer button:contains("Revert")')
-                b.wait_not_present('.pf-v5-c-modal-box__footer button:contains("Revert")')
+                b.wait_not_present(".pf-v5-c-modal-box")
 
             def cleanup(self):
                 b.click(f"#delete-vm-subVmTest1-snapshot-{self.snap_num}")
@@ -355,7 +356,6 @@ class TestMachinesSnapshots(machineslib.VirtualMachinesCase):
         ).execute()
 
         # With CD-ROM drive without media
-        # doesn't support external snapshots yet
         b.click("#vm-subVmTest1-disks-sdd-eject-button")
         b.click(".pf-v5-c-modal-box__footer button:contains(Eject)")
         b.wait_not_present(".pf-v5-c-modal-box")
@@ -364,7 +364,7 @@ class TestMachinesSnapshots(machineslib.VirtualMachinesCase):
             self,
             name="nomedia",
             state="shutoff",
-            expect_external=False,
+            expect_external=supports_external,
         ).execute()
 
         # delete CD-DROM again so that the next test can use external snapshot again


### PR DESCRIPTION
Instead of falling back to internal ones. This makes external snapshots work in more cases.
