### PR TITLE
consoles: Also wait for address when connecting to VNC

### DIFF
--- a/src/components/vm/consoles/vnc.jsx
+++ b/src/components/vm/consoles/vnc.jsx
@@ -68,7 +68,7 @@ class Vnc extends React.Component {
         }
 
         const { consoleDetail } = props;
-        if (!consoleDetail || consoleDetail.port == -1) {
+        if (!consoleDetail || consoleDetail.port == -1 || !consoleDetail.address) {
             logDebug('Vnc component: console detail not yet provided');
             return;
         }


### PR DESCRIPTION
If the inactive XML config contains a port but not a address, we would try to connect too early, before the address was actually filled in.