### PR TITLE
test: Skip NFS related tests on Fedora 42/43

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -25,8 +25,7 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-41
-      # https://pagure.io/fedora-infrastructure/issue/12389
-      # - fedora-42
+      - fedora-42
       - fedora-rawhide
       - centos-stream-9
       - centos-stream-10

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -18,8 +18,8 @@ fi
 # our tests, and only causes trouble; https://github.com/amazonlinux/amazon-ec2-utils/issues/37
 if rpm -q amazon-ec2-utils; then
     rpm -e --verbose amazon-ec2-utils
-    # clean up the symlinks
-    udevadm trigger /dev/nvme*
+    # clean up the symlinks, if they exist
+    udevadm trigger /dev/nvme* || true
 fi
 
 # Show critical packages versions

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -864,6 +864,8 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
 
     @testlib.skipImage("triggers kernel oops, https://issues.redhat.com/browse/RHEL-67841",
                        "rhel-10*", "centos-10")
+    @testlib.skipImage("NFS kernel oops https://bugzilla.redhat.com/show_bug.cgi?id=2344326",
+                       "fedora-42", "fedora-43")
     def testAddDiskNFS(self):
         b = self.browser
         m = self.machine

--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -23,6 +23,8 @@ import machineslib
 import testlib
 
 
+@testlib.skipImage("NFS kernel oops https://bugzilla.redhat.com/show_bug.cgi?id=2344326",
+                   "fedora-42", "fedora-43")
 @testlib.nondestructive
 class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
 


### PR DESCRIPTION
Setting up an NFS pool triggers a kernel oops:
https://bugzilla.redhat.com/show_bug.cgi?id=2344326

This cannot be recovered from and breaks all subsequent tests and the VM, so skip the pool tests wholesale.

----

Avoids this mess: https://artifacts.dev.testing-farm.io/64435bb1-4258-45fc-a3ab-25d967adaee7/

 - [x] But also needs this first: https://github.com/cockpit-project/bots/pull/7406