### PR TITLE
domain: Support for generic configuration in the domain XML

### DIFF
--- a/src/components/vm/vmDetailsPage.jsx
+++ b/src/components/vm/vmDetailsPage.jsx
@@ -45,6 +45,8 @@ import VmActions from './vmActions.jsx';
 import { VmNeedsShutdown } from '../common/needsShutdown.jsx';
 import { VmUsesSpice } from './usesSpice.jsx';
 
+import { domainModifyCockpitConfig, domainUpdateCockpitConfig } from "../../libvirtApi/domain";
+
 import './vmDetailsPage.scss';
 
 const _ = cockpit.gettext;
@@ -81,6 +83,13 @@ export const VmDetailsPage = ({
                         {vm.inactiveXML.description}
                     </p>
             }
+            <p>CONFIG: {JSON.stringify(vm.cockpit_config)}</p>
+            <Button onClick={() => domainModifyCockpitConfig(vm, old => ({ ...old, count: (old.count || 0) + 1 }))}>
+                {"plus"}
+            </Button>
+            <Button onClick={() => domainUpdateCockpitConfig(vm, { count: 0 })}>
+                {"reset"}
+            </Button>
         </PageSection>
     );
 

--- a/src/libvirt-xml-parse.js
+++ b/src/libvirt-xml-parse.js
@@ -6,6 +6,7 @@ import {
 } from './helpers.js';
 
 const METADATA_NAMESPACE = "https://github.com/cockpit-project/cockpit-machines";
+const CONFIG_NAMESPACE = "https://github.com/cockpit-project/cockpit-machines/config";
 
 export function getDiskElemByTarget(domxml, targetOriginal) {
     const domainElem = getElem(domxml);
@@ -294,6 +295,16 @@ export function parseDomainDumpxml(connectionName, domXml, objPath) {
         userPassword,
     };
 
+    let cockpit_config = { };
+    const configXML = metadataElem.getElementsByTagNameNS(CONFIG_NAMESPACE, "json");
+    if (configXML && configXML.length >= 1) {
+        try {
+            cockpit_config = JSON.parse(configXML[0].textContent);
+        } catch (err) {
+            console.error("Failed to parse cockpit-config of", name, ":", err);
+        }
+    }
+
     return {
         connectionName,
         uuid,
@@ -322,6 +333,7 @@ export function parseDomainDumpxml(connectionName, domXml, objPath) {
         metadata,
         hasSpice,
         hasTPM,
+        cockpit_config,
     };
 }
 

--- a/src/libvirtApi/helpers.js
+++ b/src/libvirtApi/helpers.js
@@ -107,6 +107,10 @@ export const Enum = {
     VIR_MIGRATE_UNDEFINE_SOURCE: 16,
     VIR_MIGRATE_NON_SHARED_DISK: 64,
     VIR_MIGRATE_OFFLINE: 1024,
+    // https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainMetadataType
+    VIR_DOMAIN_METADATA_DESCRIPTION: 0,
+    VIR_DOMAIN_METADATA_TITLE: 1,
+    VIR_DOMAIN_METADATA_ELEMENT: 2,
 };
 
 /**


### PR DESCRIPTION
This was triggered by #2015. We might want to keep the user choices abour scaling/resizing the in-page VNC viewer a part of the VM definition. We should persist them in some form /(so that you don't have to switch on scaling for your VM every time you log into cockpit, for example), but if we persist them, why not in the machine XML?  The question would be is this a per-user preference, or a per-machine config?  I am in the middle of that.

So this is mostly a tech demo.
