### PR TITLE
Use action option from EmptyStatePanel

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -278,12 +278,9 @@ class AppActive extends React.Component {
                     <>
                         {allNotifications}
                         <EmptyStatePanel title={ cockpit.format(_("VM $0 does not exist on $1 connection"), cockpit.location.options.name, cockpit.location.options.connection) }
-                                         action={
-                                             <Button variant="link"
-                                                     onClick={() => cockpit.location.go(["vms"])}>
-                                                 {_("Go to VMs list")}
-                                             </Button>
-                                         }
+                                         action={_("Go to VMs list")}
+                                         actionVariant="link"
+                                         onAction={() => cockpit.location.go(["vms"])}
                                          icon={ExclamationCircleIcon} />
                     </>
                 );
@@ -292,12 +289,9 @@ class AppActive extends React.Component {
                     <>
                         {allNotifications}
                         <EmptyStatePanel title={cockpit.format(vm.downloadProgress ? _("Downloading image for VM $0") : _("Creating VM $0"), cockpit.location.options.name)}
-                                         action={
-                                             <Button variant="link"
-                                                     onClick={() => cockpit.location.go(["vms"])}>
-                                                 {_("Go to VMs list")}
-                                             </Button>
-                                         }
+                                         action={_("Go to VMs list")}
+                                         actionVariant="link"
+                                         onAction={() => cockpit.location.go(["vms"])}
                                          paragraph={vm.downloadProgress && <Progress aria-label={_("Download progress")}
                                                                                      value={Number(vm.downloadProgress)}
                                                                                      measureLocation={ProgressMeasureLocation.outside} />}

--- a/src/components/libvirtSlate.jsx
+++ b/src/components/libvirtSlate.jsx
@@ -22,7 +22,6 @@ import PropTypes from 'prop-types';
 import cockpit from 'cockpit';
 
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
-import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { ExclamationCircleIcon } from "@patternfly/react-icons";
 
 const _ = cockpit.gettext;
@@ -31,16 +30,12 @@ const LibvirtSlate = ({ loadingResources }) => {
     if (loadingResources)
         return <EmptyStatePanel title={ _("Loading resources") } loading />;
 
-    const troubleshoot_btn = (
-        <Button variant="link" onClick={() => cockpit.jump("/system/services")}>
-            { _("Troubleshoot") }
-        </Button>
-    );
-
     return (
         <EmptyStatePanel icon={ ExclamationCircleIcon }
                          title={ _("Virtualization service (libvirt) is not active") }
-                         secondary={ troubleshoot_btn } />
+                         action={_("Troubleshoot")}
+                         actionVariant="link"
+                         onAction={() => cockpit.jump("/system/services")} />
     );
 };
 


### PR DESCRIPTION
Since the last cockpit lib update the EmptyStatePanel accepts an `actionVariant` allowing us to show a link button as action.

---

There should be no visual changes, just refactor.