### PR TITLE
fmf: Disable SELinux with broken RHEL 10 policy version

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -26,6 +26,9 @@ fi
 rpm -q selinux-policy cockpit-bridge cockpit-machines
 rpm -qa | grep -E 'virt|qemu' | sort
 
+# basic libvirt selftests
+virt-host-validate qemu || echo "failed with code $?"
+
 # allow test to set up things on the machine
 mkdir -p /root/.ssh
 curl https://raw.githubusercontent.com/cockpit-project/bots/main/machine/identity.pub  >> /root/.ssh/authorized_keys

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -22,6 +22,11 @@ if rpm -q amazon-ec2-utils; then
     udevadm trigger /dev/nvme*
 fi
 
+# HACK: https://issues.redhat.com/browse/RHEL-46893
+if [ "$(rpm -q selinux-policy)" = "selinux-policy-40.13.4-1.el10.noarch" ] ; then
+    setenforce 0
+fi
+
 # Show critical packages versions
 rpm -q selinux-policy cockpit-bridge cockpit-machines
 rpm -qa | grep -E 'virt|qemu' | sort


### PR DESCRIPTION
This completely breaks libvirt and libvirt-dbus.

See https://issues.redhat.com/browse/RHEL-46893

---

See https://artifacts.dev.testing-farm.io/6bf72f5d-1950-41e2-a151-76f11ce6301d/ . This also broke yesterday's RHEL 10 gating tests.