### PR TITLE
css: move CSS declarations above nested rules

### DIFF
--- a/src/components/storagePools/storagePoolList.scss
+++ b/src/components/storagePools/storagePoolList.scss
@@ -1,4 +1,10 @@
 #storage-pools-listing {
+  // Approximate size of text
+  // (overflows work, but will knock out alignment)
+  --progress-text: 8rem;
+  --progress-bar-min: 2rem;
+  --progress-bar-max: 12vw;
+
   .pf-v5-c-table tbody > tr > * {
     // These tables are 1 row tall; progress bar does odd stuff for alignment;
     // vertical alignment makes text line up
@@ -9,12 +15,6 @@
     // Undo the PF alignment offset, as we're aligning to the middle (see above)
     margin-block-start: 0;
   }
-
-  // Approximate size of text
-  // (overflows work, but will knock out alignment)
-  --progress-text: 8rem;
-  --progress-bar-min: 2rem;
-  --progress-bar-max: 12vw;
 
   td[data-label="Size"] {
     > .pf-v5-c-progress {

--- a/src/components/vm/vmReplaceSpiceDialog.scss
+++ b/src/components/vm/vmReplaceSpiceDialog.scss
@@ -1,4 +1,7 @@
 .spice-replace-dialog-panel {
+    // separate it a bit from the text above
+    margin-block-start: var(--pf-v5-global--spacer--md);
+
     // drop excessive inside spacing
     .pf-v5-c-panel__main-body {
         padding-block-start: 0;
@@ -6,9 +9,6 @@
         padding-inline-start: 0;
         padding-inline-end: 0;
     }
-
-    // but separate it a bit from the text above
-    margin-block-start: var(--pf-v5-global--spacer--md);
 }
 
 .spice-replace-dialog-popover-list {


### PR DESCRIPTION
The new SASS version warns that decelerations should appear above nested rules. This change should not have any visual impact.

> ▲ [WARNING] Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming version. To keep the existing behavior, move the declaration above the nested rule. To opt into the new behavior, wrap the declaration in `& {}`.