### PR TITLE
packit: Restrict koji_build and bodhi_update to Fedora

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -84,6 +84,7 @@ jobs:
 
   - job: koji_build
     trigger: commit
+    packages: [cockpit-machines-fedora]
     dist_git_branches:
       - fedora-development
       - fedora-39
@@ -91,6 +92,7 @@ jobs:
 
   - job: bodhi_update
     trigger: commit
+    packages: [cockpit-machines-fedora]
     dist_git_branches:
       # rawhide updates are created automatically
       - fedora-39


### PR DESCRIPTION
While they are not directly related to building srpms, this caused the koji-build jobs to run twice, and thus creating confusing "Fedora Koji build failed to be triggered" issues.

Fixes #1660

---

This already happened to me in https://github.com/martinpitt/umockdev/issues/245