### PR TITLE
test: Skip TestMachinesLifecycle.testBasicSysadmU on RHEL 8

### DIFF
--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -50,6 +50,7 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
         self._testBasic(user, superuser=False)
 
     @testlib.skipImage("No SELinux", "debian-*", "ubuntu-*", "arch", "opensuse*")
+    @testlib.skipImage("crashes C bridge", "rhel-8*")
     def testBasicSysadmU(self):
         user = self.createUser(user_group='libvirt')
         self.machine.execute(f"semanage login -a -s sysadm_u {user}")


### PR DESCRIPTION
This new test from commit de52680affdfc often triggers a C bridge crash on RHEL 8. We won't fix anything there any more, and this test at least works sometimes (so SELinux policy is correct in RHEL 8).

See https://cockpit-logs.us-east-1.linodeobjects.com/pull-1979-90a3deec-20250116-164330-rhel-8-10/log.html