### PR TITLE
test: Add a canary for the last external snapshot issue

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -899,7 +899,15 @@ export function vmSupportsExternalSnapshots(config, vm, storagePools) {
         return false;
     }
 
-    // Currently external snapshots work only for disks of type "file"
+    // HACK - https://gitlab.com/libvirt/libvirt/-/issues/631
+    //
+    // Currently external snapshots work only for disks of type
+    // "file".  We work around this by making internal snapshots
+    // instead in that case. The workaround here should be removed
+    // when the bug is fixed. Also see:
+    //
+    //     https://github.com/cockpit-project/cockpit-machines/pull/1554
+    //
     if (!disks.every(disk => disk.type === "file")) {
         logDebug(`vmSupportsExternalSnapshots: vm ${vm.name} has unsupported disk type`);
         return false;

--- a/test/check-machines-snapshots
+++ b/test/check-machines-snapshots
@@ -18,6 +18,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import subprocess
 import time
 from datetime import datetime
 
@@ -318,7 +319,9 @@ class TestMachinesSnapshots(machineslib.VirtualMachinesCase):
         m.execute("virsh snapshot-delete subVmTest1 test_snap_1")
 
         # With disk in a pool.
-        # This will make a internal snapshot.
+        #
+        # This will make a internal snapshot because of our workaround for
+        # https://gitlab.com/libvirt/libvirt/-/issues/631.
 
         p1 = os.path.join(self.vm_tmpdir, "vm_one")
         m.execute(f"mkdir --mode 777 {p1}")
@@ -338,6 +341,14 @@ class TestMachinesSnapshots(machineslib.VirtualMachinesCase):
         b.reload()
         b.enter_page('/machines')
         b.wait_visible("#vm-subVmTest1-disks-vdb-source-volume")
+
+        # Let's check whether
+        # https://gitlab.com/libvirt/libvirt/-/issues/631 has been
+        # fixed. If so, we can remove our workaround for it in
+        # helpers.js.
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            m.execute("virsh snapshot-create-as subVmTest1 snap --disk-only 2>&1")
+        self.assertIn(b"cannot generate external snapshot name for disk 'vdb' without source", cm.exception.stdout)
 
         SnapshotCreateDialog(
             self,


### PR DESCRIPTION
If the canary triggers, we can remove our workaround.