### PR TITLE
Remove undefined fontweight light

### DIFF
--- a/src/components/vm/vmDetailsPage.scss
+++ b/src/components/vm/vmDetailsPage.scss
@@ -18,7 +18,6 @@
   flex-wrap: wrap;
 
   .vm-name {
-    font-weight: var(--pf-v5-global--FontWeight--light);
     margin-inline-end: 1.5rem;
   }
 


### PR DESCRIPTION
PatternFly removed the light weight font variant so this was undefined for quite a while and thus has no UI change.

---


![Screenshot from 2024-09-16 16-15-16](https://github.com/user-attachments/assets/a29a9913-a6b3-4465-bf44-20cbafc48f00)
