### PR TITLE
Revert "test: Skip TestMachinesDisks.testAddDiskNFS on RHEL 10"

### DIFF
--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -862,8 +862,6 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         # iscsi disks are attached.
         m.execute("virsh detach-disk subVmTest1 --target vdb")
 
-    @testlib.skipImage("triggers kernel oops, https://issues.redhat.com/browse/RHEL-67841",
-                       "rhel-10*", "centos-10")
     def testAddDiskNFS(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
https://issues.redhat.com/browse/RHEL-67841 got silently fixed.

This reverts commit 423d16a23f12d4dd41b35951bbfcd958f9e6cbbf.

----

I was revisiting that bug while reporting https://bugzilla.redhat.com/show_bug.cgi?id=2344326 . I cannot reproduce the crash manually on current RHEL 10 any more, so let's give this a try in CI.