### PR TITLE
create: Show all operating systems

### DIFF
--- a/src/components/create-vm-dialog/createVmDialogUtils.js
+++ b/src/components/create-vm-dialog/createVmDialogUtils.js
@@ -17,12 +17,18 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
+import cockpit from 'cockpit';
+import React from 'react';
+import { ExclamationTriangleIcon, OutlinedClockIcon } from "@patternfly/react-icons";
+
 import {
     getTodayYearShifted,
 } from "../../helpers.js";
 
 import * as python from "python.js";
 import autoDetectOSScript from './autoDetectOS.py';
+
+const _ = cockpit.gettext;
 
 const ACCEPT_RELEASE_DATES_AFTER = getTodayYearShifted(-3);
 const ACCEPT_EOL_DATES_AFTER = getTodayYearShifted(-1);
@@ -74,6 +80,14 @@ export function filterReleaseEolDates(os) {
         (os.eolDate && compareDates(ACCEPT_EOL_DATES_AFTER, os.eolDate) < 0) ||
         (!os.eolDate && os.releaseDate && compareDates(ACCEPT_RELEASE_DATES_AFTER, os.releaseDate) < 0)
     );
+}
+
+export function getOSDescription(os) {
+    if (os.eolDate && compareDates(ACCEPT_EOL_DATES_AFTER, os.eolDate) < 0)
+        return <span><ExclamationTriangleIcon /> {cockpit.format(_("Vendor support ended $0"), os.eolDate)}</span>;
+    if (!os.eolDate && os.releaseDate && compareDates(ACCEPT_RELEASE_DATES_AFTER, os.releaseDate) < 0)
+        return <span><OutlinedClockIcon /> {cockpit.format(_("Released $0"), os.releaseDate)}</span>;
+    return null;
 }
 
 export function compareDates(a, b, emptyFirst = false) {

--- a/src/components/create-vm-dialog/createVmDialogUtils.js
+++ b/src/components/create-vm-dialog/createVmDialogUtils.js
@@ -31,7 +31,6 @@ import autoDetectOSScript from './autoDetectOS.py';
 const _ = cockpit.gettext;
 
 const ACCEPT_RELEASE_DATES_AFTER = getTodayYearShifted(-3);
-const ACCEPT_EOL_DATES_AFTER = getTodayYearShifted(-1);
 const RHSM_TOKEN = "rhsm-offline-token";
 
 export const URL_SOURCE = 'url';
@@ -74,16 +73,15 @@ export function getOSStringRepresentation(os) {
 }
 
 export function filterReleaseEolDates(os) {
-    // Filter out all OSes their EOL date exists and is olrder than allowed
-    // or their EOL date does not exist but their release date is too old
+    // Filter out all OSes with elapsed EOL, or that have been released too long ago
     return !(
-        (os.eolDate && compareDates(ACCEPT_EOL_DATES_AFTER, os.eolDate) < 0) ||
+        (os.eolDate && new Date(os.eolDate).getTime() < Date.now()) ||
         (!os.eolDate && os.releaseDate && compareDates(ACCEPT_RELEASE_DATES_AFTER, os.releaseDate) < 0)
     );
 }
 
 export function getOSDescription(os) {
-    if (os.eolDate && compareDates(ACCEPT_EOL_DATES_AFTER, os.eolDate) < 0)
+    if (os.eolDate && new Date(os.eolDate).getTime() < Date.now())
         return <span><ExclamationTriangleIcon /> {cockpit.format(_("Vendor support ended $0"), os.eolDate)}</span>;
     if (!os.eolDate && os.releaseDate && compareDates(ACCEPT_RELEASE_DATES_AFTER, os.releaseDate) < 0)
         return <span><OutlinedClockIcon /> {cockpit.format(_("Released $0"), os.releaseDate)}</span>;

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -91,16 +91,16 @@ class TestMachinesCreate(machineslib.VirtualMachinesCase):
                                                             pixel_test_tag="auto"))
 
         # check if older os are filtered
