### PR TITLE
packaging: Depend on virt-install

### DIFF
--- a/packaging/arch/PKGBUILD.in
+++ b/packaging/arch/PKGBUILD.in
@@ -5,12 +5,11 @@ pkgdesc='Cockpit UI for virtual machines'
 arch=('x86_64')
 url='https://github.com/cockpit-project/cockpit-machines'
 license=(LGPL)
-depends=(cockpit libvirt-dbus)
-optdepends=("virt-install: create new virtual machines")
 source=("SOURCE")
 sha256sums=('SKIP')
 
 package() {
+  depends=(cockpit libvirt-dbus virt-install)
   cd $pkgname
   make DESTDIR="$pkgdir" install PREFIX=/usr
 }

--- a/packaging/cockpit-machines.spec.in
+++ b/packaging/cockpit-machines.spec.in
@@ -43,7 +43,7 @@ Requires: libvirt-daemon-driver-qemu
 Requires: libvirt-daemon-driver-network
 Requires: libvirt-daemon-driver-nodedev
 Requires: libvirt-daemon-driver-storage-core
-Requires: (libvirt-daemon-config-network if virt-install)
+Requires: libvirt-daemon-config-network
 Recommends: libvirt-daemon-driver-storage-disk
 %if 0%{?rhel}
 Requires: qemu-kvm
@@ -62,8 +62,8 @@ Requires: (qemu-audio-spice if qemu-char-spice)
 %endif
 Requires: libvirt-client
 Requires: libvirt-dbus >= 1.2.0
+Requires: virt-install >= 3.0.0
 # Optional components
-Recommends: virt-install >= 3.0.0
 Recommends: libosinfo
 Recommends: python3-gobject-base
 Suggests: (qemu-virtiofsd or virtiofsd)
@@ -71,9 +71,7 @@ Suggests: (qemu-virtiofsd or virtiofsd)
 %{NPM_PROVIDES}
 
 %description
-Cockpit component for managing virtual machines.
-
-If "virt-install" is installed, you can also create new virtual machines.
+Cockpit component for managing libvirt virtual machines.
 
 %prep
 %setup -q -n %{name}

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -20,13 +20,11 @@ Depends: ${misc:Depends},
          cockpit-bridge (>= 215),
          libvirt-daemon-system,
          libvirt-clients | libvirt-bin,
-         libvirt-dbus
-Recommends: virtinst (>= 3.0.0), python3-gi, gir1.2-libosinfo-1.0, qemu-block-extra
+         libvirt-dbus,
+         virtinst (>= 3.0.0),
+Recommends: python3-gi, gir1.2-libosinfo-1.0, qemu-block-extra
 Description: Cockpit user interface for virtual machines
  The Cockpit Web Console enables users to administer GNU/Linux servers using a
  web browser.
  .
- This package adds an user interface for managing virtual machines.
- .
- If the "virtinst" package is installed, you can also create new virtual
- machines.
+ This package adds an user interface for managing libvirt virtual machines.


### PR DESCRIPTION
Our code increasingly uses `virt-xml`, which is not related to creating new machines but administering existing ones. That is also shipped in the `virt-install` package, so promote it from Recommends to Requires.

Leave the `virtInstallAvailable` runtime detection in place for the beiboot case.

Side issue in https://issues.redhat.com/browse/RHEL-61727