### PR TITLE
test: Change PXE config path to be AppArmor compatible

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -511,9 +511,9 @@ class TestMachinesCreate(machineslib.VirtualMachinesCase):
 
         # Set up the PXE server configuration files
         cmds = [
-            "mkdir -p /var/lib/libvirt/pxe-config",
-            f"echo \"{PXE_SERVER_CFG}\" > /var/lib/libvirt/pxe-config/pxe.cfg",
-            "chmod 666 /var/lib/libvirt/pxe-config/pxe.cfg"
+            "mkdir -p /var/lib/libvirt/dnsmasq",
+            f"echo \"{PXE_SERVER_CFG}\" > /var/lib/libvirt/dnsmasq/pxe.cfg",
+            "chmod 666 /var/lib/libvirt/dnsmasq/pxe.cfg"
         ]
         self.machine.execute("; ".join(cmds))
 

--- a/test/machinesxmls.py
+++ b/test/machinesxmls.py
@@ -100,7 +100,7 @@ NETWORK_XML_PXE = """<network>
   <bridge name='virbr0' stp='on' delay='0'/>
   <mac address='52:54:00:53:7d:8e'/>
   <ip address='192.168.122.1' netmask='255.255.255.0'>
-    <tftp root='/var/lib/libvirt/pxe-config'/>
+    <tftp root='/var/lib/libvirt/dnsmasq'/>
     <dhcp>
       <range start='192.168.122.2' end='192.168.122.254'/>
       <bootp file='pxe.cfg'/>


### PR DESCRIPTION
At least OpenSUSE's AppArmor config only allows libvirt to access /var/lib/libvirt/dnsmasq/. Use that standard path instead of our custom one.

See https://github.com/cockpit-project/cockpit-machines/pull/1655#discussion_r1618403695