### PR TITLE
test: Wait longer for Alpine to shut down

### DIFF
--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -173,7 +173,8 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
         b.click("#vm-subVmTest1-system-shutdown-button")
         b.wait_visible("#vm-subVmTest1-system-confirm-action-modal")
         b.click(".pf-v5-c-modal-box__footer #vm-subVmTest1-system-off")
-        b.wait_in_text("#vm-subVmTest1-system-state", "Shut off")
+        with b.wait_timeout(60):
+            b.wait_in_text("#vm-subVmTest1-system-state", "Shut off")
         b.wait_visible("#vm-subVmTest1-system-run")
 
         # the shut off button in the extended operation list


### PR DESCRIPTION
It seems to be slower than Cirros.

Example failure: https://cockpit-logs.us-east-1.linodeobjects.com/pull-1616-e0c69eeb-20240510-071702-fedora-40-devel/log.html#30-2

The console log shows that shutdown has in fact started: https://cockpit-logs.us-east-1.linodeobjects.com/pull-1616-e0c69eeb-20240510-071702-fedora-40-devel/TestMachinesLifecycle-testBasic-fedora-40-127.0.0.2-2201-subVmTest1-console.log

Thus, waiting longer should indeed work.

