### PR TITLE
create: Add a "view more" option to list of operating systems

### DIFF
--- a/src/components/create-vm-dialog/createVmDialogUtils.js
+++ b/src/components/create-vm-dialog/createVmDialogUtils.js
@@ -17,12 +17,16 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
+import cockpit from 'cockpit';
+
 import {
     getTodayYearShifted,
 } from "../../helpers.js";
 
 import * as python from "python.js";
 import autoDetectOSScript from './autoDetectOS.py';
+
+const _ = cockpit.gettext;
 
 const ACCEPT_RELEASE_DATES_AFTER = getTodayYearShifted(-3);
 const ACCEPT_EOL_DATES_AFTER = getTodayYearShifted(-1);
@@ -74,6 +78,12 @@ export function filterReleaseEolDates(os) {
         (os.eolDate && compareDates(ACCEPT_EOL_DATES_AFTER, os.eolDate) < 0) ||
         (!os.eolDate && os.releaseDate && compareDates(ACCEPT_RELEASE_DATES_AFTER, os.releaseDate) < 0)
     );
+}
+
+export function getOSEOLDescription(os) {
+    if (os.eolDate && compareDates(ACCEPT_EOL_DATES_AFTER, os.eolDate) < 0)
+        return cockpit.format(_("Vendor support ended $0"), os.eolDate);
+    return null;
 }
 
 export function compareDates(a, b, emptyFirst = false) {

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -91,16 +91,15 @@ class TestMachinesCreate(machineslib.VirtualMachinesCase):
                                                             pixel_test_tag="auto"))
 
         # check if older os are filtered
-        runner.checkFilteredOsTest(TestMachinesCreate.VmDialog(self, os_name=config.REDHAT_RHEL_4_7_FILTERED_OS,
+        runner.checkFilteredOsTest(TestMachinesCreate.VmDialog(self, os_name=config.OLD_FILTERED_OS))
+
+        runner.checkFilteredOsTest(TestMachinesCreate.VmDialog(self, os_name=config.UNSUPPORTED_FILTERED_OS,
+                                                               os_is_unsupported=True,
+                                                               pixel_test_tag="filter-unsupported"))
+
+        runner.checkFilteredOsTest(TestMachinesCreate.VmDialog(self, os_name=config.NOT_FOUND_FILTERED_OS,
+                                                               os_is_not_found=True,
                                                                pixel_test_tag="filter"))
-
-        runner.checkFilteredOsTest(TestMachinesCreate.VmDialog(self, os_name=config.MANDRIVA_2011_FILTERED_OS))
-
-        runner.checkFilteredOsTest(TestMachinesCreate.VmDialog(self, os_name=config.MAGEIA_3_FILTERED_OS))
-
-        # check that newer oses are present and searchable with substring match
-        runner.checkFilteredOsTest(TestMachinesCreate.VmDialog(self, os_name=config.WINDOWS_SERVER_10,
-                                                               os_search_name=config.WINDOWS_SERVER_10_SHORT))
 
         # check OS versions are sorted in alphabetical order
         runner.checkSortedOsTest(TestMachinesCreate.VmDialog(self), [config.FEDORA_29, config.FEDORA_28])
@@ -935,7 +934,9 @@ vnc_password= "{vnc_passwd}"
         TREE_URL = 'https://archive.fedoraproject.org/pub/archive/fedora/linux/releases/28/Server/x86_64/os'
 
         # LINUX can be filtered if 3 years old
-        REDHAT_RHEL_4_7_FILTERED_OS = 'Red Hat Enterprise Linux 4.9'
+        OLD_FILTERED_OS = 'Red Hat Enterprise Linux 8.3 (Ootpa)'
+        UNSUPPORTED_FILTERED_OS = 'Fedora 34'
+        NOT_FOUND_FILTERED_OS = 'Red Hat Enterprise Linux 4.9'
 
         FEDORA_28 = 'Fedora 28'
         FEDORA_28_SHORTID = 'fedora28'
@@ -950,13 +951,6 @@ vnc_password= "{vnc_passwd}"
 
         CENTOS_7 = 'CentOS 7'
 
-        MANDRIVA_2011_FILTERED_OS = 'Mandriva Linux 2011'
-
-        MAGEIA_3_FILTERED_OS = 'Mageia 3'
-
-        WINDOWS_SERVER_10 = 'Microsoft Windows 10'
-        WINDOWS_SERVER_10_SHORT = 'win'
-
     class VmDialog:
         vmId = 0
 
@@ -969,6 +963,8 @@ vnc_password= "{vnc_passwd}"
                      os_name="Fedora 28",
                      os_search_name=None,
                      os_short_id="fedora28",
+                     os_is_unsupported=False,
+                     os_is_not_found=False,
                      expected_os_name=None,
                      is_unattended=None,
                      profile=None,
@@ -1017,6 +1013,8 @@ vnc_password= "{vnc_passwd}"
             self.os_name = os_name
             self.os_search_name = os_search_name
             self.os_short_id = os_short_id
+            self.os_is_unsupported = os_is_unsupported
+            self.os_is_not_found = os_is_not_found
             self.expected_os_name = expected_os_name
             self.is_unattended = is_unattended
             self.profile = profile
@@ -1176,23 +1174,28 @@ vnc_password= "{vnc_passwd}"
 
             return self
 
-        def checkOsFiltered(self, present=False):
+        def checkOsFiltered(self):
             b = self.browser
 
             b.focus("#os-select-group input")
-            # os_search_name is meant to be used to test substring much
+            # os_search_name is meant to be used to test substring match
             b.input_text(self.os_search_name or self.os_name)
 
-            if not present:
-                try:
-                    with b.wait_timeout(5):
-                        b.wait_in_text("#os-select li button", "No results found")
-                    return self
-                except AssertionError:
-                    # os found which is not ok
-                    self.fail(f"{self.os_name} was not filtered")
+            # Initially we expect the OS to not be found. There will
+            # be only one button, with "Show all".
+            b.wait_in_text("#os-select li button", "Show all operating systems")
+            # Showing them all might reveal the OS
+            b.click("#os-select li button")
+            if not self.os_is_not_found:
+                # Now there is one button for the OS
+                b.wait_in_text("#os-select li button", self.os_name)
+                # It might have an indication of why it was filtered out
+                if self.os_is_unsupported:
+                    b.wait_in_text("#os-select li button", "Vendor support ended")
             else:
-                b.wait_visible(f"#os-select li button:contains({self.os_search_name})")
+                b.wait_in_text("#os-select li button", "No results found")
+
+            return self
 
         def checkRhelIsDownloadable(self):
             b = self.browser


### PR DESCRIPTION
This will show all operating systems, regardless of EOL or release dates.  Operating systems with an expired EOL date will be annotated accordingly in the list.

Fixes #509

Demo: https://youtu.be/JXuX2GRQjCM

- [x] test
- [x] demo
- [ ] design review

![image](https://github.com/user-attachments/assets/dcb1801b-8892-491f-ada8-4abbac15c6b6)

![image](https://github.com/user-attachments/assets/0badee63-49f3-40a6-b2b5-8021e57f1da7)

Note that filtering is based both on End-Of-Life and release dates. Thus, we can't strictly say "Show unsupported operating systems" since the hidden ones are not all unsupported, some are just old.