### PR TITLE
Drop usage of virtinterfaced

### DIFF
--- a/packaging/cockpit-machines.spec.in
+++ b/packaging/cockpit-machines.spec.in
@@ -43,7 +43,6 @@ Requires: libvirt-daemon-driver-qemu
 Requires: libvirt-daemon-driver-network
 Requires: libvirt-daemon-driver-nodedev
 Requires: libvirt-daemon-driver-storage-core
-Requires: (libvirt-daemon-driver-interface if virt-install)
 Requires: (libvirt-daemon-config-network if virt-install)
 Recommends: libvirt-daemon-driver-storage-disk
 %if 0%{?rhel}

--- a/src/libvirt-xml-parse.js
+++ b/src/libvirt-xml-parse.js
@@ -899,15 +899,6 @@ export function parseDumpxmlMachinesMetadataElement(metadataElem, name) {
     return subElems.length > 0 ? subElems[0].textContent : null;
 }
 
-export function parseIfaceDumpxml(ifaceXml) {
-    const retObj = {};
-    const ifaceElem = getElem(ifaceXml);
-
-    retObj.type = ifaceElem.getAttribute("type");
-
-    return retObj;
-}
-
 export function parseNetDumpxml(netXml) {
     const retObj = {};
     const netElem = getElem(netXml);

--- a/src/libvirtApi/common.js
+++ b/src/libvirtApi/common.js
@@ -455,7 +455,7 @@ export function getApiData({ connectionName }) {
     return Promise.allSettled([
         domainGetAll({ connectionName }),
         storagePoolGetAll({ connectionName }),
-        interfaceGetAll({ connectionName }),
+        interfaceGetAll(),
         networkGetAll({ connectionName }),
         nodeDeviceGetAll({ connectionName }),
         getNodeMaxMemory({ connectionName }),

--- a/src/libvirtApi/interface.js
+++ b/src/libvirtApi/interface.js
@@ -21,55 +21,27 @@
  * Provider for Libvirt using libvirt-dbus API.
  * See https://github.com/libvirt/libvirt-dbus
  */
+import cockpit from 'cockpit';
+
 import store from '../store.js';
 
 import { updateOrAddInterface } from '../actions/store-actions.js';
-import { parseIfaceDumpxml } from '../libvirt-xml-parse.js';
-import { call, Enum, timeout } from './helpers.js';
 
-/*
- * Read properties of a single Interface
- *
- * @param {object} objPath interface object path
- * @param {string} connectionName
- */
-export async function interfaceGet({
-    id: objPath,
-    connectionName,
-}) {
-    const props = {};
+export async function interfaceGetAll() {
+    let ifaces = [];
 
     try {
-        const [resultProps] = await call(connectionName, objPath, 'org.freedesktop.DBus.Properties', 'GetAll',
-                                         ['org.libvirt.Interface'], { timeout, type: 's' });
-        /* Sometimes not all properties are returned; for example when some network got deleted while part
-            * of the properties got fetched from libvirt. Make sure that there is check before reading the attributes.
-            */
-        if ("Active" in resultProps)
-            props.active = resultProps.Active.v.v;
-        if ("MAC" in resultProps)
-            props.mac = resultProps.MAC.v.v;
-        if ("Name" in resultProps)
-            props.name = resultProps.Name.v.v;
-        props.id = objPath;
-        props.connectionName = connectionName;
-
-        const [xml] = await call(connectionName, objPath, 'org.libvirt.Interface', 'GetXMLDesc', [0], { timeout, type: 'u' });
-        const iface = parseIfaceDumpxml(xml);
-        store.dispatch(updateOrAddInterface(Object.assign(props, iface)));
+        const ipData = await cockpit.spawn(["ip", "--json", "a"], { err: "message" });
+        ifaces = JSON.parse(ipData);
     } catch (ex) {
-        console.log('listInactiveInterfaces action for path', objPath, ex.toString());
+        console.warn("Failed to get interfaces with ip command:", ex.toString());
     }
-}
 
-export async function interfaceGetAll({ connectionName }) {
-    const flags = Enum.VIR_CONNECT_LIST_INTERFACES_ACTIVE | Enum.VIR_CONNECT_LIST_INTERFACES_INACTIVE;
-
-    try {
-        const [ifaces] = await call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'ListInterfaces', [flags], { timeout, type: 'u' });
-        await Promise.all(ifaces.map(path => interfaceGet({ connectionName, id: path })));
-    } catch (ex) {
-        console.warn('getAllInterfaces action failed:', ex.toString());
-        throw ex;
+    for (const iface of ifaces) {
+        store.dispatch(updateOrAddInterface({
+            name: iface.ifname,
+            MAC: iface.address,
+            Active: iface.operstate === "UP",
+        }));
     }
 }

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -53,7 +53,6 @@ sh -x test/vm.install
 
 if [ "${PLATFORM_ID:-}" != "platform:el8" ]; then
     # https://gitlab.com/libvirt/libvirt/-/issues/219
-    systemctl start virtinterfaced.socket
     systemctl start virtnetworkd.socket
     systemctl start virtnodedevd.socket
     systemctl start virtstoraged.socket

--- a/test/check-machines-networks
+++ b/test/check-machines-networks
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import json
 import xml.etree.ElementTree as ET
 
 import machineslib
@@ -25,16 +26,12 @@ from machinesxmls import TEST_NETWORK2_CLASH_XML, TEST_NETWORK2_XML, TEST_NETWOR
 
 
 def getNetworkDevice(m):
-    net_devices_str = m.execute("virsh iface-list")
-    net_devices_str = net_devices_str.split("\n", 2)[2]  # Remove first 2 lines of table header
-    if net_devices_str not in ["\n", "\r\n"]:
-        device = net_devices_str.split(' ', 2)[1]  # Get the name of device, ignoring spacing before device string
-    else:  # If $virsh-iface list did not return any device, check virsh nodedev-list net:noh
-        net_devices_str = m.execute("virsh nodedev-list net")
-        net_devices_str = net_devices_str.split("\n", 2)[0]
-        device = net_devices_str.split("_", 2)[1]  # Ignore prefix (example: net_enp0s31f6_8c_16_45_5f_77_34)
+    # To replicate `virsh iface-list` behavior, filter active interfaces
+    # from ip command and get the first active one.
+    routes = json.loads(m.execute("ip --json a"))
+    active = list(filter(lambda r: r['operstate'] == "UP", routes))
 
-    return device
+    return active[0]["ifname"]
 
 
 @testlib.nondestructive

--- a/test/vm.install
+++ b/test/vm.install
@@ -7,11 +7,6 @@ if grep -q 'ID=debian' /usr/lib/os-release; then
     echo '* soft core unlimited' >> /etc/security/limits.conf
 fi
 
-if grep -q 'ID="opensuse' /usr/lib/os-release; then
-    # Make sure virtinterfaced.socket is enabled
-    systemctl enable --now virtinterfaced.socket
-fi
-
 systemctl enable cockpit.socket
 
 # don't force https:// (self-signed cert)


### PR DESCRIPTION
virtinterfaced is being deprecated [1], and at least some distros want
to get rid of the dependency.

Replace it with reading `ip --json a` instead  to get all the interface
names.

Fixes #1777

[1] https://listman.redhat.com/archives/libvir-list/2020-December/msg00183.html

---

 - [x] Goes on top of PR #1785 for cleanliness
 - [x] Confirm with @KKoukiou that this is really legit