### PR TITLE
test: Bring back TestMultiMachineVNC tests

### DIFF
--- a/test/check-machines-multi-host-consoles
+++ b/test/check-machines-multi-host-consoles
@@ -1,0 +1,101 @@
+#!/usr/bin/python3 -cimport os, sys; os.execv(os.path.dirname(sys.argv[1]) + "/common/pywrap", sys.argv)
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2021 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import testlib
+from machineslib import VirtualMachinesCase
+
+
+class TestMultiMachineVNC(VirtualMachinesCase):
+    """
+    Test for showing the wrong VNC console when adding another host via the add
+    host feature the raw stream channel does not set the host option so would
+    connect to the console of machine you connect to instead of the newly added
+    host.
+
+    https://issues.redhat.com/browse/RHEL-3959
+    """
+
+    provision = {  # noqa: RUF012
+        "machine1": {"address": "10.111.113.1/20", "memory_mb": 1024},
+        "machine2": {"address": "10.111.113.2/20", "memory_mb": 660},
+    }
+
+    def setUp(self):
+        super().setUp()
+        self.machine1 = self.machines['machine1']
+        self.machine2 = self.machines['machine2']
+
+        self.setup_ssh_auth()
+        self.enable_multihost(self.machine1)
+        self.machine1.write("/etc/cockpit/cockpit.conf", "[Session]\nWarnBeforeConnecting=false\n", append=True)
+
+    def testBasic(self):
+        b = self.browser
+        m = self.machine
+        m2 = self.machine2
+        m2_host = "10.111.113.2"
+
+        m.execute(f"ssh-keyscan {m2_host} > /etc/ssh/ssh_known_hosts")
+        self.startLibvirt(m2)
+
+        # uses too much RAM with lots of violations
+        m.execute("systemctl mask setroubleshootd.service")
+
+        # Start a VM with a VNC on machine1
+        name = "subVmTest1"
+        self.createVm(name, graphics="vnc", ptyconsole=True)
+
+        self.login_and_go("/machines")
+        self.waitPageInit()
+
+        self.waitVmRow(name)
+        self.goToVmPage(name)
+        b.wait_in_text(f"#vm-{name}-system-state", "Running")
+
+        b.add_machine(m2_host, known_host=True, password=None, expect_warning=False)
+
+        b.switch_to_top()
+        b.click("#hosts-sel button")
+
+        b.click(f"a[href='/@{m2_host}']")
+
+        b.wait_js_cond(f'window.location.pathname == "/@{m2_host}/system"')
+        b.enter_page("/system", host=m2_host)
+        b.become_superuser()
+
+        b.go(f"/@{m2_host}/machines")
+        b.enter_page("/machines", host=m2_host)
+
+        self.createVm(name, graphics="vnc", ptyconsole=True, machine=m2)
+        self.waitVmRow("subVmTest1")
+        b.wait_in_text("#vm-subVmTest1-system-state", "Running")
+        self.goToVmPage("subVmTest1")
+
+        # Wait till we have a VNC connection
+        b.wait_visible(".pf-v5-c-console__vnc canvas")
+
+        # Both machines should have the equal amount of VNC connections
+        m1_open_connections = m.execute("ss -tupn | grep 127.0.0.1:5900 | grep qemu").splitlines()
+        m2_open_connections = m2.execute("ss -tupn | grep 127.0.0.1:5900 | grep qemu").splitlines()
+        self.assertTrue(len(m1_open_connections) == 1)
+        self.assertTrue(len(m2_open_connections) == 1)
+
+
+if __name__ == '__main__':
+    testlib.test_main()


### PR DESCRIPTION
I have deleted them in 8a11a1896ebe61a7cecf39ed8ed9026d779aeb45 because I didn't understand them and thought they are now redundant.

But they are still useful: They test that the channel for the in-page VNC viewer uses the correct "host" parameter.

(Specifically, I thought the check at the end is looking at open listening ports, not established connections.)