### PR TITLE
vm: Support for VM descriptions

### DIFF
--- a/src/components/vm/vmActions.jsx
+++ b/src/components/vm/vmActions.jsx
@@ -38,6 +38,7 @@ import { ConfirmDialog } from './confirmDialog.jsx';
 import { DeleteDialog } from "./deleteDialog.jsx";
 import { MigrateDialog } from './vmMigrateDialog.jsx';
 import { RenameDialog } from './vmRenameDialog.jsx';
+import { EditDescriptionDialog } from './vmEditDescriptionDialog.jsx';
 import { ReplaceSpiceDialog } from './vmReplaceSpiceDialog.jsx';
 import {
     domainCanDelete,
@@ -451,8 +452,20 @@ const VmActions = ({ vm, vms, onAddErrorNotification, isDetailsPage }) => {
                 {_("Rename")}
             </DropdownItem>
         );
-        dropdownItems.push(<Divider key="separator-rename" />);
     }
+
+    if (isDetailsPage) {
+        dropdownItems.push(
+            <DropdownItem key={`${id}-edit-description`}
+                          id={`${id}-edit-description`}
+                          onClick={() => Dialogs.show(<EditDescriptionDialog vm={vm} />)}>
+                {_("Edit description")}
+            </DropdownItem>
+        );
+    }
+
+    if (domainCanRename(state) || isDetailsPage)
+        dropdownItems.push(<Divider key="separator-rename" />);
 
     if (state !== undefined && domainCanDelete(state, vm.id)) {
         if (!vm.persistent) {

--- a/src/components/vm/vmDetailsPage.jsx
+++ b/src/components/vm/vmDetailsPage.jsx
@@ -75,6 +75,12 @@ export const VmDetailsPage = ({
                 <VmNeedsShutdown vm={vm} />
                 <VmUsesSpice vm={vm} />
             </div>
+            {
+                vm.inactiveXML.description &&
+                    <div className="vm-description">
+                        {vm.inactiveXML.description.split("\n").map((p, i) => <p key={i}>{p}</p>)}
+                    </div>
+            }
         </PageSection>
     );
 

--- a/src/components/vm/vmEditDescriptionDialog.jsx
+++ b/src/components/vm/vmEditDescriptionDialog.jsx
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from 'cockpit';
+import React, { useState } from 'react';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
+import { TextArea } from "@patternfly/react-core/dist/esm/components/TextArea";
+
+import { ModalError } from 'cockpit-components-inline-notification.jsx';
+import { useDialogs } from 'dialogs.jsx';
+
+import { isObjectEmpty } from '../../helpers.js';
+import { domainSetDescription } from '../../libvirtApi/domain.js';
+
+const _ = cockpit.gettext;
+
+export const EditDescriptionDialog = ({ vm }) => {
+    const Dialogs = useDialogs();
+    const [description, setDescription] = useState(vm.inactiveXML.description || "");
+    const [error, dialogErrorSet] = useState({});
+
+    async function onSubmit() {
+        try {
+            await domainSetDescription(vm, description);
+            Dialogs.close();
+        } catch (exc) {
+            dialogErrorSet({
+                dialogError: cockpit.format(_("Failed to set description of VM $0"), vm.name),
+                dialogErrorDetail: exc.message
+            });
+        }
+    }
+
+    return (
+        <Modal position="top" variant="small" isOpen onClose={Dialogs.close}
+               title={cockpit.format(_("Edit description of VM $0"), vm.name)}
+               footer={
+                   <>
+                       <Button variant='primary'
+                               id="edit-description-dialog-confirm"
+                               onClick={onSubmit}>
+                           {_("Save")}
+                       </Button>
+                       <Button variant='link' onClick={Dialogs.close}>
+                           {_("Cancel")}
+                       </Button>
+                   </>
+               }>
+            <Form onSubmit={e => {
+                e.preventDefault();
+                onSubmit();
+            }}
+            isHorizontal>
+                {!isObjectEmpty(error) && <ModalError dialogError={error.dialogError} dialogErrorDetail={error.dialogErrorDetail} />}
+                <FormGroup label={_("Description")}
+                           fieldId="edit-description-dialog-description">
+                    <TextArea id='edit-description-dialog-description'
+                               value={description}
+                               onChange={(_, value) => setDescription(value)} />
+                </FormGroup>
+            </Form>
+        </Modal>
+    );
+};

--- a/src/libvirt-xml-parse.js
+++ b/src/libvirt-xml-parse.js
@@ -245,6 +245,8 @@ export function parseDomainDumpxml(connectionName, domXml, objPath) {
     const metadataElem = getSingleOptionalElem(domainElem, "metadata");
 
     const name = domainElem.getElementsByTagName("name")[0].childNodes[0].nodeValue;
+    const uuid = domainElem.getElementsByTagName("uuid")[0].childNodes[0].nodeValue;
+    const description = domainElem.getElementsByTagName("description")[0]?.childNodes[0]?.nodeValue;
     const id = objPath;
     const osType = osTypeElem.childNodes[0].nodeValue;
     const osBoot = parseDumpxmlForOsBoot(osBootElems);
@@ -292,7 +294,9 @@ export function parseDomainDumpxml(connectionName, domXml, objPath) {
 
     return {
         connectionName,
+        uuid,
         name,
+        description,
         id,
         osType,
         osBoot,

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -367,6 +367,27 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
         b.wait_text("h2.vm-name", "test%")
         b.wait_not_present("#navbar-oops")
 
+    def testEditDescription(self):
+        b = self.browser
+
+        self.createVm("mac", running=False)
+        self.login_and_go("/machines")
+        self.waitPageInit()
+        self.goToVmPage("mac")
+
+        self.performAction("mac", "edit-description")
+
+        # Non-ascii chars, unbalanced quotes, backslash, multiple lines
+        desc1 = '"Döscrü\\ptiän \'\'\' كرة القدم'
+        desc2 = 'Second <b>line</b>'
+
+        b.set_input_text("#edit-description-dialog-description", desc1 + "\n" + desc2)
+        b.click("#edit-description-dialog-confirm")
+        b.wait_not_present("#edit-description-dialog-confirm")
+
+        b.wait_text(".vm-description p:nth-child(1)", desc1)
+        b.wait_text(".vm-description p:nth-child(2)", desc2)
+
     def testDelete(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Based on work by @Britz, thanks a lot!

This is also a proving ground for robust and convenient virt-xml invocations. I plan to renovate the rest of domain.js and other files accordingly.

--------------------------------

### Machines: Support for VM descriptions

Cockpit can now show and change the descriptions of virtual machines.

--------------------------------

Details page with description:

![image](https://github.com/cockpit-project/cockpit-machines/assets/3228183/151ef482-6954-49e9-9b65-83152bda4bd3)

The description is a `<p>` so that it doesn't get too shouty when people put a lot of text there.

"Edit description" action:

![image](https://github.com/cockpit-project/cockpit-machines/assets/3228183/aec37695-aec4-4541-900d-7033d1318d97)

"Edit description" dialog:

![image](https://github.com/cockpit-project/cockpit-machines/assets/3228183/7c8608bd-64db-41c1-bfe0-9dc4ec3c68ae)
