### PR TITLE
test: openssh 9.8 by default disabled DSA key generation

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -349,9 +349,9 @@ class TestMachinesCreate(machineslib.VirtualMachinesCase):
         self.machine.execute("ssh-keygen -t rsa -N '' -f /tmp/rsakey")
         rsakey = self.machine.execute("cat /tmp/rsakey.pub").strip()
         self.addCleanup(self.machine.execute, "rm -f /tmp/rsakey*")
-        self.machine.execute("ssh-keygen -t dsa -N '' -C '' -f /tmp/dsakey").strip()  # public key with empty comment
-        dsakey = self.machine.execute("cat /tmp/dsakey.pub")
-        self.addCleanup(self.machine.execute, "rm -f /tmp/dsakey*")
+        self.machine.execute("ssh-keygen -t ecdsa -N '' -C '' -f /tmp/ecdsakey").strip()  # public key with empty comment
+        ecdsakey = self.machine.execute("cat /tmp/ecdsakey.pub")
+        self.addCleanup(self.machine.execute, "rm -f /tmp/ecdsakey*")
 
         # Try to create VM with one SSH key
         runner.createCloudBaseImageTest(TestMachinesCreate.VmDialog(self, sourceType='cloud',
@@ -395,8 +395,8 @@ class TestMachinesCreate(machineslib.VirtualMachinesCase):
                                                                     user_password="catsaremybestfr13nds",
                                                                     user_login="foo",
                                                                     root_password="dogsaremybestfr13nds",
-                                                                    ssh_keys=[rsakey, dsakey],
-                                                                    expected_ssh_keys=[rsakey, dsakey],
+                                                                    ssh_keys=[rsakey, ecdsakey],
+                                                                    expected_ssh_keys=[rsakey, ecdsakey],
                                                                     create_and_run=True))
 
         # try to input multiple keys (separated by newline) into one text input
@@ -408,8 +408,8 @@ class TestMachinesCreate(machineslib.VirtualMachinesCase):
                                                                     user_password="catsaremybestfr13nds",
                                                                     user_login="foo",
                                                                     root_password="dogsaremybestfr13nds",
-                                                                    ssh_keys=[f"{rsakey}\n{dsakey}"],
-                                                                    expected_ssh_keys=[rsakey, dsakey],
+                                                                    ssh_keys=[f"{rsakey}\n{ecdsakey}"],
+                                                                    expected_ssh_keys=[rsakey, ecdsakey],
                                                                     create_and_run=True))
 
         # Try to create VM with invalid ssh key


### PR DESCRIPTION
By default DSA key support is now not enabled during compilation, Arch did not re-enable DSA support so can't create the keys anymore.

RHEL 8.10 can create ecdsa keys, so switching from DSA to ECDSA should work in all other supported test distributions.

---

This is required for https://github.com/cockpit-project/bots/pull/6570