### PR TITLE
test: Expect TPM to work on Arch

### DIFF
--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -35,7 +35,7 @@ def hasMonolithicDaemon(image):
 
 # software TPM doesn't work on some OSes
 def hasBrokenTPM(image):
-    return image.startswith("rhel-8") or image == 'arch'
+    return image.startswith("rhel-8")
 
 
 class VirtualMachinesCaseHelpers:


### PR DESCRIPTION
https://github.com/cockpit-project/bots/pull/7063 adds `swtpm` to our Arch image, with that TPM functionality now works.

---

These two PRs need to land in lockstep.