### PR TITLE
package.json: drop deep-equal

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@patternfly/react-table": "5.3.3",
     "@patternfly/react-tokens": "5.3.1",
     "date-fns": "3.6.0",
-    "deep-equal": "2.2.3",
     "prop-types": "15.8.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",


### PR DESCRIPTION
Machines does not deep_equal anywhere in its code or in anything imported from `pkg/lib`.