### PR TITLE
test: Fix failures for unexpected `virt-host-validate qemu`

### DIFF
--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -35,7 +35,7 @@ def hasMonolithicDaemon(image):
 class VirtualMachinesCaseHelpers:
     def waitPageInit(self):
         virtualization_disabled_ignored = self.browser.call_js_func("localStorage.getItem", "virtualization-disabled-ignored") == "true"
-        virtualization_enabled = "PASS" in self.machine.execute("virt-host-validate qemu | grep 'Checking for hardware virtualization'")
+        virtualization_enabled = "PASS" in self.machine.execute("virt-host-validate qemu | grep 'Checking for hardware virtualization' || true")
         if not virtualization_enabled and not virtualization_disabled_ignored:
             self.browser.click("#ignore-hw-virtualization-disabled-btn")
         with self.browser.wait_timeout(30):


### PR DESCRIPTION
For a few months now, the RHEL downstream gating tests for cockpit-machines have all failed like this:

```
  File "/source/test/machineslib.py", line 38, in waitPageInit
    virtualization_enabled = "PASS" in self.machine.execute("virt-host-validate qemu | grep 'Checking for hardware virtualization'")
subprocess.CalledProcessError
```

The actual output shows

> QEMU: Checking if device '/dev/kvm' exists: FAIL

and no "hardware virtualization" at all, which makes the grep fail. Treat an absent line as "fail".

---

This has repeatedly failed the RHEL 9 gating tests, let's finally fix this.