### PR TITLE
test: Use alpine image instead of cirros for guests

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -107,8 +107,8 @@ if [ "$ID" = "fedora" ]; then
     export TEST_TIMEOUT_FACTOR=3
 fi
 
-# pre-download cirros image for Machines tests
-bots/image-download cirros
+# pre-download alpine image for Machines tests
+bots/image-download alpine
 
 exclude_options=""
 for t in $EXCLUDES; do

--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -81,12 +81,12 @@ class TestMachinesConsoles(machineslib.VirtualMachinesCase):
         b.wait_visible(".pf-v5-c-console__vnc canvas")
 
         # make sure the log file is full - then empty it and reboot the VM - the log file should fill up again
-        self.waitCirrOSBooted(args['logfile'])
+        self.waitGuestBooted(args['logfile'])
 
         self.machine.execute(f"echo '' > {args['logfile']}")
         b.click("#subVmTest1-system-vnc-sendkey")
         b.click("#ctrl-alt-Delete")
-        self.waitLogFile(args['logfile'], "Requesting system reboot")
+        self.waitLogFile(args['logfile'], "reboot: Restarting system")
 
     def testInlineConsoleWithUrlRoot(self, urlroot=""):
         self.testInlineConsole(urlroot="/webcon")
@@ -117,11 +117,11 @@ class TestMachinesConsoles(machineslib.VirtualMachinesCase):
         for _ in range(0, 60):
             b.focus(f"#{name}-terminal .xterm-accessibility-tree")
             b.key_press("\r")
-            if "cirros login" in b.text(f"#{name}-terminal .xterm-accessibility-tree"):
+            if "Welcome to Alpine Linux" in b.text(f"#{name}-terminal .xterm-accessibility-tree"):
                 break
             time.sleep(1)
         # Make sure the content of console is expected
-        testlib.wait(lambda: "cirros login" in b.text(f"#{name}-terminal .xterm-accessibility-tree"))
+        testlib.wait(lambda: "Welcome to Alpine Linux" in b.text(f"#{name}-terminal .xterm-accessibility-tree"))
 
         b.click(f"#{name}-serialconsole-disconnect")
         b.wait_text(f"#{name}-terminal", "Disconnected from serial console. Click the connect button.")
@@ -137,8 +137,8 @@ class TestMachinesConsoles(machineslib.VirtualMachinesCase):
         m.execute("virsh destroy vmWithSerialConsole; virt-xml --add-device vmWithSerialConsole --console pty,target_type=virtio; virsh start vmWithSerialConsole")
         b.click("#pf-v5-c-console__type-selector")
         b.wait_visible("#pf-v5-c-console__type-selector + .pf-v5-c-select__menu")
-        b.click("li:contains('Serial console (console0)') button")
-        b.wait(lambda: m.execute("ps aux | grep 'virsh -c qemu:///system console vmWithSerialConsole console0'"))
+        b.click("li:contains('Serial console (serial0)') button")
+        b.wait(lambda: m.execute("ps aux | grep 'virsh -c qemu:///system console vmWithSerialConsole serial0'"))
         b.click("#pf-v5-c-console__type-selector")
         b.click("li:contains('Serial console (console1)') button")
         b.wait(lambda: m.execute("ps aux | grep 'virsh -c qemu:///system console vmWithSerialConsole console1'"))
@@ -147,8 +147,7 @@ class TestMachinesConsoles(machineslib.VirtualMachinesCase):
         # Remove all console firstly
         m.execute("virsh destroy vmWithSerialConsole")
         m.execute("virt-xml --remove-device vmWithSerialConsole --console all")
-        # Add serial0 and console1 ~ console5
-        m.execute("virt-xml vmWithSerialConsole --add-device --console pty,target.type=serial")
+        # Add console1 ~ console5
         m.execute("for i in {1..5};do virt-xml vmWithSerialConsole --add-device --console pty,target.type=virtio; done")
         m.execute("virsh start vmWithSerialConsole")
 

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -785,7 +785,7 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         m.execute("virsh pool-destroy images; virsh pool-undefine images")
 
         # Wait for the system to completely start
-        self.waitCirrOSBooted(args['logfile'])
+        self.waitGuestBooted(args['logfile'])
 
         self.login_and_go("/machines#/storages")
         self.waitPageInit()
@@ -843,7 +843,7 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         args = self.createVm("subVmTest1")
 
         # Wait for the system to completely start
-        self.waitCirrOSBooted(args['logfile'])
+        self.waitGuestBooted(args['logfile'])
 
         self.login_and_go("/machines")
         self.waitPageInit()
@@ -901,7 +901,7 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         args = self.createVm("subVmTest1")
 
         # Wait for the system to completely start
-        self.waitCirrOSBooted(args['logfile'])
+        self.waitGuestBooted(args['logfile'])
 
         self.login_and_go("/machines")
         self.waitPageInit()
@@ -1492,7 +1492,7 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         self.waitVmRow("subVmTest1")
 
         # Wait for the login prompt before we try detaching disks - we need the OS to be fully responsive
-        self.waitCirrOSBooted(args['logfile'])
+        self.waitGuestBooted(args['logfile'])
 
         # Test detaching non permanent disk of a running domain
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
@@ -1598,13 +1598,13 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         m.execute(f"> {args['logfile']}")  # clear logfile
         m.execute("virsh start subVmTest1")
         # Make sure that the VM booted normally before attempting to suspend it
-        self.waitCirrOSBooted(args['logfile'])
+        self.waitGuestBooted(args['logfile'])
         m.execute("virsh suspend subVmTest1")
         b.wait_in_text("#vm-subVmTest1-system-state", "Paused")
         b.click("#vm-subVmTest1-disks-vde-action-kebab")
         b.wait_visible(".pf-m-disabled #delete-vm-subVmTest1-disks-vde")
         m.execute("virsh resume subVmTest1")
