### PR TITLE
test: Drop testing on CentOS 8 Stream

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -76,7 +76,7 @@ Run `make vm` to build an RPM and install it into a standard Cockpit test VM.
 This will be `fedora-39` by default. You can set `$TEST_OS` to use a different
 image, for example
 
-    TEST_OS=centos-8-stream make vm
+    TEST_OS=centos-9-stream make vm
 
 Then run
 
@@ -93,7 +93,7 @@ failures (for interactive debugging):
 
 You can also run all of the tests:
 
-    TEST_OS=centos-8-stream make check
+    TEST_OS=... make check
 
 However, this is rather expensive, and most of the time it's better to let the
 CI machinery do this on a draft pull request.

--- a/packit.yaml
+++ b/packit.yaml
@@ -35,7 +35,6 @@ jobs:
     trigger: pull_request
     packages: [cockpit-machines-centos]
     targets:
-    - centos-stream-8
     - centos-stream-9
 
   - job: tests
@@ -50,7 +49,6 @@ jobs:
     packages: [cockpit-machines-centos]
     trigger: pull_request
     targets:
-      - centos-stream-8
       - centos-stream-9
 
   - job: copr_build

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -20,7 +20,7 @@ fi
 . /run/host/usr/lib/os-release
 export TEST_OS="${ID}-${VERSION_ID/./-}"
 
-if [ "$TEST_OS" = "centos-8" ] || [ "$TEST_OS" = "centos-9" ]; then
+if [ "$TEST_OS" = "centos-9" ]; then
     TEST_OS="${TEST_OS}-stream"
 fi
 

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -2134,7 +2134,7 @@ vnc_password= "{vnc_passwd}"
         self.assertIn("<os firmware='efi'>", m.execute("virsh dumpxml VmNotInstalled"))
 
         # auto-enabled software TPM (doesn't work on RHEL 8 or arch)
-        if not m.image.startswith("rhel-8") and not m.image.startswith("centos-8") and m.image != 'arch':
+        if not m.image.startswith("rhel-8") and m.image != 'arch':
             tpm_xml = m.execute("virsh dumpxml VmNotInstalled | xmllint --xpath /domain/devices/tpm -")
             self.assertIn('model="tpm-crb"', tpm_xml)
             self.assertIn('type="emulator"', tpm_xml)
@@ -2248,7 +2248,7 @@ vnc_password= "{vnc_passwd}"
         self.assertIn("<os>", domainXML)
         self.assertNotIn("efi", domainXML)
 
-    @testlib.skipImage("does not support virt-xml --tpm", "rhel-8*", "centos-8*")
+    @testlib.skipImage("does not support virt-xml --tpm", "rhel-8*")
     @testlib.skipImage("does not support TPM 2.0", "arch")
     def testConfigureBeforeInstallBiosTPM(self):
         m = self.machine

--- a/test/check-machines-hostdevs
+++ b/test/check-machines-hostdevs
@@ -209,8 +209,8 @@ class TestMachinesHostDevs(machineslib.VirtualMachinesCase):
 
         b.wait_in_text("#vm-subVmTest1-hostdev-1-source #slot-1", "0000:00:0f.0")
 
-        # QEMU version on rhel and centos-8/9-stream doesn't support scsi-host devices yet
-        if not m.image.startswith("rhel-8") and not m.image.startswith("rhel-9") and m.image != "centos-8-stream" and m.image != "centos-9-stream":
+        # QEMU version on RHEL 8/9 doesn't support scsi-host devices yet
+        if not m.image.startswith("rhel-8") and not m.image.startswith("rhel-9") and m.image != "centos-9-stream":
             # Test the unsupported device type, e.g. scsi_host, doesn't have "Remove" button
             m.execute(f"echo \"{SCSI_HOST_HOSTDEV}\" > /tmp/scsihost_hostdevxml")
             m.execute("virsh attach-device --domain subVmTest1 --file /tmp/scsihost_hostdevxml --persistent")

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -439,7 +439,7 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
         b.click(f"#vm-{name}-delete-modal-dialog button:contains(Delete)")
         self.waitVmRow(name, 'system', False)
 
-        if not m.image.startswith("rhel-8-") and m.image != "centos-8-stream":  # no snapshot support
+        if not m.image.startswith("rhel-8-"):
             # Delete a VM with snapshots and ensure the qcow2 image overlays get also cleaned up
             name = "vm-with-snapshots"
             self.createVm(name, running=False)

--- a/test/check-machines-networks
+++ b/test/check-machines-networks
@@ -123,7 +123,7 @@ class TestMachinesNetworks(machineslib.VirtualMachinesCase):
         b.wait_in_text("#card-pf-networks .pf-v5-c-card__header button", "Network")
         b.click(".pf-v5-c-card .pf-v5-c-card__header button:contains(Network)")
 
