### PR TITLE
Show snapshot creation date as time delta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PACKAGE_NAME := $(shell awk '/"name":/ {gsub(/[",]/, "", $$2); print $$2}' packa
 RPM_NAME := cockpit-$(PACKAGE_NAME)
 VERSION := $(shell T=$$(git describe 2>/dev/null) || T=1; echo $$T | tr '-' '.')
 ifeq ($(TEST_OS),)
-TEST_OS = fedora-39
+TEST_OS = fedora-40
 endif
 export TEST_OS
 TARFILE=$(RPM_NAME)-$(VERSION).tar.xz

--- a/src/components/vm/snapshots/vmSnapshotsCard.jsx
+++ b/src/components/vm/snapshots/vmSnapshotsCard.jsx
@@ -26,9 +26,10 @@ import { CheckIcon, InfoAltIcon } from '@patternfly/react-icons';
 
 import cockpit from 'cockpit';
 import { useDialogs, DialogsContext } from 'dialogs.jsx';
+import * as timeformat from 'timeformat';
 import { ListingTable } from "cockpit-components-table.jsx";
 
-import { vmId, localize_datetime, vmSupportsExternalSnapshots } from "../../../helpers.js";
+import { vmId, vmSupportsExternalSnapshots } from "../../../helpers.js";
 import { CreateSnapshotModal } from "./vmSnapshotsCreateModal.jsx";
 import { DeleteResourceButton } from '../../common/deleteResource.jsx';
 import { RevertSnapshotModal } from './vmSnapshotsRevertModal.jsx';
@@ -76,11 +77,12 @@ export class VmSnapshotsCard extends React.Component {
             {
                 name: _("Creation time"),
                 value: (snap, snapId) => {
-                    const date = localize_datetime(snap.creationTime * 1000);
+                    const dateRel = timeformat.distanceToNow(snap.creationTime * 1000, true);
+                    const dateAbs = timeformat.dateTimeSeconds(snap.creationTime * 1000);
                     return (
                         <Flex className="snap-creation-time">
                             <FlexItem id={`${id}-snapshot-${snapId}-date`} spacer={{ default: 'spacerSm' }}>
-                                {date}
+                                <Tooltip content={dateAbs}><span>{dateRel}</span></Tooltip>
                             </FlexItem>
                             { snap.isCurrent && <FlexItem><Tooltip content={_("Current")}>
                                 <CheckIcon id={`${id}-snapshot-${snapId}-current`} />

--- a/src/components/vm/snapshots/vmSnapshotsCard.jsx
+++ b/src/components/vm/snapshots/vmSnapshotsCard.jsx
@@ -16,17 +16,20 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
+
 import React from 'react';
 
-import cockpit from 'cockpit';
-import { useDialogs, DialogsContext } from 'dialogs.jsx';
-import { vmId, localize_datetime, vmSupportsExternalSnapshots } from "../../../helpers.js";
-import { CreateSnapshotModal } from "./vmSnapshotsCreateModal.jsx";
-import { ListingTable } from "cockpit-components-table.jsx";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
 import { CheckIcon, InfoAltIcon } from '@patternfly/react-icons';
+
+import cockpit from 'cockpit';
+import { useDialogs, DialogsContext } from 'dialogs.jsx';
+import { ListingTable } from "cockpit-components-table.jsx";
+
+import { vmId, localize_datetime, vmSupportsExternalSnapshots } from "../../../helpers.js";
+import { CreateSnapshotModal } from "./vmSnapshotsCreateModal.jsx";
 import { DeleteResourceButton } from '../../common/deleteResource.jsx';
 import { RevertSnapshotModal } from './vmSnapshotsRevertModal.jsx';
 import { snapshotDelete, snapshotGetAll } from '../../../libvirtApi/snapshot.js';

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -17,9 +17,6 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import * as dfnlocales from 'date-fns/locale';
-import { formatRelative } from 'date-fns';
-
 import cockpit from 'cockpit';
 import store from './store.js';
 
@@ -39,11 +36,6 @@ export function toReadableNumber(number) {
         const fixed1 = Math.floor(number * 10) / 10;
         return (number - fixed1 === 0) ? Math.floor(number) : fixed1;
     }
-}
-
-export function localize_datetime(time) {
-    const locale = (cockpit.language == "en") ? dfnlocales.enUS : dfnlocales[cockpit.language.replace('_', '')];
-    return formatRelative(time, Date.now(), { locale });
 }
 
 export const diskBusTypes = {

--- a/test/check-machines-snapshots
+++ b/test/check-machines-snapshots
@@ -20,7 +20,6 @@
 import os
 import subprocess
 import time
-from datetime import datetime
 
 import machineslib
 import testlib
@@ -35,15 +34,6 @@ def supportsSnapshot(image):
 class TestMachinesSnapshots(machineslib.VirtualMachinesCase):
 
     def testSnapshots(self):
-        # Checks if difference of @time1 and @time2 is not greater than @difference (in seconds)
-        def checkTimeDiff(time1, time2, difference):
-            tmp = time2.split(' ')  # split "today at 13:13:13" into day and time
-            if not tmp[2].startswith('00:') and not tmp[0] == "today":
-                return False
-
-            diff = datetime.strptime(time1, '%H:%M:%S') - datetime.strptime("".join(tmp[-2:]), '%I:%M%p')
-            return -difference < diff.total_seconds() < difference
-
         b = self.browser
         m = self.machine
 
@@ -65,7 +55,6 @@ class TestMachinesSnapshots(machineslib.VirtualMachinesCase):
         m.execute("virsh detach-disk --domain subVmTest1 --target vda --persistent")  # vda is raw disk, which are not supported by internal snapshots
         m.execute("qemu-img create -f qcow2 /var/lib/libvirt/images/foobar.qcow2 1M")
         m.execute("virsh attach-disk --domain subVmTest1 --source /var/lib/libvirt/images/foobar.qcow2 --target vdb --persistent")
-        time1 = datetime.now().strftime("%H:%M:%S")
         m.execute("virsh snapshot-create-as --domain subVmTest1 --name snapshotB --description 'Description of snapshotB' --disk-only")
 
         b.reload()  # snapshots events not available yet: https://gitlab.com/libvirt/libvirt/-/issues/44
@@ -76,13 +65,11 @@ class TestMachinesSnapshots(machineslib.VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-snapshot-0-description", "Description of snapshotB")
         b.wait_in_text("#vm-subVmTest1-snapshot-0-type", "no state saved")
         b.wait_in_text("#vm-subVmTest1-snapshot-0-parent", "No parent")
-        time2 = b.text("#vm-subVmTest1-snapshot-0-date")
-        self.assertTrue(checkTimeDiff(time1, time2, 60))
+        b.wait_text("#vm-subVmTest1-snapshot-0-date", "less than a minute ago")
 
         # Check snapshot for shutoff VM
         self.performAction("subVmTest1", "forceOff")
 
-        time1 = datetime.now().strftime("%H:%M:%S")
         long_description = "This is a long description" * 10
         m.execute(f"virsh snapshot-create-as --domain subVmTest1 --name snapshotC --description '{long_description}'")
 
@@ -93,8 +80,7 @@ class TestMachinesSnapshots(machineslib.VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-snapshot-0-description", long_description)
         b.wait_in_text("#vm-subVmTest1-snapshot-0-type", "shut off")
         b.wait_in_text("#vm-subVmTest1-snapshot-0-parent", "snapshotB")
-        time2 = b.text("#vm-subVmTest1-snapshot-0-date")
-        self.assertTrue(checkTimeDiff(time1, time2, 60))
+        b.wait_text("#vm-subVmTest1-snapshot-0-date", "less than a minute ago")
 
         b.assert_pixels(
             "#vm-subVmTest1-snapshots", "vm-snapshost-card",


### PR DESCRIPTION
We use `timeformat.distanceToNow()` in most places in cockpit. Use that
for consistency rather than showing a fuzzified absolut/relative time
stamp mix with date-fn's formatRelative(). For more precision, show the
absolute creation time in a tooltip.

This weans cockpit-machines off the date-fns API, which we try to get
rid of (https://github.com/cockpit-project/cockpit/issues/20653).

-----

Current main:

![snapshots-main](https://github.com/cockpit-project/cockpit-machines/assets/200109/f01b8a07-b4f5-40df-adc6-1b0f6c77d51b)

This PR:

![snap-pr](https://github.com/cockpit-project/cockpit-machines/assets/200109/6c38d067-173a-4ece-a2a7-7eee2b1ba74e)