### PR TITLE
consoles: Allow configuring VNC

### DIFF
--- a/src/components/vm/consoles/consoles.css
+++ b/src/components/vm/consoles/consoles.css
@@ -28,3 +28,7 @@
 #pf-v5-c-console__send-shortcut {
     display: none;
 }
+
+.consoles-card .pf-v5-c-empty-state__icon {
+    color: var(--pf-v5-global--custom-color--200);
+}

--- a/src/components/vm/consoles/vncAddEdit.jsx
+++ b/src/components/vm/consoles/vncAddEdit.jsx
@@ -1,0 +1,192 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright 2024 Fsas Technologies Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from 'cockpit';
+
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+    Form, Modal, ModalVariant,
+    FormGroup, FormHelperText, HelperText, HelperTextItem,
+    InputGroup, TextInput, Button,
+} from "@patternfly/react-core";
+import { EyeIcon, EyeSlashIcon } from "@patternfly/react-icons";
+
+import { ModalError } from 'cockpit-components-inline-notification.jsx';
+import { DialogsContext } from 'dialogs.jsx';
+import { domainChangeVncSettings, domainAttachVnc, domainGet } from '../../../libvirtApi/domain.js';
+import { NeedsShutdownAlert } from '../../common/needsShutdown.jsx';
+
+const _ = cockpit.gettext;
+
+const VncBody = ({ idPrefix, onValueChanged, dialogValues, validationErrors }) => {
+    const [showPassword, setShowPassword] = useState(false);
+
+    return (
+        <>
+            <FormGroup
+                fieldId={`${idPrefix}-portmode`}
+                label={_("Port")} isInline hasNoPaddingTop isStack>
+                <TextInput
+                    id={`${idPrefix}-port`}
+                    value={dialogValues.vncPort}
+                    type="text"
+                    validated={validationErrors?.vncPort ? "error" : null}
+                    onChange={(event) => onValueChanged('vncPort', event.target.value)} />
+                <FormHelperText>
+                    <HelperText>
+                        { validationErrors?.vncPort
+                            ? <HelperTextItem variant='error'>{validationErrors?.vncPort}</HelperTextItem>
+                            : <HelperTextItem>
+                                {_("Leave empty to automatically assign a free port when the machine starts")}
+                            </HelperTextItem>
+                        }
+                    </HelperText>
+                </FormHelperText>
+            </FormGroup>
+            <FormGroup fieldId={`${idPrefix}-password`} label={_("Password")}>
+                <InputGroup>
+                    <TextInput
+                        id={`${idPrefix}-password`}
+                        type={showPassword ? "text" : "password"}
+                        value={dialogValues.vncPassword}
+                        onChange={(event) => onValueChanged('vncPassword', event.target.value)} />
+                    <Button
+                        variant="control"
+                        onClick={() => setShowPassword(!showPassword)}>
+                        { showPassword ? <EyeSlashIcon /> : <EyeIcon /> }
+                    </Button>
+                </InputGroup>
+            </FormGroup>
+        </>
+    );
+};
+
+function validateDialogValues(values) {
+    const res = { };
+
+    if (values.vncPort != "" && (!values.vncPort.match("^[0-9]+$") || Number(values.vncPort) < 5900))
+        res.vncPort = _("Port must be 5900 or larger.");
+
+    return Object.keys(res).length > 0 ? res : null;
+}
+
+VncBody.propTypes = {
+    idPrefix: PropTypes.string.isRequired,
+    onValueChanged: PropTypes.func.isRequired,
+    dialogValues: PropTypes.object.isRequired,
+    validationErrors: PropTypes.object,
+};
+
+export class AddEditVNCModal extends React.Component {
+    static contextType = DialogsContext;
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            dialogError: undefined,
+            vncPort: Number(props.consoleDetail?.port) == -1 ? "" : props.consoleDetail?.port || "",
+            vncPassword: props.consoleDetail?.password || "",
+            validationErrors: null,
+        };
+
+        this.save = this.save.bind(this);
+        this.onValueChanged = this.onValueChanged.bind(this);
+        this.dialogErrorSet = this.dialogErrorSet.bind(this);
+    }
+
+    onValueChanged(key, value) {
+        const stateDelta = { [key]: value, validationErrors: null };
+        this.setState(stateDelta);
+    }
+
+    dialogErrorSet(text, detail) {
+        this.setState({ dialogError: text, dialogErrorDetail: detail });
+    }
+
+    save() {
+        const Dialogs = this.context;
+        const { vm } = this.props;
+
+        const errors = validateDialogValues(this.state);
+        if (errors) {
+            this.setState({ validationErrors: errors });
+            return;
+        }
+
+        const vncParams = {
+            listen: this.props.consoleDetail?.address || "",
+            port: this.state.vncPort || "",
+            password: this.state.vncPassword || "",
+        };
+
+        (this.props.consoleDetail ? domainChangeVncSettings(vm, vncParams) : domainAttachVnc(vm, vncParams))
+                .then(() => {
+                    domainGet({ connectionName: vm.connectionName, id: vm.id });
+                    Dialogs.close();
+                })
+                .catch((exc) => {
+                    this.dialogErrorSet(_("VNC settings could not be saved"), exc.message);
+                });
+    }
+
+    render() {
+        const Dialogs = this.context;
+        const { idPrefix, vm } = this.props;
+
+        const defaultBody = (
+            <Form onSubmit={e => e.preventDefault()} isHorizontal>
+                <VncBody
+                    idPrefix={idPrefix}
+                    dialogValues={this.state}
+                    validationErrors={this.state.validationErrors}
+                    onValueChanged={this.onValueChanged} />
+            </Form>
+        );
+
+        return (
+            <Modal position="top" variant={ModalVariant.medium} id={`${idPrefix}-dialog`} isOpen onClose={Dialogs.close} className='vnc-edit'
+                   title={this.props.consoleDetail ? _("Edit VNC settings") : _("Add VNC")}
+                   footer={
+                       <>
+                           <Button isDisabled={!!this.state.validationErrors} id={`${idPrefix}-save`} variant='primary' onClick={this.save}>
+                               {this.props.consoleDetail ? _("Save") : _("Add")}
+                           </Button>
+                           <Button id={`${idPrefix}-cancel`} variant='link' onClick={Dialogs.close}>
+                               {_("Cancel")}
+                           </Button>
+                       </>
+                   }>
+                <>
+                    { vm.state === 'running' && !this.state.dialogError && <NeedsShutdownAlert idPrefix={idPrefix} /> }
+                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                    {defaultBody}
+                </>
+            </Modal>
+        );
+    }
+}
+
+AddEditVNCModal.propTypes = {
+    idPrefix: PropTypes.string.isRequired,
+    vm: PropTypes.object.isRequired,
+    consoleDetail: PropTypes.object,
+};

