### PR TITLE
disks: Display source for disks of type "block"

### DIFF
--- a/src/components/vm/disks/vmDiskColumns.jsx
+++ b/src/components/vm/disks/vmDiskColumns.jsx
@@ -39,6 +39,7 @@ const _ = cockpit.gettext;
 
 export const DISK_SOURCE_LIST = [
     { name: "file", label: _("File") },
+    { name: "dev", label: _("Block device") },
     { name: "device", label: _("Device") },
     { name: "protocol", label: _("Protocol") },
     { name: "pool", label: _("Pool") },

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -1667,6 +1667,28 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
                 force=True,
             ).execute()
 
+    def testBlockDeviceDisk(self):
+        b = self.browser
+        m = self.machine
+
+        loop_dev = self.add_loopback_disk()
+
+        self.createVm("subVmTest1", running=False)
+        m.execute(f"virt-xml subVmTest1 --add-device --disk source.type=block,source.dev={loop_dev}")
+        m.execute("virsh start subVmTest1")
+
+        self.login_and_go("/machines")
+        self.waitPageInit()
+
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
+        self.goToVmPage("subVmTest1")
+
+        b.wait_in_text('#vm-subVmTest1-disks', "Block device")
+        b.wait_text('#vm-subVmTest1-disks-vdb-source-dev', loop_dev)
+
+        if "debian" in m.image or "ubuntu" in m.image:
+            self.allow_journal_messages(f'.* type=1400 .* apparmor="DENIED" operation="open".*profile="virt-aa-helper" name="{loop_dev}".*')
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
They have an entry like `<source dev="..." />`.