### PR TITLE
test: wait until the VM is running before a poweroff

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -2246,6 +2246,7 @@ vnc_password= "{vnc_passwd}"
         # Wait for virt-install to define the VM and then stop it,
         # otherwise we get 'domain is ready being removed' error
         testlib.wait(lambda: "VmNotInstalled" in m.execute("virsh list --persistent"), delay=3)
+        b.wait_in_text("#vm-VmNotInstalled-system-state", "Running")
         logfile = "/var/log/libvirt/qemu/VmNotInstalled.log"
         m.execute(f"> {logfile}")  # clear logfile
         self.performAction("VmNotInstalled", "forceOff", checkExpectedState=False)


### PR DESCRIPTION
On RHEL 10 there is seems to be a race where the machine is powered off when it isn't fully running causing an libvirt error which in turns causes the test to flake.

---

This should solve [this flake](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1976-86f02498-20250114-181748-rhel-10-0/log.html) fails 40% of the time. Which shows an error:

![image](https://github.com/user-attachments/assets/f88a1e67-8951-4f17-b214-121d270ca74e)
