### PR TITLE
test: Also attach console output of test VMs on failure

### DIFF
--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -463,6 +463,18 @@ class VirtualMachinesCase(testlib.MachineCase, VirtualMachinesCaseHelpers, stora
             testlib.attach(dest, move=True)
             print(f"Wrote {vm} log to {dest_file}")
 
+    def downloadVmConsole(self, vm):
+        m = self.machine
+
+        console_log = f"/var/log/libvirt/console-{vm}.log"
+        # Log file may not exist
+        if m.execute(f"! test -f {console_log} || echo exists").strip() == "exists":
+            dest_file = f"{self.label()}-{m.label}-{vm}-console.log"
+            dest = os.path.abspath(dest_file)
+            m.download(console_log, dest)
+            testlib.attach(dest, move=True)
+            print(f"Wrote {vm} console log to {dest_file}")
+
     def downloadVmsArtifacts(self):
         m = self.machine
 
@@ -472,6 +484,7 @@ class VirtualMachinesCase(testlib.MachineCase, VirtualMachinesCaseHelpers, stora
         for vm in vms:
             self.downloadVmXml(vm)
             self.downloadVmLog(vm)
+            self.downloadVmConsole(vm)
 
     def tearDown(self):
         b = self.browser


### PR DESCRIPTION
I hope to get some insights into the frequent failures to shut off a vm, like here: https://cockpit-logs.us-east-1.linodeobjects.com/pull-1616-01ca2ff1-20240507-110227-fedora-40-devel/log.html#40

Alpine will ignore shut-off requests while it is still booting, but the tests are (mostly) careful to wait for that to be over before shutting it down again. But let's see.