### PR TITLE
test: Enable multi-host cockpit feature for TestMultiMachineVNC

### DIFF
--- a/test/check-machines-multi-host-consoles
+++ b/test/check-machines-multi-host-consoles
@@ -42,6 +42,7 @@ class TestMultiMachineVNC(VirtualMachinesCase):
         self.machine2 = self.machines['machine2']
 
         self.setup_ssh_auth()
+        self.enable_multihost(self.machine1)
 
     def testBasic(self):
         b = self.browser


### PR DESCRIPTION
This test does a direct remote host connection via URL change, which is forbidden by default on newer OSes since [1]. Enable multi-host feature for this test.

https://github.com/cockpit-project/cockpit/commit/4cb9238994ba

---

This blocks https://github.com/cockpit-project/bots/pull/6730 which updates cockpit to 322, and now [causes this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6730-dee48a5f-20240813-053938-debian-testing-cockpit-project-cockpit-machines/log.html#60-2)