### PR TITLE
snapshots: Only use external snapshots for disks of type "file"

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -899,14 +899,8 @@ export function vmSupportsExternalSnapshots(config, vm, storagePools) {
         return false;
     }
 
-    // Currently external snapshots works only for disks where we can specify a local path of a newly created disk snapshot file
-    // This rules out all disks which are not file-based, or pool-based where pool is of type "dir"
-    // or media-less disks
-    const supportedPools = storagePools.filter(pool => pool.type === "dir" && pool.connectionName === vm.connectionName);
-    if (!disks.every(disk =>
-        (disk.type === "file" && disk.source?.file) ||
-        (disk.type === "volume" && supportedPools.some(pool => pool.name === disk.source.pool))
-    )) {
+    // Currently external snapshots work only for disks of type "file" with a source.
+    if (!disks.every(disk => (disk.type === "file" && disk.source?.file))) {
         logDebug(`vmSupportsExternalSnapshots: vm ${vm.name} has unsupported disk type`);
         return false;
     }

--- a/src/libvirt-xml-create.js
+++ b/src/libvirt-xml-create.js
@@ -1,4 +1,21 @@
-import { getStoragePoolPath } from "./helpers.js";
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
 
 export function getDiskXML(type, file, device, poolName, volumeName, format, target, cacheMode, shareable, busType, serial) {
     const doc = document.implementation.createDocument('', '', null);
@@ -253,16 +270,6 @@ export function getSnapshotXML(name, description, disks, memoryPath, isExternal,
                 const diskElem = doc.createElement('disk');
                 diskElem.setAttribute('name', disk.target);
                 diskElem.setAttribute('snapshot', 'external');
-
-                if (disk.type === "volume") {
-                    const poolPath = getStoragePoolPath(storagePools, disk.source.pool, connectionName);
-                    if (poolPath) {
-                        const sourceElem = doc.createElement('source');
-                        sourceElem.setAttribute('file', `${poolPath}/${disk.source.volume}.snap`);
-                        diskElem.appendChild(sourceElem);
-                    }
-                }
-
                 disksElem.appendChild(diskElem);
             }
         });

--- a/test/check-machines-snapshots
+++ b/test/check-machines-snapshots
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import time
 from datetime import datetime
 
@@ -300,7 +301,39 @@ class TestMachinesSnapshots(machineslib.VirtualMachinesCase):
         ).execute()
         m.execute("virsh snapshot-delete subVmTest1 test_snap_1")
 
-        # With second disk: CD-ROM with media
+        # With disk in a pool.
+        # This will make a internal snapshot.
+
+        p1 = os.path.join(self.vm_tmpdir, "vm_one")
+        m.execute(f"mkdir --mode 777 {p1}")
+        m.execute(f"virsh pool-create-as myPoolOne --type dir --target {p1}")
+        m.execute("virsh vol-create-as myPoolOne mydisk --capacity 100M --format qcow2")
+        testlib.wait(lambda: "mydisk" in m.execute("virsh vol-list myPoolOne"))
+
+        diskXML = """<disk type="volume" device="disk">
+          <driver name="qemu"/>
+          <source pool="myPoolOne" volume="mydisk"/>
+          <target dev="vdb" bus="virtio"/>
+        </disk>""".replace("\n", "")
+
+        m.execute(f"echo '{diskXML}' > /tmp/disk.xml; virsh attach-device --config --file /tmp/disk.xml subVmTest1")
+
+        # virsh attach-disk doesn't send an event for offline VM changes
+        b.reload()
+        b.enter_page('/machines')
+        b.wait_visible("#vm-subVmTest1-disks-vdb-source-volume")
+
+        SnapshotCreateDialog(
+            self,
+            name="withpool",
+            state="shutoff",
+            expect_external=False,
+        ).execute()
+
+        self.deleteDisk("vdb")
+        testlib.wait(lambda: "vdb" not in m.execute("virsh domblklist subVmTest1"), delay=1)
+
+        # With CD-ROM with media
         m.execute("touch /var/lib/libvirt/images/mock.iso")
         m.execute("virsh attach-disk --domain subVmTest1 --config --source /var/lib/libvirt/images/mock.iso "
                   "--target sdd --type cdrom")
@@ -315,7 +348,7 @@ class TestMachinesSnapshots(machineslib.VirtualMachinesCase):
             expect_external=supports_external,
         ).execute()
 
-        # with CD-ROM drive without media
+        # With CD-ROM drive without media
         # doesn't support external snapshots yet
         b.click("#vm-subVmTest1-disks-sdd-eject-button")
         b.click(".pf-v5-c-modal-box__footer button:contains(Eject)")


### PR DESCRIPTION
The previous method of changing the source of a "volume" disk to be a "file" disk leads to broken snapshots that can't be reverted or deleted.

And leaving the source alone leads to an error during snapshot creation.

Fixes: https://issues.redhat.com/browse/RHEL-33468
