### PR TITLE
test: Disable multi-host warning in TestMultiMachineVNC

### DIFF
--- a/test/check-machines-multi-host-consoles
+++ b/test/check-machines-multi-host-consoles
@@ -43,6 +43,7 @@ class TestMultiMachineVNC(VirtualMachinesCase):
 
         self.setup_ssh_auth()
         self.enable_multihost(self.machine1)
+        self.machine1.write("/etc/cockpit/cockpit.conf", "[Session]\nWarnBeforeConnecting=false\n", append=True)
 
     def testBasic(self):
         b = self.browser


### PR DESCRIPTION
Adjust to https://github.com/cockpit-project/cockpit/pull/20861 to keep tests uniform across OSes.

Fixes #1913

---

Triggered [additional updates-testing scenario](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1915-e3758558-20241121-064038-fedora-40-updates-testing/log.html) to confirm the fix for #1913