### PR TITLE
dependabot: Keep PF at current major version and downgrade sass

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,14 @@ updates:
       xterm:
         patterns:
           - "@xterm*"
+    ignore:
+      # needs to be done in Cockpit first
+      - dependency-name: "@patternfly/*"
+        update-types: ["major"]
+
+      # https://github.com/cockpit-project/cockpit/issues/21151
+      - dependency-name: "sass"
+        versions: ["1.80.x", "2.x"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "htmlparser": "1.7.7",
     "ipaddr.js": "2.2.0",
     "jed": "1.1.1",
-    "sass": "1.80.3",
+    "sass": "1.79.6",
     "sizzle": "2.3.10",
     "stylelint": "16.10.0",
     "stylelint-config-recommended-scss": "14.0.0",


### PR DESCRIPTION
Ignore sass updates which introduced a warning about incompatible changes on every build and don't upgrade to a PF major version as this is done in Cockpit first.