### PR TITLE
appstream: Fix validation problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TARFILE=$(RPM_NAME)-$(VERSION).tar.xz
 NODE_CACHE=$(RPM_NAME)-node-$(VERSION).tar.xz
 SPEC=$(RPM_NAME).spec
 PREFIX ?= /usr/local
-APPSTREAMFILE=org.cockpit-project.$(PACKAGE_NAME).metainfo.xml
+APPSTREAMFILE=org.cockpit_project.$(PACKAGE_NAME).metainfo.xml
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check for node_modules/
 NODE_MODULES_TEST=package-lock.json

--- a/org.cockpit_project.machines.metainfo.xml
+++ b/org.cockpit_project.machines.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
-  <id>org.cockpit_project.cockpit_machines</id>
+  <id>org.cockpit_project.machines</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Machines</name>
   <summary>Manage your virtual machines</summary>
@@ -15,4 +15,7 @@
   <launchable type="cockpit-manifest">machines</launchable>
   <url type="homepage">https://cockpit-project.org/</url>
   <update_contact>cockpit-devel_AT_lists.fedorahosted.org</update_contact>
+  <developer id="org.cockpit-project">
+    <name>Cockpit Project</name>
+  </developer>
 </component>


### PR DESCRIPTION
Rename the file to match its ID, fix the ID (extra cockpit- prefix), and add developer tag. This fixes all issues with `appstreamcli validate`:

> I: org.cockpit_project.cockpit_machines: developer-info-missing
> W: org.cockpit_project.cockpit_machines: metainfo-filename-cid-mismatch