-        runner.checkFilteredOsTest(TestMachinesCreate.VmDialog(self, os_name=config.REDHAT_RHEL_4_7_FILTERED_OS,
+        runner.checkFilteredOsTest(TestMachinesCreate.VmDialog(self, os_name=config.OLD_FILTERED_OS,
+                                                               os_is_old=True))
+
+        runner.checkFilteredOsTest(TestMachinesCreate.VmDialog(self, os_name=config.UNSUPPORTED_FILTERED_OS,
+                                                               os_is_unsupported=True,
+                                                               pixel_test_tag="filter-unsupported"))
+
+        runner.checkFilteredOsTest(TestMachinesCreate.VmDialog(self, os_name=config.NOT_FOUND_FILTERED_OS,
+                                                               os_is_not_found=True,
                                                                pixel_test_tag="filter"))
-
-        runner.checkFilteredOsTest(TestMachinesCreate.VmDialog(self, os_name=config.MANDRIVA_2011_FILTERED_OS))
-
-        runner.checkFilteredOsTest(TestMachinesCreate.VmDialog(self, os_name=config.MAGEIA_3_FILTERED_OS))
-
-        # check that newer oses are present and searchable with substring match
-        runner.checkFilteredOsTest(TestMachinesCreate.VmDialog(self, os_name=config.WINDOWS_SERVER_10,
-                                                               os_search_name=config.WINDOWS_SERVER_10_SHORT))
 
         # check OS versions are sorted in alphabetical order
         runner.checkSortedOsTest(TestMachinesCreate.VmDialog(self), [config.FEDORA_29, config.FEDORA_28])
@@ -953,7 +953,9 @@ vnc_password= "{vnc_passwd}"
         TREE_URL = 'https://archive.fedoraproject.org/pub/archive/fedora/linux/releases/28/Server/x86_64/os'
 
         # LINUX can be filtered if 3 years old
-        REDHAT_RHEL_4_7_FILTERED_OS = 'Red Hat Enterprise Linux 4.9'
+        OLD_FILTERED_OS = 'Red Hat Enterprise Linux 8.3 (Ootpa)'
+        UNSUPPORTED_FILTERED_OS = 'Fedora 34'
+        NOT_FOUND_FILTERED_OS = 'Red Hat Enterprise Linux 4.9'
 
         FEDORA_28 = 'Fedora 28'
         FEDORA_28_SHORTID = 'fedora28'
@@ -968,13 +970,6 @@ vnc_password= "{vnc_passwd}"
 
         CENTOS_7 = 'CentOS 7'
 
-        MANDRIVA_2011_FILTERED_OS = 'Mandriva Linux 2011'
-
-        MAGEIA_3_FILTERED_OS = 'Mageia 3'
-
-        WINDOWS_SERVER_10 = 'Microsoft Windows 10'
-        WINDOWS_SERVER_10_SHORT = 'win'
-
     class VmDialog:
         vmId = 0
 
@@ -987,6 +982,9 @@ vnc_password= "{vnc_passwd}"
                      os_name="Fedora 28",
                      os_search_name=None,
                      os_short_id="fedora28",
+                     os_is_unsupported=False,
+                     os_is_old=False,
+                     os_is_not_found=False,
                      expected_os_name=None,
                      is_unattended=None,
                      profile=None,
@@ -1035,6 +1033,9 @@ vnc_password= "{vnc_passwd}"
             self.os_name = os_name
             self.os_search_name = os_search_name
             self.os_short_id = os_short_id
+            self.os_is_unsupported = os_is_unsupported
+            self.os_is_old = os_is_old
+            self.os_is_not_found = os_is_not_found
             self.expected_os_name = expected_os_name
             self.is_unattended = is_unattended
             self.profile = profile
@@ -1159,15 +1160,13 @@ vnc_password= "{vnc_passwd}"
             b.wait_not_present("#navbar-oops")
 
             # re-input an OS which is "Fedora 28"
-            # need to click the extend button to show the OS list
-            b.click("#os-select-group button[aria-label=\"Options menu\"]")
             b.set_input_text("#os-select-group input", "Fedora")
             b.click("#os-select li button:contains('Fedora 28')")
             b.wait_attr_contains("#os-select-group input", "value", "Fedora 28")
             b.wait_not_present("#navbar-oops")
 
             # click the 'X' button to clear the OS input and check there is no Ooops
-            b.click("#os-select-group button[aria-label=\"Clear all\"]")
+            b.click("#os-select-group button[aria-label=\"Clear input value\"]")
             b.wait_attr("#os-select-group input", "value", "")
             b.wait_not_present("#navbar-oops")
 
@@ -1197,23 +1196,25 @@ vnc_password= "{vnc_passwd}"
 
             return self
 
-        def checkOsFiltered(self, present=False):
+        def checkOsFiltered(self):
             b = self.browser
 
             b.focus("#os-select-group input")
-            # os_search_name is meant to be used to test substring much
+            # os_search_name is meant to be used to test substring match
             b.input_text(self.os_search_name or self.os_name)
 
-            if not present:
-                try:
-                    with b.wait_timeout(5):
-                        b.wait_in_text("#os-select li button", "No results found")
-                    return self
-                except AssertionError:
-                    # os found which is not ok
-                    self.fail(f"{self.os_name} was not filtered")
+            if not self.os_is_not_found:
+                # There should be exactly one entry
+                b.wait_in_text("#os-select li button:not(:disabled)", self.os_name)
+                # It might have a description
+                if self.os_is_unsupported:
+                    b.wait_in_text("#os-select li button:not(:disabled)", "Vendor support ended")
+                elif self.os_is_old:
+                    b.wait_in_text("#os-select li button:not(:disabled)", "Released ")
             else:
-                b.wait_visible(f"#os-select li button:contains({self.os_search_name})")
+                b.wait_in_text("#os-select li button", "No results found")
+
+            return self
 
         def checkRhelIsDownloadable(self):
             b = self.browser
@@ -1225,7 +1226,7 @@ vnc_password= "{vnc_passwd}"
             b.wait_visible(f"#os-select li button:contains('{TestMachinesCreate.TestCreateConfig.RHEL_8_1}')")
             b.wait_not_present(f"#os-select li button:contains('{TestMachinesCreate.TestCreateConfig.RHEL_7_1}')")
             # make the select list go away to not obscure other elements
-            b.click("#os-select-group .pf-v5-c-select__toggle-button")
+            b.click("#os-select-group button.pf-v5-c-menu-toggle__button")
             b.wait_not_present("#os-select li")
 
             return self
@@ -1233,14 +1234,14 @@ vnc_password= "{vnc_passwd}"
         def checkOsSorted(self, sorted_list):
             b = self.browser
 
-            b.click("#os-select-group .pf-v5-c-select .pf-v5-c-button")
+            b.click("#os-select-group button.pf-v5-c-menu-toggle__button")
 
             # Find the first OS from the sorted list, and get a text of it's next neighbour
             next_os = b.text(f"#os-select-group li:contains({sorted_list[0]}) + li")
             # The next neighbour should contain the second OS from the sorted list
             self.assertEqual(next_os, sorted_list[1])
             # make the select list go away to not obscure other elements
-            b.click("#os-select-group .pf-v5-c-select__toggle-button")
+            b.click("#os-select-group button.pf-v5-c-menu-toggle__button")
             b.wait_not_present("#os-select li")
             return self
 
@@ -1383,7 +1384,7 @@ vnc_password= "{vnc_passwd}"
 
             b.wait_not_present("#offline-token")
             if self.os_name:
-                b.click("#os-select-group > div button")
+                b.click("#os-select-group button.pf-v5-c-menu-toggle__button")
                 b.click(f"#os-select li:contains('{self.os_name}') button")
                 b.wait_attr("#os-select-group input", "value", self.os_name)
 
@@ -2008,7 +2009,7 @@ vnc_password= "{vnc_passwd}"
             dialog.open() \
 
             b.select_from_dropdown("#source-type", dialog.sourceType)
-            b.click("#os-select-group > div button")
+            b.click("#os-select-group button.pf-v5-c-menu-toggle__button")
             b.click(f"#os-select li:contains('{dialog.os_name}') button")
             b.wait_attr("#os-select-group input", "value", dialog.os_name)
             if not dialog.offline_token_autofilled:


### PR DESCRIPTION
This will show all operating systems, regardless of EOL or release dates, but the recommended ones will be at the top.  Operating systems with an expired EOL date will be annotated accordingly in the list.

The tests have been brought up-to-date with regard to what OSes are actually in the list and are downloadable.

Fixes #509

Demo: https://youtu.be/I9VCtm2T49U

- [x] https://github.com/cockpit-project/cockpit/pull/21183
- [x] #1923 
- [x] tests
- [x] design review
 
-------

Machines: Download and install unsupported and older operating systems

Cockpit now offers to download and install also unsupported and older operating systems, while still promoting supported and newer ones.

![Screen Shot 2024-12-11 at 09 11 03](https://github.com/user-attachments/assets/b09e2ad0-3d4e-4cd5-9c5e-afd297307948)

