### PR TITLE
test: Avoid racing the serial console

### DIFF
--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -110,8 +110,6 @@ class TestMachinesConsoles(machineslib.VirtualMachinesCase):
         b.click("#SerialConsole button")
         b.wait_not_present("#pf-v5-c-console__type-selector + .pf-v5-c-select__menu")
 
-        b.wait_in_text(f"#{name}-terminal .xterm-accessibility-tree", f"Connected to domain '{name}'")
-
         # In case the OS already finished booting, press Enter into the console to re-trigger the login prompt
         # Sometimes, pressing Enter one time doesn't take effect, so loop to press Enter to make sure the console has accepted it
         for _ in range(0, 60):
@@ -127,7 +125,8 @@ class TestMachinesConsoles(machineslib.VirtualMachinesCase):
         b.wait_text(f"#{name}-terminal", "Disconnected from serial console. Click the connect button.")
 
         b.click(f"#{name}-serialconsole-connect")
-        b.wait_in_text(f"#{name}-terminal .xterm-accessibility-tree > div:nth-child(1)", "Connected to domain")
+        b.wait_in_text(f"#{name}-terminal .xterm-accessibility-tree > div:nth-child(1)",
+                       f"Connected to domain '{name}'")
 
         b.click("button:contains(Expand)")
         b.assert_pixels("#vm-vmWithSerialConsole-consoles-page", "vm-details-console-serial",


### PR DESCRIPTION
The "Connected" message might already be scrolled out of the terminal when we check for it. We are already checking it as well after the boot is complete, and we can make that check a bit more precise.