### PR TITLE
fmf: Disable SELinux on RHEL 10 on current policy version

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -27,6 +27,10 @@ case "$(rpm -q selinux-policy)" in
     selinux-policy-40.13.4-1.el10.noarch|selinux-policy-40.13.5-1.el10.noarch)
         setenforce 0 ;;
 
+    # HACK: https://issues.redhat.com/browse/RHEL-49567
+    selinux-policy-40.13.6-1.el10.noarch)
+        setenforce 0 ;;
+
     # HACK: same regression in rawhide: https://bugzilla.redhat.com/show_bug.cgi?id=2297965
     selinux-policy-41.8-4.fc41.noarch)
         setenforce 0 ;;


### PR DESCRIPTION
RHEL-46893 may or may not be fixed, but now
https://issues.redhat.com/browse/RHEL-49567 completely ruins the show.

----

Recently, the centos-10 test has failed like this: https://artifacts.dev.testing-farm.io/7b011b67-48ba-4890-84d7-0ed15978ee73/ Let's hope not too much else has broken since then :crossed_fingers: 