### PR TITLE
Fix race condition in testCreateDownloadAnOS() on tumbleweed, disable broken SELinux on rawhide

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -26,6 +26,10 @@ fi
 if [ "$(rpm -q selinux-policy)" = "selinux-policy-40.13.4-1.el10.noarch" ] ; then
     setenforce 0
 fi
+# HACK: same regression in rawhide: https://bugzilla.redhat.com/show_bug.cgi?id=2297965
+if [ "$(rpm -q selinux-policy)" = "selinux-policy-41.8-4.fc41.noarch" ] ; then
+    setenforce 0
+fi
 
 # Show critical packages versions
 rpm -q selinux-policy cockpit-bridge cockpit-machines

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1328,6 +1328,10 @@ vnc_password= "{vnc_passwd}"
                     user_login = virt_install_cmd_out.split("user-login=", 1)[1].split(",")[0].rstrip()
                     self.assertIn(user_login, self.user_login)
 
+            # HACK: wait for virt-install to finish; this only races on tumbleweed
+            if self.machine.image == 'opensuse-tumbleweed' and self.create_and_run:
+                self.machine.execute(f"while {virt_install_cmd}; do sleep 1; done", timeout=300)
+
         def fill(self):
             b = self.browser
             if not self.name_generated:

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1300,6 +1300,12 @@ vnc_password= "{vnc_passwd}"
             else:
                 self.browser.click(".pf-v5-c-modal-box__footer button:contains(Create and edit)")
             self.browser.wait_not_present("#create-vm-dialog")
+
+            if self.create_and_run:
+                self.browser.wait_text(f"#vm-{self.name}-{self.connection}-state", "Running")
+            else:
+                self.browser.wait_text(f"#vm-{self.name}-{self.connection}-state", "Shut off")
+
             if self.storage_pool != NO_STORAGE:
                 self.goToVmPage(self.name)
                 self.browser.wait_text(f"#vm-{self.name}-disks-vda-bus", "virtio")


### PR DESCRIPTION
This test [almost always](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6612-f8f545a2-20240713-052557-opensuse-tumbleweed-cockpit-project-cockpit-machines/log.html) [fails](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1720-67dc5b2a-20240715-070654-opensuse-tumbleweed/log.html) on tumbleweed, but never *ever* locally. I even tried to reproduce the exact series of nondestructive tests:
```
TEST_OS=opensuse-tumbleweed test/common/run-tests -tv TestMachinesStoragePools.testStoragePoolsDeletion TestMachinesSettings.testBootOrder TestMachinesNetworks.testNetworkState TestMachinesNICs.testNICDelete TestMachinesHostDevs.testHostDevicesList TestMachinesFilesystems.testBasicSessionConnection TestMachinesDisks.testDetachDisk TestMachinesCreate.testDisabledCreate TestMachinesCreate.testCreateImportDisk TestMachinesCreate.testCreateDownloadAnOS
```

The [weather report](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit-machines&days=7&test=%2Ftest%2Fcheck-machines-create+TestMachinesCreate.testCreateDownloadAnOS) also shows that this fails exclusively on tumbleweed, in more than 77% of runs.

Turning debugging to 11.

I'll give this a little bit of investigation, but only so much -- if I can't figure it out quickly, I'll disable the test for now.

@Nykseli @Lunarequest @SludgeGirl FYI