### PR TITLE
test: selinux-policy-40.13.5-1.el10.noarch is broken as well

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -22,14 +22,15 @@ if rpm -q amazon-ec2-utils; then
     udevadm trigger /dev/nvme*
 fi
 
-# HACK: https://issues.redhat.com/browse/RHEL-46893
-if [ "$(rpm -q selinux-policy)" = "selinux-policy-40.13.4-1.el10.noarch" ] ; then
-    setenforce 0
-fi
-# HACK: same regression in rawhide: https://bugzilla.redhat.com/show_bug.cgi?id=2297965
-if [ "$(rpm -q selinux-policy)" = "selinux-policy-41.8-4.fc41.noarch" ] ; then
-    setenforce 0
-fi
+case "$(rpm -q selinux-policy)" in
+    # HACK: https://issues.redhat.com/browse/RHEL-46893
+    selinux-policy-40.13.4-1.el10.noarch|selinux-policy-40.13.5-1.el10.noarch)
+        setenforce 0 ;;
+
+    # HACK: same regression in rawhide: https://bugzilla.redhat.com/show_bug.cgi?id=2297965
+    selinux-policy-41.8-4.fc41.noarch)
+        setenforce 0 ;;
+esac
 
 # Show critical packages versions
 rpm -q selinux-policy cockpit-bridge cockpit-machines


### PR DESCRIPTION
Rewrite this using a `case` as that's syntactically easier.

---

See https://artifacts.dev.testing-farm.io/be2e002f-fb32-4cfb-8a55-3f2b2a870dc9/ - I kept the old version as that's still in some RHEL 10 composes.