### PR TITLE
test: enable ruff preview rules

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 194

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ exclude = [
 ]
 # FIXME: we want 118, but needs fixing tests first
 line-length = 183
+preview = true
 src = []
 
 [tool.ruff.lint]

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1701,7 +1701,7 @@ vnc_password= "{vnc_passwd}"
                     b.wait_in_text(f"#vm-{dialog.name}-{dialog.connection}-state", final_state)
             b.wait_not_present("#create-vm-dialog")
             b.wait_text(f"#vm-{dialog.name}-{dialog.connection}-state",
-                        dialog.create_and_run and "Running" or "Shut off")
+                        "Running" if dialog.create_and_run else "Shut off")
 
         def _tryCreate(self, dialog, generated_name=None):
             name = generated_name or dialog.name

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -442,10 +442,10 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
                 b.set_input_text(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-mac", self.mac)
 
             if (self.vm_state == "running" and
-                    (self.source_type is not None and self.source_type != self.source_type_current or
-                        self.source is not None and self.source != self.source_current or
-                        self.model is not None and self.model != self.model_current or
-                        self.mac is not None and self.mac != self.mac_current)):
+                    ((self.source_type is not None and self.source_type != self.source_type_current) or
+                        (self.source is not None and self.source != self.source_current) or
+                        (self.model is not None and self.model != self.model_current) or
+                        (self.mac is not None and self.mac != self.mac_current))):
                 b.wait_visible(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-idle-message")
             else:
                 b.wait_not_present(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-idle-message")

--- a/test/files/mock-range-server.py
+++ b/test/files/mock-range-server.py
@@ -74,7 +74,7 @@ class RangeHTTPRequestHandler(SimpleHTTPRequestHandler):
         Otherwise, the entire file is copied using SimpleHTTPServer.copyfile
         """
 
-        start, end = self.range
+        start, _ = self.range
         infile.seek(start)
         bufsize = 64 * 1024  # 64KB
         while True:


### PR DESCRIPTION
Ruff's preview rules now implements the rules which we used flake8 for.