### PR TITLE
build.js: prefer startsWith over regex with a caret

### DIFF
--- a/build.js
+++ b/build.js
@@ -57,8 +57,7 @@ function watch_dirs(dir, on_change) {
     const callback = (ev, dir, fname) => {
         // only listen for "change" events, as renames are noisy
         // ignore hidden files and the "4913" temporary file created by vim
-        const isHidden = /^\./.test(fname);
-        if (ev !== "change" || isHidden || fname === "4913")
+        if (ev !== "change" || fname.startsWith('.') || fname === "4913")
             return;
         on_change(path.join(dir, fname));
     };


### PR DESCRIPTION
Found by eslint-plugin-unicorn.