### PR TITLE
manifest: drop content-security-policy

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,8 +24,6 @@
         ]
      }
   },
-  "content-security-policy": "img-src 'self' data:; frame-src 'self' data:",
-
   "config": {
       "StorageMigrationSupported": {
           "rhel": false


### PR DESCRIPTION
The default content-security-policy of cockpit-bridge is enough for files it already includes `img-src: 'self' data:` and `frame-src` is not needed as we don't have or want any iframes or frames in machines.

---

Same as https://github.com/cockpit-project/cockpit-files/pull/646