### PR TITLE
snapshots: Ignore limitations of external format on RHEL

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -39,6 +39,7 @@ const VMS_CONFIG = {
     },
 
     StorageMigrationSupported: true,
+    ForceExternalSnapshots: false,
 };
 
 export async function load_config() {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -23,6 +23,8 @@ import { formatRelative } from 'date-fns';
 import cockpit from 'cockpit';
 import store from './store.js';
 
+import VMS_CONFIG from "./config.js";
+
 const _ = cockpit.gettext;
 
 export const LIBVIRT_SESSION_CONNECTION = 'session';
@@ -899,8 +901,11 @@ export function vmSupportsExternalSnapshots(config, vm, storagePools) {
         return false;
     }
 
-    // Currently external snapshots work only for disks of type "file"
-    if (!disks.every(disk => disk.type === "file")) {
+    // HACK: https://gitlab.com/libvirt/libvirt/-/issues/631
+    //
+    // Currently external snapshots work only for disks of type "file".
+
+    if (!VMS_CONFIG.ForceExternalSnapshots && !disks.every(disk => disk.type === "file")) {
         logDebug(`vmSupportsExternalSnapshots: vm ${vm.name} has unsupported disk type`);
         return false;
     }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -29,6 +29,9 @@
   "config": {
       "StorageMigrationSupported": {
           "rhel": false
+      },
+      "ForceExternalSnapshots": {
+          "rhel": true
       }
   }
 }


### PR DESCRIPTION
Internal snapshots are not fully supported on RHEL, so we assume that the limitations of external snapshots on RHEL are fixed.