### PR TITLE
Downgrade sass back to 1.79.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "htmlparser": "1.7.7",
     "ipaddr.js": "2.2.0",
     "jed": "1.1.1",
-    "sass": "1.80.4",
+    "sass": "1.79.6",
     "sizzle": "2.3.10",
     "stylelint": "16.10.0",
     "stylelint-config-recommended-scss": "14.0.0",


### PR DESCRIPTION
Reverts commit ebdef700530.

See https://github.com/cockpit-project/cockpit/issues/21151 We already configured this in dependabot (commit fac7a3824b), but that landed too late, after the dependabot run.