### PR TITLE
libvirtApi remove use of interfaceGetAll

### DIFF
--- a/src/libvirtApi/common.js
+++ b/src/libvirtApi/common.js
@@ -58,9 +58,6 @@ import {
     timeout,
 } from "../libvirtApi/helpers.js";
 import {
-    interfaceGetAll,
-} from "../libvirtApi/interface.js";
-import {
     networkGet,
     networkGetAll,
 } from "../libvirtApi/network.js";
@@ -455,7 +452,6 @@ export function getApiData({ connectionName }) {
     return Promise.allSettled([
         domainGetAll({ connectionName }),
         storagePoolGetAll({ connectionName }),
-        interfaceGetAll({ connectionName }),
         networkGetAll({ connectionName }),
         nodeDeviceGetAll({ connectionName }),
         getNodeMaxMemory({ connectionName }),


### PR DESCRIPTION
this is in reference to #1777, `interfaceGetAll` is only used in one place and in local testing all tests still pass. `GetXMLDesc` would need a larger rework to drop usage but most of its usage should be fine