### PR TITLE
Add underscores to unused parameters

### DIFF
--- a/src/components/vm/nics/vmNicsCard.jsx
+++ b/src/components/vm/nics/vmNicsCard.jsx
@@ -279,7 +279,7 @@ export class VmNetworkTab extends React.Component {
         this.getIpAddr();
     }
 
-    componentDidUpdate(prevProps, prevState) {
+    componentDidUpdate(prevProps, _prevState) {
         if (prevProps.vm.state !== this.props.vm.state)
             this.getIpAddr();
     }

--- a/src/components/vm/snapshots/vmSnapshotsCreateModal.jsx
+++ b/src/components/vm/snapshots/vmSnapshotsCreateModal.jsx
@@ -134,7 +134,7 @@ function get_available_space(path, superuser, callback) {
                 const info = JSON.parse(output);
                 callback(info.free * info.unit);
             })
-            .catch(exc => {
+            .catch(() => {
                 // channel has already logged the error
                 callback(null);
             });

--- a/src/components/vm/vmCloneDialog.jsx
+++ b/src/components/vm/vmCloneDialog.jsx
@@ -60,7 +60,7 @@ export const CloneDialog = ({ name, connectionName }) => {
             options.superuser = "try";
         return cockpit.spawn(["virt-clone", "--connect", "qemu:///" + connectionName, "--original", name, "--name", newVmName, "--auto-clone"], options)
                 .stream(setVirtCloneOutput)
-                .then(Dialogs.close, exc => {
+                .then(Dialogs.close, () => {
                     setInProgress(false);
                     dialogErrorSet({ dialogError: cockpit.format(_("Failed to clone VM $0"), name) });
                 });

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -296,7 +296,7 @@ export function rephraseUI(key, original) {
  * @param mimeType
  * @returns {*}
  */
-export function fileDownload({ data, fileName = 'myFile.dat', mimeType = 'application/octet-stream' }) {
+export function fileDownload({ data, _fileName = 'myFile.dat', mimeType = 'application/octet-stream' }) {
     if (!data) {
         console.error('fileDownload(): no data to download');
         return false;

--- a/src/libvirtApi/common.js
+++ b/src/libvirtApi/common.js
@@ -374,7 +374,7 @@ function startEventMonitorNetworks(connectionName) {
     /* Subscribe to signals on Network Interface */
     dbusClient(connectionName).subscribe(
         { interface: "org.libvirt.Network" },
-        (path, iface, signal, args) => {
+        (path, _iface, signal) => {
             switch (signal) {
             case "Refresh":
             /* These signals imply possible changes in what we display, so re-read the state */
@@ -424,7 +424,7 @@ function startEventMonitorStoragePools(connectionName) {
     /* Subscribe to signals on StoragePool Interface */
     dbusClient(connectionName).subscribe(
         { interface: "org.libvirt.StoragePool" },
-        (path, iface, signal, args) => {
+        (path, _iface, signal) => {
             switch (signal) {
             case "Refresh":
             /* These signals imply possible changes in what we display, so re-read the state */


### PR DESCRIPTION
oxlint complains about this by default, its `no-unused-vars` is stricter then eslint :)