### PR TITLE
vm: Limit size of descriptions

### DIFF
--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -912,6 +912,11 @@ async function domainSetXML(vm, option, values) {
 }
 
 export async function domainSetDescription(vm, description) {
+    // The description will appear in a "open" message for a "spawn"
+    // channel, and excessive lengths will crash the session with a
+    // protocol error. So let's limit it to a reasonable length here.
+    if (description.length > 32000)
+        description = description.slice(0, 32000);
     await domainSetXML(vm, "metadata", { description });
 }
 


### PR DESCRIPTION
Descriptions longer than about 128KiB will crash the Cockpit session with a protocol error since they are included in the open message for a "spawn" channel.

Only use the first 32k (about) when setting them to avoid that.

Fixes #1889