-        # HACK: Firefox 112 on centos-8-stream does not have `:has` yet, so for now use JavaScript to obtain the elements parent sibling.
+        # HACK: Firefox 112 on RHEL 8 does not have `:has` yet, so for now use JavaScript to obtain the elements parent sibling.
         b.inject_js("""
            ph_input_form_helper_text = function(id) {
               return document.getElementById(id).parentElement.parentElement.querySelector(".pf-v5-c-helper-text__item.pf-m-error").textContent

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -26,10 +26,6 @@ import testlib
 # echo "options kvm-intel nested=1" > /etc/modprobe.d/kvm-intel.conf
 # rmmod kvm-intel && modprobe kvm-intel || true
 
-# virt-install changed the default to "host-passthrough"
-# https://github.com/virt-manager/virt-manager/commit/2c477f330244e04614e174f50fbf37260c535705
-distrosWithDefaultHostModel = ["centos-8-stream"]
-
 
 @testlib.nondestructive
 class TestMachinesSettings(machineslib.VirtualMachinesCase):
@@ -234,8 +230,6 @@ class TestMachinesSettings(machineslib.VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
 
         cpu_model = "host-model"
-        if m.image in distrosWithDefaultHostModel:
-            cpu_model = "host-passthrough"
 
         # Copy host CPU configuration
         b.click("#vm-subVmTest1-cpu button")
@@ -473,8 +467,6 @@ class TestMachinesSettings(machineslib.VirtualMachinesCase):
         b.click("#vm-subVmTest1-cpu button")
         b.wait_visible("#machines-cpu-modal-dialog")
         cpu_model = "host-model"
-        if m.image in distrosWithDefaultHostModel:
-            cpu_model = "host-passthrough"
         b.select_from_dropdown("#cpu-model-select-group select", cpu_model)
         b.set_input_text("#machines-vcpu-max-field input", "3")  # Change values
         b.set_input_text("#machines-vcpu-count-field input", "3")
@@ -503,7 +495,7 @@ class TestMachinesSettings(machineslib.VirtualMachinesCase):
         self.assertEqual(virsh_output, 'action="reset"')
 
         # Check both changes have been applied
-        b.wait_in_text("#vm-subVmTest1-cpu", "3 vCPUs, host passthrough" if m.image in distrosWithDefaultHostModel else "3 vCPUs, host")
+        b.wait_in_text("#vm-subVmTest1-cpu", "3 vCPUs, host")
         b.wait_in_text("#vm-subVmTest1-watchdog-state", "Reset")
 
     def testWatchdog(self):
@@ -662,7 +654,7 @@ class TestMachinesSettings(machineslib.VirtualMachinesCase):
         m.execute("virsh destroy subVmTest1")
 
         # Some OSes don't support target.hotplug=off
-        if m.image.startswith("rhel-8") or m.image in ["centos-8-stream"]:
+        if m.image.startswith("rhel-8"):
             self.assertIn("Unknown --controller options", m.execute(
                 "! virt-xml subVmTest1 --edit model=pci-root --controller target.hotplug=off 2>&1")
             )

--- a/test/check-machines-snapshots
+++ b/test/check-machines-snapshots
@@ -27,7 +27,7 @@ import testlib
 
 # libvirt-dbus snapshot APIs are available since 1.4.0, see https://github.com/libvirt/libvirt-dbus/commit/642b1b71
 def supportsSnapshot(image):
-    return image != "centos-8-stream" and not image.startswith("rhel-8")
+    return not image.startswith("rhel-8")
 
 
 @testlib.nondestructive
@@ -258,7 +258,6 @@ class TestMachinesSnapshots(machineslib.VirtualMachinesCase):
         # external memory snapshots introduced in libvirt 9.9.0
         supports_external = not (
             m.image.startswith("rhel-8") or
-            m.image.startswith("centos-8") or
             m.image in ["debian-stable", "ubuntu-2204", "ubuntu-stable", "fedora-39"])
         # Transitional code while we move ubuntu-stable from 23.10 mantic to 24.04 noble
         if m.image == "ubuntu-stable" and m.execute(". /etc/os-release; echo $VERSION_ID").strip() == "24.04":

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -29,7 +29,7 @@ def hasMonolithicDaemon(image):
     return (image.startswith("rhel-8-") or
             image.startswith("debian") or
             image.startswith("ubuntu") or
-            image in ["centos-8-stream", "arch"])
+            image in ["arch"])
 
 
 class VirtualMachinesCaseHelpers:


### PR DESCRIPTION
C8S is going to be EOL in a month [1], and we are not going to do a RHEL 8 update at this point any more.

Keep testing on rhel-8-10 though, as we do want to keep the code working for the beiboot scenario or backports.

[1] https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/