### PR TITLE
Use cockpit.format_bytes() for displaying VM memory

### DIFF
--- a/src/components/vm/overview/vmOverviewCard.jsx
+++ b/src/components/vm/overview/vmOverviewCard.jsx
@@ -33,9 +33,7 @@ import { HelpIcon } from '@patternfly/react-icons';
 import { CPUModal } from './cpuModal.jsx';
 import MemoryModal from './memoryModal.jsx';
 import {
-    convertToBestUnit,
     rephraseUI,
-    units,
     vmId,
 } from '../../../helpers.js';
 import { updateVm } from '../../../actions/store-actions.js';
@@ -111,12 +109,11 @@ class VmOverviewCard extends React.Component {
                         label={_("Run when host boots")} />
             </DescriptionListDescription>
         );
-        const memory = convertToBestUnit(vm.currentMemory, units.KiB);
         const memoryLink = (
             <DescriptionListDescription id={`${idPrefix}-memory-count`}>
                 <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                     <FlexItem>
-                        {cockpit.format("$0 $1", parseFloat(memory.value).toFixed(1), memory.unit)}
+                        {cockpit.format_bytes(vm.currentMemory * 1024, { base2: true })}
                     </FlexItem>
                     <Button variant="link" isInline isDisabled={!vm.persistent} onClick={this.openMemory}>
                         {_("edit")}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -100,11 +100,6 @@ export function getBestUnit(input, inputUnit) {
     return logUnitMap[getLogarithmOfBase1024(convertToUnitVerbose(input, inputUnit, units.B).value)];
 }
 
-export function convertToBestUnit(input, inputUnit) {
-    return convertToUnitVerbose(input, inputUnit,
-                                logUnitMap[getLogarithmOfBase1024(convertToUnitVerbose(input, inputUnit, units.B).value)]);
-}
-
 export function convertToUnit(input, inputUnit, outputUnit) {
     return convertToUnitVerbose(input, inputUnit, outputUnit).value;
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -109,7 +109,7 @@ export function convertToUnit(input, inputUnit, outputUnit) {
     return convertToUnitVerbose(input, inputUnit, outputUnit).value;
 }
 
-export function convertToUnitVerbose(input, inputUnit, outputUnit) {
+function convertToUnitVerbose(input, inputUnit, outputUnit) {
     const result = {
         value: 0,
         unit: units.B.name,

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -2200,7 +2200,7 @@ vnc_password= "{vnc_passwd}"
 
         # Check configuration changes survived installation
         # Check memory settings have persisted
-        b.wait_in_text("#vm-VmNotInstalled-memory-count", "130.0 MiB")
+        b.wait_in_text("#vm-VmNotInstalled-memory-count", "130 MiB")
         b.click("#vm-VmNotInstalled-memory-count button")
         b.wait_visible("#vm-VmNotInstalled-memory-modal-memory")
         b.wait_val("#vm-VmNotInstalled-memory-modal-max-memory", "150")

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -414,11 +414,11 @@ class TestMachinesSettings(machineslib.VirtualMachinesCase):
         b.click("#vm-subVmTest1-memory-modal-save")
         b.wait_not_present("#vm-memory-modal")
 
-        b.wait_in_text("#vm-subVmTest1-memory-count", f"{f'{current_memory - 10:.1f}'} MiB")
+        b.wait_in_text("#vm-subVmTest1-memory-count", f"{f'{current_memory - 10}'} MiB")
 
         # Shut off domain and check changes are  still there
         self.performAction("subVmTest1", "forceOff")
-        b.wait_in_text("#vm-subVmTest1-memory-count", f"{f'{current_memory - 10:.1f}'} MiB")
+        b.wait_in_text("#vm-subVmTest1-memory-count", f"{f'{current_memory - 10}'} MiB")
 
         # Click for the edit link
         b.click("#vm-subVmTest1-memory-count button")


### PR DESCRIPTION
Eliminate convertToBestUnit() in favour of our standard API. Use the default precision of "3" for consistency with other pages, and adjust the test accordingly.

---

This is a first test balloon. There are dozens of `convertToUnit()` calls which should also be moved to `cockpit.format_bytes()`.