### PR TITLE
Replace deprecated virtinterfaced calls with ip command

### DIFF
--- a/src/libvirtApi/common.js
+++ b/src/libvirtApi/common.js
@@ -455,7 +455,7 @@ export function getApiData({ connectionName }) {
     return Promise.allSettled([
         domainGetAll({ connectionName }),
         storagePoolGetAll({ connectionName }),
-        interfaceGetAll({ connectionName }),
+        interfaceGetAll(),
         networkGetAll({ connectionName }),
         nodeDeviceGetAll({ connectionName }),
         getNodeMaxMemory({ connectionName }),

--- a/src/libvirtApi/interface.js
+++ b/src/libvirtApi/interface.js
@@ -24,52 +24,19 @@
 import store from '../store.js';
 
 import { updateOrAddInterface } from '../actions/store-actions.js';
-import { parseIfaceDumpxml } from '../libvirt-xml-parse.js';
-import { call, Enum, timeout } from './helpers.js';
 
-/*
- * Read properties of a single Interface
- *
- * @param {object} objPath interface object path
- * @param {string} connectionName
- */
-export async function interfaceGet({
-    id: objPath,
-    connectionName,
-}) {
-    const props = {};
+export async function interfaceGetAll() {
+    let ifaces = [];
 
     try {
-        const [resultProps] = await call(connectionName, objPath, 'org.freedesktop.DBus.Properties', 'GetAll',
-                                         ['org.libvirt.Interface'], { timeout, type: 's' });
-        /* Sometimes not all properties are returned; for example when some network got deleted while part
-            * of the properties got fetched from libvirt. Make sure that there is check before reading the attributes.
-            */
-        if ("Active" in resultProps)
-            props.active = resultProps.Active.v.v;
-        if ("MAC" in resultProps)
-            props.mac = resultProps.MAC.v.v;
-        if ("Name" in resultProps)
-            props.name = resultProps.Name.v.v;
-        props.id = objPath;
-        props.connectionName = connectionName;
-
-        const [xml] = await call(connectionName, objPath, 'org.libvirt.Interface', 'GetXMLDesc', [0], { timeout, type: 'u' });
-        const iface = parseIfaceDumpxml(xml);
-        store.dispatch(updateOrAddInterface(Object.assign(props, iface)));
+        const ipData = await cockpit.spawn(["ip", "--json", "a"], { err: "ignore" });
+        ifaces = JSON.parse(ipData);
     } catch (ex) {
-        console.log('listInactiveInterfaces action for path', objPath, ex.toString());
+        console.log("Failed to get interfaces with ip command", ex.toString());
     }
-}
 
-export async function interfaceGetAll({ connectionName }) {
-    const flags = Enum.VIR_CONNECT_LIST_INTERFACES_ACTIVE | Enum.VIR_CONNECT_LIST_INTERFACES_INACTIVE;
-
-    try {
-        const [ifaces] = await call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'ListInterfaces', [flags], { timeout, type: 'u' });
-        await Promise.all(ifaces.map(path => interfaceGet({ connectionName, id: path })));
-    } catch (ex) {
-        console.warn('getAllInterfaces action failed:', ex.toString());
-        throw ex;
+    for (const iface of ifaces) {
+        // It seems that we only need the interface name that's used in getNetworkDevices() later
+        store.dispatch(updateOrAddInterface({name: iface.ifname}));
     }
 }

--- a/test/check-machines-networks
+++ b/test/check-machines-networks
@@ -19,22 +19,19 @@
 
 import xml.etree.ElementTree as ET
 
+import json
 import machineslib
 import testlib
 from machinesxmls import TEST_NETWORK2_CLASH_XML, TEST_NETWORK2_XML, TEST_NETWORK3_XML, TEST_NETWORK4_XML, TEST_NETWORK_IPV6_XML, TEST_NETWORK_XML
 
 
 def getNetworkDevice(m):
-    net_devices_str = m.execute("virsh iface-list")
-    net_devices_str = net_devices_str.split("\n", 2)[2]  # Remove first 2 lines of table header
-    if net_devices_str not in ["\n", "\r\n"]:
-        device = net_devices_str.split(' ', 2)[1]  # Get the name of device, ignoring spacing before device string
-    else:  # If $virsh-iface list did not return any device, check virsh nodedev-list net:noh
-        net_devices_str = m.execute("virsh nodedev-list net")
-        net_devices_str = net_devices_str.split("\n", 2)[0]
-        device = net_devices_str.split("_", 2)[1]  # Ignore prefix (example: net_enp0s31f6_8c_16_45_5f_77_34)
+    # To replicate `virsh iface-list` behavior, filter active interfaces
+    # from ip command and get the first active one.
+    routes = json.loads(m.execute("ip --json a"))
+    active = list(filter(lambda r: r['operstate'] == "UP", routes))
 
-    return device
+    return active[0]["ifname"]
 
 
 @testlib.nondestructive

--- a/test/vm.install
+++ b/test/vm.install
@@ -7,11 +7,6 @@ if grep -q 'ID=debian' /usr/lib/os-release; then
     echo '* soft core unlimited' >> /etc/security/limits.conf
 fi
 
-if grep -q 'ID="opensuse' /usr/lib/os-release; then
-    # Make sure virtinterfaced.socket is enabled
-    systemctl enable --now virtinterfaced.socket
-fi
-
 systemctl enable cockpit.socket
 
 # don't force https:// (self-signed cert)


### PR DESCRIPTION
The libvirt ListInterfaces dbus call is used to only to list out names of interfaces. On a test vm (Tumbleweed and Fedora) it's needed to get the virbr0 bridge interface.

This complexity can be reduced to simply use `ip --json a` to get all the interface names.

Note that this probably needs to be ran against https://github.com/cockpit-project/bots/pull/6909

This PR tries to solve the issues/concerns in: https://github.com/cockpit-project/cockpit-machines/pull/1782