### PR TITLE
Enable tests on CentOS 10 stream

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -36,6 +36,7 @@ jobs:
     packages: [cockpit-machines-centos]
     targets:
     - centos-stream-9
+    - centos-stream-10
 
   - job: tests
     packages: [cockpit-machines-fedora]
@@ -50,6 +51,7 @@ jobs:
     trigger: pull_request
     targets:
       - centos-stream-9
+      - centos-stream-10
 
   - job: copr_build
     trigger: release

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -51,6 +51,11 @@ if [ "$ID" = fedora ]; then
     dnf install -y virtiofsd
 fi
 
+# HACK: https://issues.redhat.com/browse/RHEL-29893
+if [ "$PLATFORM_ID" = "platform:el10" ]; then
+    dnf install -y kernel-modules-extra
+fi
+
 # Run tests in the cockpit tasks container, as unprivileged user
 # TODO: Run in "host" network ns, as some tests fail on unexpected veth/bridge claimed by the container
 # fix these and then use the isolation in starter-kit and friends

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -2520,8 +2520,8 @@ vnc_password= "{vnc_passwd}"
         self.goToMainPage()
         self.machine.execute(f"virsh destroy {vmCockpit}; virsh undefine {vmCockpit}")
 
-        # RHEL 9 doesn't support SPICE, so skip the rest of the test
-        if m.image.startswith("rhel-9") or m.image.startswith("centos-9"):
+        # RHEL ≥ 9 doesn't support SPICE, so skip the rest of the test
+        if (m.image.startswith("rhel-") or m.image.startswith("centos-")) and "rhel-8" not in m.image:
             return
 
         #

--- a/test/check-machines-hostdevs
+++ b/test/check-machines-hostdevs
@@ -221,8 +221,8 @@ class TestMachinesHostDevs(machineslib.VirtualMachinesCase):
 
         b.wait_in_text("#vm-subVmTest1-hostdev-1-source #slot-1", "0000:00:0f.0")
 
-        # QEMU version on RHEL 8/9 doesn't support scsi-host devices yet
-        if not m.image.startswith("rhel-8") and not m.image.startswith("rhel-9") and m.image != "centos-9-stream":
+        # QEMU version on RHEL doesn't support scsi-host devices
+        if not m.image.startswith("rhel") and not m.image.startswith("centos"):
             # Test the unsupported device type, e.g. scsi_host, doesn't have "Remove" button
             m.execute(f"echo \"{SCSI_HOST_HOSTDEV}\" > /tmp/scsihost_hostdevxml")
             m.execute("virsh attach-device --domain subVmTest1 --file /tmp/scsihost_hostdevxml --persistent")

--- a/test/check-machines-multi-host-consoles
+++ b/test/check-machines-multi-host-consoles
@@ -32,7 +32,7 @@ class TestMultiMachineVNC(VirtualMachinesCase):
     """
 
     provision = {  # noqa: RUF012
-        "machine1": {"address": "10.111.113.1/20", "memory_mb": 660},
+        "machine1": {"address": "10.111.113.1/20", "memory_mb": 1024},
         "machine2": {"address": "10.111.113.2/20", "memory_mb": 660},
     }
 
@@ -51,6 +51,9 @@ class TestMultiMachineVNC(VirtualMachinesCase):
 
         m.execute(f"ssh-keyscan {m2_host} > /etc/ssh/ssh_known_hosts")
         self.startLibvirt(m2)
+
+        # uses too much RAM with lots of violations
+        m.execute("systemctl mask setroubleshootd.service")
 
         # Start a VM with a VNC on machine1
         name = "subVmTest1"

--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -456,8 +456,8 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
                 source={"host": "127.0.0.1", "source_path": target_iqn}
             ).execute()
 
-            if "debian" not in m.image and "ubuntu" not in m.image and "rhel-9" not in m.image and "centos-9" not in m.image:
-                # iscsi-direct pool type is not available in Debian/Ubuntu (https://bugs.debian.org/918728)
+            if "debian" not in m.image and "ubuntu" not in m.image and "rhel" not in m.image and "centos" not in m.image:
+                # iscsi-direct pool type is not available in RHEL and Debian/Ubuntu (https://bugs.debian.org/918728)
                 StoragePoolCreateDialog(
                     self,
                     name="my_iscsi_direct_pool",


### PR DESCRIPTION
 - Requires https://github.com/cockpit-project/bots/pull/6378
 - Requires https://github.com/cockpit-project/bots/pull/6413
 - Requires https://github.com/cockpit-project/bots/pull/6415

:warning: While this does fix the "centos-10" test, I intend to keep this in the `_manual` testmap for the time being. C10S is still too broken. I just want an one-time fix for now, plus enable it in TF (which we can ignore), as we got asked to do a first release to C10.