### PR TITLE
Test cleanups to prepare for upcoming ubuntu-2404/ubuntu-stable move

### DIFF
--- a/test/check-machines-snapshots
+++ b/test/check-machines-snapshots
@@ -243,12 +243,7 @@ class TestMachinesSnapshots(machineslib.VirtualMachinesCase):
         b.wait_visible("#vm-subVmTest1-add-snapshot-button")
 
         # external memory snapshots introduced in libvirt 9.9.0
-        supports_external = not (
-            m.image.startswith("rhel-8") or
-            m.image in ["debian-stable", "ubuntu-2204", "ubuntu-stable", "fedora-39"])
-        # Transitional code while we move ubuntu-stable from 23.10 mantic to 24.04 noble
-        if m.image == "ubuntu-stable" and m.execute(". /etc/os-release; echo $VERSION_ID").strip() == "24.04":
-            supports_external = True
+        supports_external = not (m.image.startswith("rhel-8") or m.image in ["debian-stable", "ubuntu-2204"])
 
         # HACK: deleting external snapshots for non-running VMs is broken https://bugs.debian.org/bug=1061725
         # Work around that by temporarily disabling libvirtd's AppArmor profile. AppArmor isn't installed by

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -444,9 +444,6 @@ class VirtualMachinesCase(testlib.MachineCase, VirtualMachinesCaseHelpers, stora
         self.allow_journal_messages(r'.* type=1400 .* apparmor="DENIED" operation="capable" profile="\S*libvirtd.* capname="sys_rawio".*')
         # AppArmor doesn't like the non-standard path for our storage pools
         self.allow_journal_messages('.* type=1400 .* apparmor="DENIED" operation="open".* profile="virt-aa-helper" name="%s.*' % self.vm_tmpdir)
-        if m.image in ["ubuntu-stable"]:
-            self.allow_journal_messages('.* type=1400 .* apparmor="DENIED" operation="open" profile="libvirt.* name="/" .* denied_mask="r" .*')
-            self.allow_journal_messages('.* type=1400 .* apparmor="DENIED" operation="open" profile="libvirt.* name="/sys/bus/nd/devices/" .* denied_mask="r" .*')
 
         # FIXME: Testing on Arch Linux fails randomly with networkmanager time outs while the test passes.
         if m.image == 'arch':


### PR DESCRIPTION
See https://github.com/cockpit-project/bots/pull/6797.