### PR TITLE
Drop old PatternFly State label workaround

### DIFF
--- a/src/components/vms/hostvmslist.scss
+++ b/src/components/vms/hostvmslist.scss
@@ -22,9 +22,3 @@
 .pf-v5-c-toolbar__item {
     gap: 0 var(--pf-v5-global--spacer--xs);
 }
-
-// HACK: the label has alig-self: flex-start which renders the State not in the middle.
-// Seems fixed in 5.0.0!
-.pf-v5-c-toolbar__item.pf-m-label {
-    align-self: normal;
-}


### PR DESCRIPTION
The current PatternFly version is 5.4.0