### PR TITLE
eslint: enable no-useless-fragment rule by default

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,6 +39,7 @@
         "react/jsx-curly-newline": "off",
         "react/jsx-handler-names": "off",
         "react/prop-types": "off",
+        "react/jsx-no-useless-fragment": "error",
         "space-before-function-paren": "off",
         "standard/no-callback-literal": "off",
 

--- a/src/components/create-vm-dialog/createVmDialog.jsx
+++ b/src/components/create-vm-dialog/createVmDialog.jsx
@@ -890,31 +890,29 @@ const MemoryRow = ({ memorySize, memorySizeUnit, nodeMaxMemory, minimumMemory, o
     }
 
     return (
-        <>
-            <FormGroup label={_("Memory")}
+        <FormGroup label={_("Memory")}
                        fieldId='memory-size' id='memory-group'>
-                <InputGroup>
-                    <TextInput id='memory-size' value={memorySize}
+            <InputGroup>
+                <TextInput id='memory-size' value={memorySize}
                                className="size-input"
                                onKeyUp={digitFilter}
                                onChange={(_, value) => onValueChanged('memorySize', Number(value))} />
-                    <FormSelect id="memory-size-unit-select"
+                <FormSelect id="memory-size-unit-select"
                                 className="unit-select"
                                 data-value={memorySizeUnit}
                                 value={memorySizeUnit}
                                 onChange={(_event, value) => onValueChanged('memorySizeUnit', value)}>
-                        <FormSelectOption value={units.MiB.name} key={units.MiB.name}
+                    <FormSelectOption value={units.MiB.name} key={units.MiB.name}
                                           label={_("MiB")} />
-                        <FormSelectOption value={units.GiB.name} key={units.GiB.name}
+                    <FormSelectOption value={units.GiB.name} key={units.GiB.name}
                                           label={_("GiB")} />
-                    </FormSelect>
-                </InputGroup>
-                <FormHelper fieldId="memory-size"
+                </FormSelect>
+            </InputGroup>
+            <FormHelper fieldId="memory-size"
                             variant={validationStateMemory}
                             helperTextInvalid={validationStateMemory == "error" && validationFailed.memory}
                             helperText={helperText} />
-            </FormGroup>
-        </>
+        </FormGroup>
     );
 };
 
@@ -1010,32 +1008,30 @@ const StorageRow = ({ connectionName, allowNoDisk, storageSize, storageSizeUnit,
             </FormGroup>}
 
             { (storagePoolName === "NewVolumeQCOW2" || storagePoolName === "NewVolumeRAW") &&
-            <>
-                <FormGroup label={_("Storage limit")} fieldId='storage-limit'
+            <FormGroup label={_("Storage limit")} fieldId='storage-limit'
                            id='storage-group'>
-                    <InputGroup>
-                        <TextInput id='storage-limit' value={storageSize}
+                <InputGroup>
+                    <TextInput id='storage-limit' value={storageSize}
                                    className="size-input"
                                    onKeyUp={digitFilter}
                                    onChange={(_, value) => onValueChanged('storageSize', Number(value))} />
-                        <FormSelect id="storage-limit-unit-select"
+                    <FormSelect id="storage-limit-unit-select"
                                     data-value={storageSizeUnit}
                                     className="unit-select"
                                     value={storageSizeUnit}
                                     onChange={(_event, value) => onValueChanged('storageSizeUnit', value)}>
-                            <FormSelectOption value={units.MiB.name} key={units.MiB.name}
+                        <FormSelectOption value={units.MiB.name} key={units.MiB.name}
                                                label={_("MiB")} />
-                            <FormSelectOption value={units.GiB.name} key={units.GiB.name}
+                        <FormSelectOption value={units.GiB.name} key={units.GiB.name}
                                                label={_("GiB")} />
-                        </FormSelect>
-                    </InputGroup>
-                    <FormHelper
+                    </FormSelect>
+                </InputGroup>
+                <FormHelper
                         fieldId="storage-limit"
                         variant={validationStateStorage}
                         helperTextInvalid={validationStateStorage == "error" && validationFailed.storage}
                         helperText={helperTextNewVolume} />
-                </FormGroup>
-            </>}
+            </FormGroup>}
         </>
     );
 };
