### PR TITLE
test: drop selinux-policy workarounds

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -22,20 +22,6 @@ if rpm -q amazon-ec2-utils; then
     udevadm trigger /dev/nvme*
 fi
 
-case "$(rpm -q selinux-policy)" in
-    # HACK: https://issues.redhat.com/browse/RHEL-46893
-    selinux-policy-40.13.4-1.el10.noarch|selinux-policy-40.13.5-1.el10.noarch)
-        setenforce 0 ;;
-
-    # HACK: https://issues.redhat.com/browse/RHEL-49567
-    selinux-policy-40.13.6-1.el10.noarch)
-        setenforce 0 ;;
-
-    # HACK: same regression in rawhide: https://bugzilla.redhat.com/show_bug.cgi?id=2297965
-    selinux-policy-41.8-4.fc41.noarch)
-        setenforce 0 ;;
-esac
-
 # Show critical packages versions
 rpm -q selinux-policy cockpit-bridge cockpit-machines
 rpm -qa | grep -E 'virt|qemu' | sort


### PR DESCRIPTION
Neither of these versions exist anymore in Rawhide and RHEL 10.