### PR TITLE
test: Don't expect multi-host warning

### DIFF
--- a/test/check-machines-multi-host-consoles
+++ b/test/check-machines-multi-host-consoles
@@ -68,8 +68,7 @@ class TestMultiMachineVNC(VirtualMachinesCase):
         self.goToVmPage(name)
         b.wait_in_text(f"#vm-{name}-system-state", "Running")
 
-        # Cockpit 329 warns the user before adding a remote host
-        b.add_machine(m2_host, known_host=True, password=None, expect_warning=not self.system_before(329))
+        b.add_machine(m2_host, known_host=True, password=None, expect_warning=False)
 
         b.switch_to_top()
         b.click("#hosts-sel button")


### PR DESCRIPTION
Commit b1ae874e44579 collided with commit 3b01b1842c8b8d3 which disables
the warnings unconditionally.

---

See failures in https://github.com/cockpit-project/bots/pull/7140 and https://github.com/cockpit-project/bots/pull/7123