@@ -1356,15 +1352,12 @@ class CreateVmModal extends React.Component {
                     validationFailed={validationFailed} />
 
                 {this.state.sourceType != DOWNLOAD_AN_OS &&
-                <>
-                    <OSRow
+                <OSRow
                         os={this.state.os}
                         osInfoList={this.props.osInfoList}
                         onValueChanged={this.onValueChanged}
                         isLoading={this.state.autodetectOSInProgress}
-                        validationFailed={validationFailed} />
-
-                </>}
+                        validationFailed={validationFailed} />}
                 { this.state.sourceType != EXISTING_DISK_IMAGE_SOURCE &&
                 <StorageRow
                     allowNoDisk={this.state.sourceType !== CLOUD_IMAGE}

--- a/src/components/networks/networkOverviewTab.jsx
+++ b/src/components/networks/networkOverviewTab.jsx
@@ -227,8 +227,7 @@ const NetworkAddStaticHostEntries = ({ idPrefix, network, parentIndex, setIsOpen
     };
 
     return (
-        <>
-            <Modal id="add-new-static-entry" position="top" variant="small" isOpen onClose={() => setIsOpen(false)}
+        <Modal id="add-new-static-entry" position="top" variant="small" isOpen onClose={() => setIsOpen(false)}
                 title={_("Add a DHCP static host entry")}
                 footer={
                     <>
@@ -240,27 +239,26 @@ const NetworkAddStaticHostEntries = ({ idPrefix, network, parentIndex, setIsOpen
                         </Button>
                     </>
                 }>
-                <Form onSubmit={e => {
-                    e.preventDefault();
-                }} isHorizontal>
-                    {error && <ModalError dialogError={_("Failed to save network settings")} dialogErrorDetail={error} />}
-                    <FormGroup label={_("MAC address")} fieldId="add-new-static-entry-mac-address">
-                        <TextInput id="add-new-static-entry-mac-address"
+            <Form onSubmit={e => {
+                e.preventDefault();
+            }} isHorizontal>
+                {error && <ModalError dialogError={_("Failed to save network settings")} dialogErrorDetail={error} />}
+                <FormGroup label={_("MAC address")} fieldId="add-new-static-entry-mac-address">
+                    <TextInput id="add-new-static-entry-mac-address"
                                    validated={isSubmitted && !macAddress ? "error" : "default"}
                                    value={macAddress}
                                    onChange={(_, value) => setMacAddress(value)} />
-                        <FormHelper fieldId="add-new-static-entry-mac-address" helperTextInvalid={isSubmitted && !macAddress && _("MAC address must not be empty")} />
-                    </FormGroup>
-                    <FormGroup label={_("IP address")} fieldId="add-new-static-entry-ip-address">
-                        <TextInput id="add-new-static-entry-ip-address"
+                    <FormHelper fieldId="add-new-static-entry-mac-address" helperTextInvalid={isSubmitted && !macAddress && _("MAC address must not be empty")} />
+                </FormGroup>
+                <FormGroup label={_("IP address")} fieldId="add-new-static-entry-ip-address">
+                    <TextInput id="add-new-static-entry-ip-address"
                                    validated={isSubmitted && !ipAddress ? "error" : "default"}
                                    value={ipAddress}
                                    onChange={(_, value) => setIpAddress(value)} />
-                        <FormHelper fieldId="add-new-static-entry-ip-address" helperTextInvalid={isSubmitted && !ipAddress && _("IP address must not be empty")} />
-                    </FormGroup>
-                </Form>
-            </Modal>
-        </>
+                    <FormHelper fieldId="add-new-static-entry-ip-address" helperTextInvalid={isSubmitted && !ipAddress && _("IP address must not be empty")} />
+                </FormGroup>
+            </Form>
+        </Modal>
     );
 };
 

--- a/src/components/vm/disks/vmDisksCard.jsx
+++ b/src/components/vm/disks/vmDisksCard.jsx
@@ -257,14 +257,12 @@ export const VmDisksCard = ({ vm, vms, disks, renderCapacity, supportedDiskBusTy
     });
 
     return (
-        <>
-            <ListingTable variant='compact'
+        <ListingTable variant='compact'
                 gridBreakPoint='grid-lg'
                 emptyCaption={_("No disks defined for this VM")}
                 aria-label={`VM ${vm.name} Disks`}
                 columns={columnTitles}
                 rows={rows} />
-        </>
     );
 };
 

--- a/src/components/vm/filesystems/vmFilesystemsCard.jsx
+++ b/src/components/vm/filesystems/vmFilesystemsCard.jsx
@@ -85,13 +85,11 @@ export const VmFilesystemsCard = ({ connectionName, vmName, vmState, filesystems
     });
 
     return (
-        <>
-            <ListingTable variant='compact'
+        <ListingTable variant='compact'
                           gridBreakPoint='grid-lg'
                           emptyCaption={_("No directories shared between the host and this VM")}
                           columns={columnTitles}
                           rows={rows} />
-        </>
     );
 };
 

--- a/src/components/vm/hostdevs/hostDevCard.jsx
+++ b/src/components/vm/hostdevs/hostDevCard.jsx
@@ -143,11 +143,9 @@ export const VmHostDevActions = ({ vm }) => {
     }
 
     return (
-        <>
-            <Button id={`${idPrefix}-add`} variant='secondary' onClick={open}>
-                {_("Add host device")}
-            </Button>
-        </>
+        <Button id={`${idPrefix}-add`} variant='secondary' onClick={open}>
+            {_("Add host device")}
+        </Button>
     );
 };
 


### PR DESCRIPTION
This rule is not part of the standard ESLint recommends set but is useful and can be auto-fixed.