### PR TITLE
fmf: Fix bogus /dev/sda* → nvme* symlinks on TF machines

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -10,6 +10,14 @@ DNF="dnf install --disablerepo=fedora-cisco-openh264 -y"
 # RHEL/CentOS 8 and Fedora have this, but not RHEL 9; tests check this more precisely
 $DNF libvirt-daemon-driver-storage-iscsi-direct || true
 
+# HACK: this package creates bogus/broken sda → nvme symlinks; it's new in rawhide TF default instances, not required for
+# our tests, and only causes trouble; https://github.com/amazonlinux/amazon-ec2-utils/issues/37
+if rpm -q amazon-ec2-utils; then
+    rpm -e --verbose amazon-ec2-utils
+    # clean up the symlinks
+    udevadm trigger /dev/nvme*
+fi
+
 # Show critical packages versions
 rpm -q selinux-policy cockpit-bridge cockpit-machines
 rpm -qa | grep -E 'virt|qemu' | sort


### PR DESCRIPTION
Same as https://github.com/cockpit-project/cockpit/commit/6add938bbe5462

This broke all the storage pools tests.

---

[example](https://artifacts.dev.testing-farm.io/460483e1-8117-4945-92ed-e53477b16607/)

See https://github.com/amazonlinux/amazon-ec2-utils/issues/37 for the root cause.