### PR TITLE
packaging: depend on virt-install on Debian

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -21,7 +21,7 @@ Depends: ${misc:Depends},
          libvirt-daemon-system,
          libvirt-clients | libvirt-bin,
          libvirt-dbus,
-         virtinst (>= 3.0.0),
+         virt-install (>= 3.0.0) | virtinst (>= 3.0.0),
 Recommends: python3-gi, gir1.2-libosinfo-1.0, qemu-block-extra
 Description: Cockpit user interface for virtual machines
  The Cockpit Web Console enables users to administer GNU/Linux servers using a


### PR DESCRIPTION
Starting from version 1:5.0.0-2, the `virt-manager` source in Debian renames the `virtinst` binary package to `virt-install`, adding the old package as transitional dummy package.

Hence, tweak the Debian packaging to try to pull the new `virt-install` first, falling back to the old `virtinst`.

There is no behaviour change on older Debian & Debian-based versions, and in newer versions it makes it possible to uninstall the transitional `virtinst`.