### PR TITLE
Fix disabled VM action dropdown item tooltip

### DIFF
--- a/src/components/vm/vmActions.jsx
+++ b/src/components/vm/vmActions.jsx
@@ -473,7 +473,7 @@ const VmActions = ({ vm, vms, onAddErrorNotification, isDetailsPage }) => {
                 <Tooltip key={`${id}-delete`} id={`${id}-delete-tooltip`} content={_("This VM is transient. Shut it down if you wish to delete it.")}>
                     <DropdownItem id={`${id}-delete`}
                                   className='pf-m-danger'
-                                  isDisabled>
+                                  isAriaDisabled>
                         {_("Delete")}
                     </DropdownItem>
                 </Tooltip>

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -530,7 +530,7 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
         m.execute(f"virsh undefine {name}")
         b.wait_visible(f"tr[data-row-id=vm-{name}-system][data-vm-transient=true]")
         b.click(f"#vm-{name}-system-action-kebab")
-        b.wait_visible(f".pf-m-disabled #vm-{name}-system-delete")  # delete buton should be disabled
+        b.wait_visible(f".pf-m-aria-disabled #vm-{name}-system-delete")  # delete buton should be disabled
         b.click(f"#vm-{name}-system-forceOff")
         b.wait_visible(f"#vm-{name}-system-confirm-action-modal")
         b.click(f".pf-v5-c-modal-box__footer #vm-{name}-system-forceOff")


### PR DESCRIPTION
When using `isDisabled` property in Buttons/Dropdowns/etc, their tooltips are not getting triggered.
We need to use `isAriaDisabled` instead of `isDisabled` in this case.

See more info: https://github.com/patternfly/patternfly-react/issues/5826