### PR TITLE
Revert "libvirtApi remove use of interfaceGetAll"

### DIFF
--- a/src/libvirtApi/common.js
+++ b/src/libvirtApi/common.js
@@ -58,6 +58,9 @@ import {
     timeout,
 } from "../libvirtApi/helpers.js";
 import {
+    interfaceGetAll,
+} from "../libvirtApi/interface.js";
+import {
     networkGet,
     networkGetAll,
 } from "../libvirtApi/network.js";
@@ -452,6 +455,7 @@ export function getApiData({ connectionName }) {
     return Promise.allSettled([
         domainGetAll({ connectionName }),
         storagePoolGetAll({ connectionName }),
+        interfaceGetAll({ connectionName }),
         networkGetAll({ connectionName }),
         nodeDeviceGetAll({ connectionName }),
         getNodeMaxMemory({ connectionName }),


### PR DESCRIPTION
Reverts cockpit-project/cockpit-machines#1779

This needs more investigation. This functionality isn't properly covered by tests.