### PR TITLE
Add client operation logs for cockpit-machines

### DIFF
--- a/packaging/cockpit-machines.spec.in
+++ b/packaging/cockpit-machines.spec.in
@@ -86,11 +86,23 @@ If "virt-install" is installed, you can also create new virtual machines.
 %make_install PREFIX=/usr
 appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/metainfo/*
 
+# Add cockpit-machines-logging service
+install -Dm644 %{_sourcedir}/src/systemd/cockpit-machines-logging.service %{buildroot}%{_unitdir}/cockpit-machines-logging.service
+install -Dm755 %{_sourcedir}/src/bin/cockpit-machines-logging %{buildroot}%{_bindir}/cockpit-machines-logging
+
+%post
+%systemd_post cockpit-machines-logging.service
+
+%preun
+%systemd_preun cockpit-machines-logging.service
+
 %files
 %doc README.md
 %license LICENSE dist/index.js.LEGAL.txt dist/index.css.LEGAL.txt
 %{_datadir}/cockpit/*
 %{_datadir}/metainfo/*
+%{_unitdir}/cockpit-machines-logging.service
+%attr(0755, root, root) %{_bindir}/cockpit-machines-logging
 
 # The changelog is automatically generated and merged
 %changelog

--- a/src/bin/cockpit-machines-logging
+++ b/src/bin/cockpit-machines-logging
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+busctl monitor --match 'interface=org.libvirt.Domain'

--- a/src/systemd/cockpit-machines-logging.service
+++ b/src/systemd/cockpit-machines-logging.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Cockpit machines logging
+Documentation=man:cockpit-machines
+Requires=cockpit.service
+After=cockpit.service
+
+[Service]
+ExecStart=/usr/bin/cockpit-machines-logging
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This feature provides cockpit-machines to output client-side operation logs.

**What it does**
This feature enables logging of guest operations performed using libvirt-dbus.
This log entry will contain information about the operation, including the date, guest uuid, and operation. 

**Example:**
When this feature is enabled, shutting down a guest via cockpit-machines will generate a log entry in the journal, regardless of whether the guest actually shut down. 
```
Aug 14 15:19:51 localhost cockpit-machines-logging[2650]:   Sender=:1.38  Destination=org.libvirt  Path=/org/libvirt/QEMU/domain/_ced394f8_d398_478b_bd4b_aefdb520ad90  Interface=org.libvirt.Domain  Member=Shutdown
```

**Default behavior:**
This feature is disabled by default. Users needing logging can enable it by manually enabling the service (cockpit-machines-logging.service):
```
ohruka@localhost:~/cockpit-machines$ systemctl status cockpit-machines-logging
○ cockpit-machines-logging.service - Cockpit machines logging
     Loaded: loaded (/usr/lib/systemd/system/cockpit-machines-logging.service; disabled; preset: disabled)
    Drop-In: /usr/lib/systemd/system/service.d
             └─10-timeout-abort.conf
     Active: inactive (dead)
       Docs: man:cockpit-machines
ohruka@localhost:~/cockpit-machines$
```