### PR TITLE
package.json: Switch to @xterm/*

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,7 @@ updates:
           - "types*"
       xterm:
         patterns:
-          - "xterm*"
+          - "@xterm*"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = 07fddba43934fb256ec8da03812f081eab3baa18 # 321 + 117 commits
+COCKPIT_REPO_COMMIT = b5a98be3e0601b45cd8a557cde1c80b896a903fb # 322 + 19 commits
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "@patternfly/react-styles": "5.3.1",
     "@patternfly/react-table": "5.3.4",
     "@patternfly/react-tokens": "5.3.1",
+    "@xterm/addon-canvas": "0.7.0",
+    "@xterm/xterm": "5.5.0",
     "dequal": "2.0.3",
     "prop-types": "15.8.1",
     "react": "18.3.1",
@@ -59,8 +61,6 @@
     "redux": "5.0.1",
     "redux-thunk": "3.1.0",
     "throttle-debounce": "5.0.2",
-    "xterm": "5.1.0",
-    "xterm-addon-canvas": "0.5.0",
     "@novnc/novnc": "1.4.0"
   }
 }


### PR DESCRIPTION
These are the new names, and they have more recent releases.

See https://github.com/cockpit-project/cockpit/commit/c9096a71671be7 Follow suit.

----

Spotted in #1761 when trying to bump cockpit lib import.