-        self.waitCirrOSBooted(args['logfile'])
+        self.waitGuestBooted(args['logfile'])
 
         # Test detaching of disk on non-persistent VM
         m.execute("virsh undefine subVmTest1")

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -139,7 +139,7 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # Wait for the system to completely start
-        self.waitCirrOSBooted(args['logfile'])
+        self.waitGuestBooted(args['logfile'])
 
         # Send Non-Maskable Interrupt (no change in VM state is expected)
         self.performAction("subVmTest1", "sendNMI")
@@ -164,11 +164,11 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
 
         # force reboot
         self.performAction("subVmTest1", "forceReboot", logPath=args['logfile'])
-        self.waitCirrOSBooted(args['logfile'])
+        self.waitGuestBooted(args['logfile'])
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         # the shut off button beside the VM name
-        self.waitCirrOSBooted(args['logfile'])
+        self.waitGuestBooted(args['logfile'])
         b.click("#vm-subVmTest1-system-shutdown-button")
         b.wait_visible("#vm-subVmTest1-system-confirm-action-modal")
         b.click(".pf-v5-c-modal-box__footer #vm-subVmTest1-system-off")
@@ -179,7 +179,7 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
         self.machine.execute(f"echo '' > {args['logfile']}")
         b.click("#vm-subVmTest1-system-run")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
-        self.waitCirrOSBooted(args['logfile'])
+        self.waitGuestBooted(args['logfile'])
         self.performAction("subVmTest1", "off")
 
         # force shut off
@@ -431,7 +431,7 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
         self.goToVmPage(name)
 
         # Make sure that the VM booted normally before attempting to suspend it
-        self.waitCirrOSBooted(args['logfile'])
+        self.waitGuestBooted(args['logfile'])
 
         self.machine.execute(f"virsh -c qemu:///system suspend {name}")
         b.wait_in_text(f"#vm-{name}-system-state", "Paused")

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -197,7 +197,7 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
         self.waitPageInit()
         self.waitVmRow("subVmTest1")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
-        self.waitCirrOSBooted(args['logfile'])
+        self.waitGuestBooted(args['logfile'])
         self.goToVmPage("subVmTest1")
 
         self.deleteIface(1)
@@ -334,7 +334,7 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
         m.execute(f"> {args['logfile']}")  # clear logfile
         b.click("#vm-subVmTest1-system-run")
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
-        self.waitCirrOSBooted(args['logfile'])
+        self.waitGuestBooted(args['logfile'])
 
         # Because of bug in debian-testing, attachment of virtio vNICs after restarting VM will fail
         # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1005284

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -408,7 +408,7 @@ class TestMachinesSettings(machineslib.VirtualMachinesCase):
 
         # Check memory hotunplugging
         # The balloon driver needs to be loaded to descrease memory
-        self.waitCirrOSBooted(args['logfile'])
+        self.waitGuestBooted(args['logfile'])
 
         b.set_input_text("#vm-subVmTest1-memory-modal-memory", str(current_memory - 10))
         # Save the memory settings
@@ -461,7 +461,7 @@ class TestMachinesSettings(machineslib.VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.goToVmPage("subVmTest1")
 
-        self.waitCirrOSBooted(args['logfile'])
+        self.waitGuestBooted(args['logfile'])
 
         # Change CPU model setting
         b.click("#vm-subVmTest1-cpu button")
@@ -646,7 +646,7 @@ class TestMachinesSettings(machineslib.VirtualMachinesCase):
         setWatchdogActionLive(action="reset")
         setWatchdogActionLive(action="pause", previous_action="reset")
         # Make sure that the VM booted normally before attempting to hotunplug
-        self.waitCirrOSBooted(args['logfile'])
+        self.waitGuestBooted(args['logfile'])
         removeWatchdogDevice(live=True)
         # Check rebooting machine will not unexpectedly affect watchdog configuration
         setWatchdogActionLive(action="poweroff", reboot_machine=True)

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -156,10 +156,10 @@ class VirtualMachinesCaseHelpers:
                      if ! echo "$out" | grep -q 'Active.*yes'; then virsh net-start default; fi""")
         m.execute(r"until virsh net-info default | grep 'Active:\s*yes'; do sleep 1; done")
 
-    def createVm(self, name, graphics='none', ptyconsole=False, running=True, memory=128, connection='system', machine=None, os="cirros0.4.0"):
+    def createVm(self, name, graphics='none', ptyconsole=False, running=True, memory=128, connection='system', machine=None, os="linux2016"):
         m = machine or self.machine
 
-        image_file = m.pull("cirros")
+        image_file = m.pull("alpine")
 
         if connection == "system":
             img = f"/var/lib/libvirt/images/{name}-2.img"
@@ -182,7 +182,7 @@ class VirtualMachinesCaseHelpers:
             "memory": memory,
         }
         if ptyconsole:
-            console = "pty,target.type=virtio "
+            console = "pty,target.type=serial "
         else:
             console = f"file,target.type=serial,source.path={args['logfile']} "
 
@@ -330,8 +330,8 @@ class VirtualMachinesCaseHelpers:
             print(f"----- log of failed VM ------\n{log}\n---------")
             raise
 
-    def waitCirrOSBooted(self, logfile):
-        self.waitLogFile(logfile, "login as 'cirros' user.")
+    def waitGuestBooted(self, logfile):
+        self.waitLogFile(logfile, "Welcome to Alpine Linux")
 
 
 class VirtualMachinesCase(testlib.MachineCase, VirtualMachinesCaseHelpers, storagelib.StorageHelpers, netlib.NetworkHelpers):


### PR DESCRIPTION
Alpine has qemu-guest-agent, which we want to use to test snapshots.
