### PR TITLE
Enable VNC debug logging

### DIFF
--- a/src/components/vm/consoles/vnc.jsx
+++ b/src/components/vm/consoles/vnc.jsx
@@ -168,7 +168,7 @@ class Vnc extends React.Component {
                         encrypt={encrypt}
                         shared
                         credentials={credentials}
-                        vncLogging='warn'
+                        vncLogging={ window.debugging?.includes("vnc") ? 'debug' : 'warn' }
                         onDisconnected={this.onDisconnected}
                         onInitFailed={this.onInitFailed}
                         additionalButtons={additionalButtons}


### PR DESCRIPTION
When setting `window.debugging = "vnc"`, enable VncConsole's debug logging. This is particularly helpful for logging console resize requests from the client (Cockpit) as well as resize announcements from libvirt.

https://issues.redhat.com/browse/RHEL-73808

---

The libvirt server announces resolution changes like this:

> Screen: 400x474, bpp: 32, depth: 24, bigEndian: 0, trueColor: 1, redMax: 255, greenMax: 255, blueMax: 255, redShift: 16, greenShift: 8, blueShift: 0

the VNC console reacts to that by scaling its output. OTOH if you resize the client (by either changing the browser window size or e.g. use the "Expand" button for the console) you get

> Requested new desktop size: 395.816650390625x474.1000061035156
> Setting viewport to full display region

So it logs both directions. This should help with investigating https://issues.redhat.com/browse/RHEL-50521 and others in the future.