### PR TITLE
consoles: Fix closing of "Send key" dropdown via the toggle

### DIFF
--- a/src/components/vm/consoles/vnc.jsx
+++ b/src/components/vm/consoles/vnc.jsx
@@ -149,7 +149,10 @@ class Vnc extends React.Component {
             <Dropdown onSelect={this.onExtraKeysDropdownToggle}
                 key={cockpit.format("$0-$1-vnc-sendkey", vmName, connectionName)}
                 toggle={(toggleRef) => (
-                    <MenuToggle id={cockpit.format("$0-$1-vnc-sendkey", vmName, connectionName)} ref={toggleRef} onClick={(_event, isOpen) => this.setState({ isActionOpen: isOpen })}>
+                    <MenuToggle
+                        id={cockpit.format("$0-$1-vnc-sendkey", vmName, connectionName)}
+                        ref={toggleRef}
+                        onClick={(_event) => this.setState({ isActionOpen: !isActionOpen })}>
                         {_("Send key")}
                     </MenuToggle>
                 )}


### PR DESCRIPTION
The onClick event of a MenuToggle is not special, it's just the regular React onClick event that all components have. It does not have a "isOpen" parameter.