### PR TITLE
fmf: Drop F40 repo on RHEL 10, re-disable c10s packit test

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -36,7 +36,8 @@ jobs:
     packages: [cockpit-machines-centos]
     targets:
     - centos-stream-9
-    - centos-stream-10
+    # blocked on https://issues.redhat.com/browse/RHEL-29893
+    # - centos-stream-10
 
   - job: tests
     packages: [cockpit-machines-fedora]
@@ -51,7 +52,8 @@ jobs:
     trigger: pull_request
     targets:
       - centos-stream-9
-      - centos-stream-10
+      # blocked on https://issues.redhat.com/browse/RHEL-29893
+      # - centos-stream-10
 
   - job: copr_build
     trigger: release

--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -1,5 +1,14 @@
 discover:
     how: fmf
+
+# counteract https://issues.redhat.com/browse/TFT-2564
+adjust:
+  prepare+:
+  - how: shell
+    script: |
+      rm --force --verbose /etc/yum.repos.d/fedora.repo
+    when: distro == centos-10
+
 execute:
     how: tmt
 


### PR DESCRIPTION
https://issues.redhat.com/browse/TFT-2564 currently adds that for
$reasons, and it's all too likely to install/cross-grade to Fedora
packages with `dnf` commands. This currently happens with libvirt
packages.

Remove the Fedora repo early in the test plan, so that our test
dependencies will actually be installed from CentOS, not Fedora.


----

See [recent run](https://artifacts.dev.testing-farm.io/cf6b1fce-a7a6-4118-b5f5-d81434e61b60/). This should at least fix the cross-grade of libvirt to f40, and maybe even the testCreateDownloadAnOS test regression.