### PR TITLE
test: Check creating and booting an EFI guest

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -73,7 +73,7 @@ Rules configuration can be found in the `.stylelintrc.json` file.
 # Running tests locally
 
 Run `make vm` to build an RPM and install it into a standard Cockpit test VM.
-This will be `fedora-39` by default. You can set `$TEST_OS` to use a different
+This will be `fedora-40` by default. You can set `$TEST_OS` to use a different
 image, for example
 
     TEST_OS=centos-9-stream make vm

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PACKAGE_NAME := $(shell awk '/"name":/ {gsub(/[",]/, "", $$2); print $$2}' packa
 RPM_NAME := cockpit-$(PACKAGE_NAME)
 VERSION := $(shell T=$$(git describe 2>/dev/null) || T=1; echo $$T | tr '-' '.')
 ifeq ($(TEST_OS),)
-TEST_OS = fedora-39
+TEST_OS = fedora-40
 endif
 export TEST_OS
 TARFILE=$(RPM_NAME)-$(VERSION).tar.xz

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1328,15 +1328,20 @@ vnc_password= "{vnc_passwd}"
                 b.set_input_text("#vm-name", self.name)
 
             b.wait_not_present("#offline-token")
-            if self.os_name:
-                b.click("#os-select-group > div button")
-                b.click(f"#os-select li:contains('{self.os_name}') button")
-                b.wait_attr("#os-select-group input", "value", self.os_name)
 
             if self.sourceType != 'disk_image':
                 b.select_from_dropdown("#source-type", self.sourceType)
             else:
                 b.wait_not_present("#source-type")
+
+            # Data loading doesn't start immediately
+            time.sleep(1)
+            b.wait_attr("#os-select-group", "data-loading", "false")
+
+            if self.os_name:
+                b.click("#os-select-group > div button")
+                b.click(f"#os-select li:contains('{self.os_name}') button")
+                b.wait_attr("#os-select-group input", "value", self.os_name)
 
             if self.sourceType == 'file' or self.sourceType == 'cloud':
                 b.set_file_autocomplete_val("#source-file-group", self.location or " ")
@@ -2309,11 +2314,12 @@ vnc_password= "{vnc_passwd}"
         vmName = "subVmTest1"
         self.login_and_go("/machines")
         self.waitPageInit()
-        dialog = TestMachinesCreate.VmDialog(self, sourceType='file',
+        dialog = TestMachinesCreate.VmDialog(self, sourceType='cloud',
                                              name=vmName,
                                              location="/var/lib/libvirt/images/alpine-efi",
-                                             memory_size=128, memory_size_unit='MiB',
-                                             storage_size=256, storage_size_unit='MiB',
+                                             os_name="Oracle Linux 6.0",
+                                             memory_size=256, memory_size_unit='MiB',
+                                             storage_size=512, storage_size_unit='MiB',
                                              create_and_run=False)
         dialog.open().fill()
         b.click(".pf-v5-c-modal-box__footer #create-and-edit")
@@ -2331,6 +2337,14 @@ vnc_password= "{vnc_passwd}"
         # Install the VM
         b.click(f"#vm-{vmName}-system-install")
         b.wait_in_text(f"#vm-{vmName}-system-state", "Running")
+
+        # Now the boot messages are on the serial console
+        b.click("#pf-v5-c-console__type-selector")
+        b.wait_visible("#pf-v5-c-console__type-selector + .pf-v5-c-select__menu")
+        b.click("#SerialConsole button")
+        b.wait_not_present("#pf-v5-c-console__type-selector + .pf-v5-c-select__menu")
+
+        testlib.sit()
 
         # AppArmor policy fixed in later versions, don't bother with reporting
         if m.image == 'debian-stable':

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -2298,6 +2298,44 @@ vnc_password= "{vnc_passwd}"
         if m.image == 'debian-stable':
             self.allow_journal_messages('.*apparmor="DENIED".*name="/etc/ssl/openssl.cnf".*comm="swtpm".*')
 
+    def testConfigureBeforeInstallEFI(self):
+        m = self.machine
+        b = self.browser
+        TestMachinesCreate.CreateVmRunner(self)
+
+        m.upload([m.pull("alpine-efi")], "/var/lib/libvirt/images/")
+
+        # create VM with an EFI image
+        vmName = "subVmTest1"
+        self.login_and_go("/machines")
+        self.waitPageInit()
+        dialog = TestMachinesCreate.VmDialog(self, sourceType='file',
+                                             name=vmName,
+                                             location="/var/lib/libvirt/images/alpine-efi",
+                                             memory_size=128, memory_size_unit='MiB',
+                                             storage_size=256, storage_size_unit='MiB',
+                                             create_and_run=False)
+        dialog.open().fill()
+        b.click(".pf-v5-c-modal-box__footer #create-and-edit")
+        b.wait_not_present("#create-vm-dialog")
+        b.wait_in_text(f"#vm-{vmName}-firmware", "BIOS")
+
+        # Change the os boot firmware to EFI
+        b.click(f"#vm-{vmName}-firmware")
+        b.wait_visible(".pf-v5-c-modal-box__body")
+        b.select_from_dropdown(".pf-v5-c-modal-box__body select", "efi")
+        b.click("#firmware-dialog-apply")
+        b.wait_not_present(".pf-v5-c-modal-box__body")
+        b.wait_in_text(f"#vm-{vmName}-firmware", "UEFI")
+
+        # Install the VM
+        b.click(f"#vm-{vmName}-system-install")
+        b.wait_in_text(f"#vm-{vmName}-system-state", "Running")
+
+        # AppArmor policy fixed in later versions, don't bother with reporting
+        if m.image == 'debian-stable':
+            self.allow_journal_messages('.*apparmor="DENIED".*name="/etc/ssl/openssl.cnf".*comm="swtpm".*')
+
     def testCreateDownloadRhel(self):
         runner = TestMachinesCreate.CreateVmRunner(self, rhel_download=True)
         config = TestMachinesCreate.TestCreateConfig


### PR DESCRIPTION
Use our new "alpine-efi" bots image as guest.

This isn't very comprehensive yet, mostly to validate that the alpine-efi image works, and that c-machines/libvirt can *actually* boot an EFI guest. We may want to extend this to more tests in the future, so that we'll get better ARM coverage. But that at least sets a baseline.

---

Requires https://github.com/cockpit-project/bots/pull/6351 . Also, the first image I tried this on was fedora-40, and it [failed right away](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1619-039a1ed8-20240507-145041-fedora-40-bots%236351/log.html#74). Turns out it's *drumroll* [SELinux](https://github.com/cockpit-project/bots/issues/5944), so this will need a naughty. That's added to the bots PR now.