### PR TITLE
test: Disable two problematic tests on opensuse-tumbleweed

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -483,6 +483,7 @@ class TestMachinesCreate(machineslib.VirtualMachinesCase):
         runner.checkDialogFormValidationTest(TestMachinesCreate.VmDialog(self, "existing-name", storage_size=1,
                                                                          check_script_finished=False, env_is_empty=False), {"vm-name": "already exists"})
 
+    @testlib.skipImage("TODO: fails in 50% of runs", "opensuse-tumbleweed")
     def testCreatePXE(self):
         runner = TestMachinesCreate.CreateVmRunner(self)
 
@@ -644,6 +645,7 @@ vnc_password= "{vnc_passwd}"
             "127.0.0.1", "::1", None, None)
 
     @testlib.skipImage("TODO: Arch Linux has no iscsi support", "arch")
+    @testlib.skipImage("TODO: fails in 80% of runs", "opensuse-tumbleweed")
     def testCreateThenInstall(self):
         runner = TestMachinesCreate.CreateVmRunner(self)
         config = TestMachinesCreate.TestCreateConfig


### PR DESCRIPTION
testCreateThenInstall fails in 80% of runs, testCreatePXE in 50%. This really needs debugging, but in the meantime it makes it way too hard to land any PR. So dial this back for now.

---

See [weather report](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit-machines&days=7):

![image](https://github.com/user-attachments/assets/7b8e843e-e3d6-45ec-8e5e-1783922003ec)

CreateFileSource with "only" 38% failure rate is halfway bearable with the auto-retries.

@Lunarequest @SludgeGirl FYI