### PR TITLE
Add "Add TPM" VM action

### DIFF
--- a/src/components/common/needsShutdown.jsx
+++ b/src/components/common/needsShutdown.jsx
@@ -77,6 +77,10 @@ export function needsShutdownWatchdog(vm) {
     return vm.persistent && vm.state === "running" && vm.inactiveXML.watchdog.action !== vm.watchdog.action;
 }
 
+export function needsShutdownTpm(vm) {
+    return vm.persistent && vm.state === "running" && vm.inactiveXML.hasTPM !== vm.hasTPM;
+}
+
 export function needsShutdownSpice(vm) {
     return vm.hasSpice !== vm.inactiveXML.hasSpice;
 }
@@ -120,6 +124,10 @@ export function getDevicesRequiringShutdown(vm) {
     // SPICE
     if (needsShutdownSpice(vm))
         devices.push(_("SPICE"));
+
+    // TPM
+    if (needsShutdownTpm(vm))
+        devices.push(_("TPM"));
 
     return devices;
 }

--- a/src/components/vm/vmActions.jsx
+++ b/src/components/vm/vmActions.jsx
@@ -66,6 +66,7 @@ const _ = cockpit.gettext;
 
 const onStart = (vm, setOperationInProgress) => domainStart({ name: vm.name, id: vm.id, connectionName: vm.connectionName }).catch(ex => {
     setOperationInProgress(false);
+    console.warn("Failed to start VM", vm.name, ":", cockpit.message(ex));
     store.dispatch(
         updateVm({
             connectionName: vm.connectionName,

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -1082,13 +1082,5 @@ export async function domainReplaceSpice({ connectionName, id: objPath }) {
 
 export async function domainAddTPM({ connectionName, vmName }) {
     const args = ["virt-xml", "-c", `qemu:///${connectionName}`, "--add-device", "--tpm", "default", vmName];
-    return cockpit.spawn(args, { err: "message", superuser: connectionName === "system" ? "try" : null })
-            // RHEL 8 does not support --tpm default; arch (and likely other system setups) fails with
-            // unsupported configuration: TPM version '2.0' is not supported
-            .catch(ex => {
-                if (ex.message?.includes("Unknown TPM backend type") || ex.message?.includes("unsupported configuration"))
-                    console.log("Failed to add TPM:", ex);
-                else
-                    return Promise.reject(ex);
-            });
+    return cockpit.spawn(args, { err: "message", superuser: connectionName === "system" ? "try" : null });
 }

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -2186,6 +2186,12 @@ vnc_password= "{vnc_passwd}"
             tpm_xml = m.execute("virsh dumpxml VmNotInstalled | xmllint --xpath /domain/devices/tpm -")
             self.assertIn('model="tpm-crb"', tpm_xml)
             self.assertIn('type="emulator"', tpm_xml)
+            # thus menu does not offer to add a TPM
+            b.click("#vm-VmNotInstalled-system-action-kebab")
+            b.wait_visible("#vm-VmNotInstalled-system-delete")
+            self.assertNotIn("Add TPM", b.text("ul.pf-v5-c-menu__list"))
+            b.click("#vm-VmNotInstalled-system-action-kebab")
+            b.wait_not_present("ul.pf-v5-c-menu__list")
 
         # Temporarily delete the OVMF binary and check the firmware options again
         if "fedora" in m.image or "rhel" in m.image or "centos" in m.image:
@@ -2319,15 +2325,34 @@ vnc_password= "{vnc_passwd}"
         b.wait_not_present("#create-vm-dialog")
         b.wait_in_text(f"#vm-{vmName}-firmware", "BIOS")
 
-        # manually add TPM to BIOS
-        if not machineslib.hasBrokenTPM(m.image):
-            m.execute(f"virt-xml --add-device --tpm default {vmName}")
-            self.assertIn("tpm", m.execute(f"virsh dumpxml {vmName}"))
+        # add TPM to VM
+        self.assertNotIn("tpm", m.execute(f"virsh dumpxml {vmName}"))
+        self.performAction(vmName, "add-tpm")
 
-            # this doesn't change the UI, so we have to reload to ensure that the UI picks up the change
-            # otherwise this is a race condition
-            b.reload()
-            b.enter_page('/machines')
+        if machineslib.hasBrokenTPM(m.image):
+            error_location = ".pf-v5-c-alert-group li .pf-v5-c-alert"
+            b.wait_in_text(error_location, f"Failed to add TPM to VM {vmName}")
+            b.wait_in_text("button.alert-link.more-button", "show more")
+            b.click("button.alert-link.more-button")
+            b.wait_in_text(error_location, "unsupported configuration")
+            # Close the notification
+            b.click(".pf-v5-c-alert-group li .pf-v5-c-alert button.pf-m-plain")
+            b.wait_not_present(".pf-v5-c-alert-group li .pf-v5-c-alert")
+        else:
+            testlib.wait(lambda: "tpm" in m.execute(f"virsh dumpxml {vmName}"))
+
+            # "Add TPM" action goes away (async); no other visual feedback for non-running VM
+            for _retry in range(10):
+                time.sleep(0.2)
+                b.click(f"#vm-{vmName}-system-action-kebab")
+                b.wait_visible(f"#vm-{vmName}-system-delete")
+                menu = b.text("ul.pf-v5-c-menu__list")
+                b.click(f"#vm-{vmName}-system-action-kebab")
+                b.wait_not_present("ul.pf-v5-c-menu__list")
+                if "Add TPM" not in menu:
+                    break
+            else:
+                self.fail("timed out waiting for Add TPM menu item removal")
 
         # Change the os boot firmware to EFI
         b.click(f"#vm-{vmName}-firmware")
@@ -2353,7 +2378,7 @@ vnc_password= "{vnc_passwd}"
         b.click(f"#vm-{vmName}-system-install")
         b.wait_in_text(f"#vm-{vmName}-system-state", "Running")
 
-        # AppArmor policy fixed in later versions, don't bother with reporting
+        # https://launchpad.net/bugs/1968187
         if m.image == 'debian-stable':
             self.allow_journal_messages('.*apparmor="DENIED".*name="/etc/ssl/openssl.cnf".*comm="swtpm".*')
 

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -2265,6 +2265,9 @@ vnc_password= "{vnc_passwd}"
 
         self.allow_browser_errors("Failed when connecting: Connection closed")
         self.allow_journal_messages(".* couldn't shutdown fd: Transport endpoint is not connected")
+        # https://launchpad.net/bugs/1968187
+        if m.image == 'debian-stable':
+            self.allow_journal_messages('.*apparmor="DENIED".*name="/etc/ssl/openssl.cnf".*comm="swtpm".*')
 
     def testConfigureBeforeInstallBios(self):
         TestMachinesCreate.CreateVmRunner(self)

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -2172,12 +2172,17 @@ vnc_password= "{vnc_passwd}"
         b.wait_visible(".pf-v5-c-modal-box__body")
         b.select_from_dropdown(".pf-v5-c-modal-box__body select", "efi")
         b.click("#firmware-dialog-apply")
+        # ack error message if adding TPM failed
+        if machineslib.hasBrokenTPM(m.image):
+            b.wait_in_text(".pf-v5-c-modal-box .pf-v5-c-alert", "Failed to change firmware")
+            b.wait_in_text(".pf-v5-c-modal-box .pf-v5-c-alert", "TPM")
+            b.click('.pf-v5-c-modal-box__footer button:contains("Cancel")')
         b.wait_not_present(".pf-v5-c-modal-box__body")
         b.wait_in_text("#vm-VmNotInstalled-firmware", "UEFI")
         self.assertIn("<os firmware='efi'>", m.execute("virsh dumpxml VmNotInstalled"))
 
-        # auto-enabled software TPM (doesn't work on RHEL 8 or arch)
-        if not m.image.startswith("rhel-8") and m.image != 'arch':
+        # auto-enabled software TPM
+        if not machineslib.hasBrokenTPM(m.image):
             tpm_xml = m.execute("virsh dumpxml VmNotInstalled | xmllint --xpath /domain/devices/tpm -")
             self.assertIn('model="tpm-crb"', tpm_xml)
             self.assertIn('type="emulator"', tpm_xml)
@@ -2294,8 +2299,6 @@ vnc_password= "{vnc_passwd}"
         self.assertIn("<os>", domainXML)
         self.assertNotIn("efi", domainXML)
 
-    @testlib.skipImage("does not support virt-xml --tpm", "rhel-8*")
-    @testlib.skipImage("does not support TPM 2.0", "arch")
     def testConfigureBeforeInstallBiosTPM(self):
         m = self.machine
         b = self.browser
@@ -2317,24 +2320,34 @@ vnc_password= "{vnc_passwd}"
         b.wait_in_text(f"#vm-{vmName}-firmware", "BIOS")
 
         # manually add TPM to BIOS
-        m.execute(f"virt-xml --add-device --tpm default {vmName}")
-        self.assertIn("tpm", m.execute(f"virsh dumpxml {vmName}"))
-        # this doesn't change the UI, so we have to reload to ensure that the UI picks up the change
-        # otherwise this is a race condition
-        b.reload()
-        b.enter_page('/machines')
+        if not machineslib.hasBrokenTPM(m.image):
+            m.execute(f"virt-xml --add-device --tpm default {vmName}")
+            self.assertIn("tpm", m.execute(f"virsh dumpxml {vmName}"))
+
+            # this doesn't change the UI, so we have to reload to ensure that the UI picks up the change
+            # otherwise this is a race condition
+            b.reload()
+            b.enter_page('/machines')
 
         # Change the os boot firmware to EFI
         b.click(f"#vm-{vmName}-firmware")
         b.wait_visible(".pf-v5-c-modal-box__body")
         b.select_from_dropdown(".pf-v5-c-modal-box__body select", "efi")
         b.click("#firmware-dialog-apply")
+        # ack error message if adding TPM failed
+        if machineslib.hasBrokenTPM(m.image):
+            b.wait_in_text(".pf-v5-c-modal-box .pf-v5-c-alert", "Failed to change firmware")
+            b.wait_in_text(".pf-v5-c-modal-box .pf-v5-c-alert", "TPM")
+            b.click('.pf-v5-c-modal-box__footer button:contains("Cancel")')
         b.wait_not_present(".pf-v5-c-modal-box__body")
         b.wait_in_text(f"#vm-{vmName}-firmware", "UEFI")
 
-        # did not add a second TPM; that would fail in the dialog anyway, but let's double-check the backend
-        out = m.execute(f"virsh dumpxml {vmName} | xmllint --xpath /domain/devices/tpm - | grep --count '<tpm'")
-        self.assertEqual(out.strip(), "1")
+        if machineslib.hasBrokenTPM(m.image):
+            self.assertNotIn("tpm", m.execute(f"virsh dumpxml {vmName}"))
+        else:
+            # did not add a second TPM; that would fail in the dialog anyway, but let's double-check the backend
+            out = m.execute(f"virsh dumpxml {vmName} | xmllint --xpath /domain/devices/tpm - | grep --count '<tpm'")
+            self.assertEqual(out.strip(), "1")
 
         # Install the VM
         b.click(f"#vm-{vmName}-system-install")

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -454,6 +454,7 @@ class TestMachinesSettings(machineslib.VirtualMachinesCase):
 
     def testMultipleSettings(self):
         b = self.browser
+        m = self.machine
 
         # We want a machine without watchdog
         args = self.createVm("subVmTest1", os="linux2016")
@@ -497,6 +498,47 @@ class TestMachinesSettings(machineslib.VirtualMachinesCase):
         # Check both changes have been applied
         b.wait_in_text("#vm-subVmTest1-cpu", "3 vCPUs, host")
         b.wait_in_text("#vm-subVmTest1-watchdog-state", "Reset")
+
+        # Add TPM to running VM
+        b.click("#vm-subVmTest1-system-run")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
+        self.assertNotIn("tpm", m.execute("virsh dumpxml subVmTest1"))
+        self.assertNotIn("tpm", m.execute("virsh dumpxml --inactive subVmTest1"))
+        self.performAction("subVmTest1", "add-tpm")
+        if machineslib.hasBrokenTPM(m.image):
+            error_location = ".pf-v5-c-alert-group li .pf-v5-c-alert"
+            b.wait_in_text(error_location, "Failed to add TPM to VM subVmTest1")
+            b.wait_in_text("button.alert-link.more-button", "show more")
+            b.click("button.alert-link.more-button")
+            b.wait_in_text(error_location, "unsupported configuration")
+            # Close the notification
+            b.click(".pf-v5-c-alert-group li .pf-v5-c-alert button.pf-m-plain")
+            b.wait_not_present(".pf-v5-c-alert-group li .pf-v5-c-alert")
+        else:
+            # this can only add it to the inactive XML, not live
+            b.click("#vm-subVmTest1-needs-shutdown")
+            b.wait_in_text(".pf-v5-c-popover", "TPM")
+            b.click(".pf-v5-c-popover button")
+            b.wait_not_present(".pf-v5-c-popover")
+            self.assertIn("tpm", m.execute("virsh dumpxml --inactive subVmTest1"))
+            self.assertNotIn("tpm", m.execute("virsh dumpxml subVmTest1"))
+            # removes menu entry
+            b.click("#vm-subVmTest1-system-action-kebab")
+            b.wait_visible("#vm-subVmTest1-system-delete")
+            self.assertFalse(b.is_present("#vm-subVmTest1-system-add-tpm"))
+            b.click("#vm-subVmTest1-system-action-kebab")
+            b.wait_not_present(".pf-v5-c-menu__list")
+
+            # after restarting, TPM is active
+            self.performAction("subVmTest1", "forceOff")
+            b.wait_not_present("#vm-subVmTest1-needs-shutdown")
+            b.click("#vm-subVmTest1-system-run")
+            b.wait_in_text("#vm-subVmTest1-system-state", "Running")
+            self.assertIn("tpm", m.execute("virsh dumpxml subVmTest1"))
+
+            # https://launchpad.net/bugs/1968187
+            if m.image.startswith("debian"):
+                self.allow_journal_messages('.*apparmor="DENIED".*name="/etc/ssl/openssl.cnf".*comm="swtpm".*')
 
     def testWatchdog(self):
         b = self.browser

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -33,6 +33,11 @@ def hasMonolithicDaemon(image):
             image in ["arch"])
 
 
+# software TPM doesn't work on some OSes
+def hasBrokenTPM(image):
+    return image.startswith("rhel-8") or image == 'arch'
+
+
 class VirtualMachinesCaseHelpers:
     machine: testvm.Machine
 


### PR DESCRIPTION
We implemented this feature because there was a use case where upgrading the Windows OS to Windows11 required additional TPM devices.

Selecting "Add TPM" will add a TPM device with default settings.
"Add TPM" is only displayed if no TPM device exists.

 - [x] https://github.com/cockpit-project/bots/pull/7064

----

## Machines: Action to add a TPM

This can help with upgrading old VMs to a newer guest OS that requires a TPM, such as Windows 11.

![tpm_kebab](https://github.com/user-attachments/assets/23fd88a2-4f30-4beb-8cf8-07de452805d4)