--- a/src/components/vm/vmDetailsPage.jsx
+++ b/src/components/vm/vmDetailsPage.jsx
@@ -132,24 +132,22 @@ export const VmDetailsPage = ({
             title: _("Usage"),
             body: <VmUsageTab vm={vm} />,
         },
-        ...(vm.displays.length
-            ? [{
-                id: `${vmId(vm.name)}-consoles`,
-                className: "consoles-card",
-                title: _("Console"),
-                actions: vm.state != "shut off"
-                    ? <Button variant="link"
-                          onClick={() => {
-                              const urlOptions = { name: vm.name, connection: vm.connectionName };
-                              return cockpit.location.go(["vm", "console"], { ...cockpit.location.options, ...urlOptions });
-                          }}
-                          icon={<ExpandIcon />}
-                          iconPosition="right">{_("Expand")}</Button>
-                    : null,
-                body: <Consoles vm={vm} config={config}
-                            onAddErrorNotification={onAddErrorNotification} />,
-            }]
-            : []),
+        {
+            id: `${vmId(vm.name)}-consoles`,
+            className: "consoles-card",
+            title: _("Console"),
+            actions: vm.state != "shut off"
+                ? <Button variant="link"
+                      onClick={() => {
+                          const urlOptions = { name: vm.name, connection: vm.connectionName };
+                          return cockpit.location.go(["vm", "console"], { ...cockpit.location.options, ...urlOptions });
+                      }}
+                      icon={<ExpandIcon />}
+                      iconPosition="right">{_("Expand")}</Button>
+                : null,
+            body: <Consoles vm={vm} config={config}
+                      onAddErrorNotification={onAddErrorNotification} />,
+        },
         {
             id: `${vmId(vm.name)}-disks`,
             className: "disks-card",

--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -19,6 +19,7 @@
 
 import os
 import time
+import xml.etree.ElementTree as ET
 
 import machineslib
 import testlib
@@ -246,7 +247,7 @@ fullscreen=0
         # Test message is present if VM is not running
         self.performAction(name, "forceOff", checkExpectedState=False)
 
-        b.wait_in_text("#vm-not-running-message", "start the virtual machine")
+        b.wait_in_text("#vm-not-running-message", "Start the virtual machine")
 
         # Test deleting VM from console page will not trigger any error
         self.performAction(name, "delete")
@@ -329,6 +330,124 @@ fullscreen=0
         b.wait_in_text(".pf-v5-c-console__manual-connection dl > div:nth-child(2) dd", "5900")
 
         self.waitViewerDownload("vnc", my_ip)
+
+    def testAddEditVNC(self, withSerial=True):
+        b = self.browser
+
+        # Create a machine without any consoles
+
+        name = "subVmTest1"
+        self.createVm(name, ptyconsole=withSerial)
+
+        self.login_and_go("/machines")
+        self.waitPageInit()
+        self.waitVmRow(name)
+        self.goToVmPage(name)
+
+        def assert_state(text):
+            b.wait_in_text(f"#vm-{name}-consoles .pf-v5-c-empty-state", text)
+
+        def assert_not_state(text):
+            b.wait_not_in_text(f"#vm-{name}-consoles .pf-v5-c-empty-state", text)
+
+        if withSerial:
+            b.click("#pf-v5-c-console__type-selector")
+            b.wait_visible("#pf-v5-c-console__type-selector + .pf-v5-c-select__menu")
+            b.click("#VncConsole button")
+            b.wait_not_present("#pf-v5-c-console__type-selector + .pf-v5-c-select__menu")
+
+        # "Console" card shows empty state
+
+        if withSerial:
+            assert_state("Graphical console support not enabled")
+            b.assert_pixels(f"#vm-{name}-consoles", "no-vnc")
+        else:
+            assert_state("Console support not enabled")
+
+        b.click(f"#vm-{name}-consoles .pf-v5-c-empty-state button:contains(Add VNC)")
+
+        b.wait_visible("#add-vnc-dialog")
+        b.set_input_text("#add-vnc-port", "5000")
+        b.click("#add-vnc-save")
+        b.wait_visible("#add-vnc-dialog .pf-m-error:contains('Port must be 5900 or larger.')")
+        b.set_input_text("#add-vnc-port", "Hamburg")
+        b.wait_not_present("#add-vnc-dialog .pf-m-error")
+        b.click("#add-vnc-save")
+        b.wait_visible("#add-vnc-dialog .pf-m-error:contains('Port must be 5900 or larger.')")
+        if withSerial:
+            b.assert_pixels("#add-vnc-dialog", "add")
+        b.set_input_text("#add-vnc-port", "100000000000")  # for testing failed libvirt calls
+        b.set_input_text("#add-vnc-password", "foobar")
+        b.wait_attr("#add-vnc-password", "type", "password")
+        b.click("#add-vnc-dialog .pf-v5-c-input-group button")
+        b.wait_attr("#add-vnc-password", "type", "text")
+        b.click("#add-vnc-save")
+        b.wait_in_text("#add-vnc-dialog", "VNC settings could not be saved")
+        b.wait_in_text("#add-vnc-dialog", "cannot parse vnc port 100000000000")
+        b.set_input_text("#add-vnc-port", "5901")
+        b.click("#add-vnc-save")
+        b.wait_not_present("#add-vnc-dialog")
+
+        if withSerial:
+            assert_state("Restart this virtual machine to access its graphical console")
+            b.wait_visible(f"#vm-{name}-needs-shutdown")
+            b.assert_pixels(f"#vm-{name}-consoles", "needs-shutdown")
+        else:
+            assert_state("Restart this virtual machine to access its console")
+
+        root = ET.fromstring(self.machine.execute(f"virsh dumpxml --inactive --security-info {name}"))
+        graphics = root.find('devices').findall('graphics')
+        self.assertEqual(len(graphics), 1)
+        self.assertEqual(graphics[0].get('port'), "5901")
+        self.assertEqual(graphics[0].get('passwd'), "foobar")
+
+        b.click(f"#vm-{name}-consoles .pf-v5-c-empty-state button:contains(VNC settings)")
+        b.wait_visible("#edit-vnc-dialog")
+        b.wait_val("#edit-vnc-port", "5901")
+        b.wait_val("#edit-vnc-password", "foobar")
+        if withSerial:
+            b.assert_pixels("#edit-vnc-dialog", "edit")
+        b.set_input_text("#edit-vnc-port", "")
+        b.click("#edit-vnc-save")
+        b.wait_not_present("#edit-vnc-dialog")
+
+        root = ET.fromstring(self.machine.execute(f"virsh dumpxml --inactive --security-info {name}"))
+        graphics = root.find('devices').findall('graphics')
+        self.assertEqual(len(graphics), 1)
+        self.assertEqual(graphics[0].get('port'), "-1")
+        self.assertEqual(graphics[0].get('passwd'), "foobar")
+
+        # Shut down machine
+
+        self.performAction("subVmTest1", "forceOff")
+        assert_state("Start the virtual machine to access its console")
+        if withSerial:
+            b.assert_pixels(f"#vm-{name}-consoles", "shutoff")
+
+        # Remove VNC from the outside and do the whole dance again
+
+        self.machine.execute(f"virt-xml --remove-device --graphics vnc {name}")
+
+        if withSerial:
+            assert_state("Start the virtual machine to access its serial console")
+            assert_state("Graphical console support not enabled")
+            b.assert_pixels(f"#vm-{name}-consoles", "shutoff-no-vnc")
+        else:
+            assert_state("Console support not enabled")
+
+        b.click("#vm-not-running-message button:contains(Add VNC)")
+        b.wait_visible("#add-vnc-dialog")
+        b.click("#add-vnc-save")
+        b.wait_not_present("#add-vnc-dialog")
+
+        if withSerial:
+            assert_not_state("Graphical console support not enabled")
+        else:
+            assert_not_state("Console support not enabled")
+        assert_state("Start the virtual machine to access its console")
+
+    def testAddEditVNCNoSerial(self):
+        self.testAddEditVNC(withSerial=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Demo: https://www.youtube.com/watch?v=T_moc6agxyE 
(up-to-date as of Feb 7, doesn't have the correct UI strings, sorry.)

Pixel changes: https://github.com/cockpit-project/pixel-test-reference/compare/fef884db2f402038be5b2f37e0df9d45a7aca4c2..67b88cd2d097c91e240fe935b9e4a430f6a8a7d9

Via the "Consoles" card, when the machine is off, but also via the VNC console tab when the machine is running and has no VNC.

This is the minimum to get #1795 finished, IMO, and we should not try to do more. Anything on top happens in #1972 and elsewhere, at its own pace.

- [x] only allow configuring the port, we are not comfortable with people opening the listening address without also adding encryption.
- [x] better UI for "auto" vs "manual" port.
- [x] talk about VNC in the not-running page instead of just "supported"
- [x] always mention port, either number or "automatic"
- [x] allow adding VNC while machine is running, properly warn about "pending changes", etc.
- [x] demo
- [x] more precise "shutdown required" detection
- [x] put a "shutdown required" message into the dialogs.
- [x] remove errors from dialog when fields are changed
- [x] Martin's review comments
- [x] Squash
- [x] Use a EmptyState component ala #2019
- [x] "Pending" icon when appropriate
- [x] demo
- [x] string changes from the mockup
- [ ] Skip dialog with "Add VNC"
- [ ] Find place for "edit" button where it is associated with "remote viewing".
- [ ] tests, coverage

