### PR TITLE
test: Ensure stable snapshot sorting

### DIFF
--- a/test/check-machines-snapshots
+++ b/test/check-machines-snapshots
@@ -309,7 +309,7 @@ class TestMachinesSnapshots(machineslib.VirtualMachinesCase):
         # Test create the same description and different name
         SnapshotCreateDialog(
             self,
-            name="test_snap_des",
+            name="test_snap_0",
             description="Description of test_snap_1",
             expect_external=supports_external,
             state="shutoff",


### PR DESCRIPTION
Snapshots are sorted by creation time, and then by name.  The test expects "test_snap_des" to be in the first row, which it normally is since it is created last. But if it is created in the same second as "test_snap_1", then it will be in the second row because its name is sorted after "test_snap_1".

Let's fix that by naming it "test_snap_0". Then it is always in the first row, even when the creation times are equal.