### PR TITLE
helpers: Include filename when triggering download

### DIFF
--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -29,9 +29,8 @@ class TestMachinesConsoles(machineslib.VirtualMachinesCase):
 
     def waitDownloadFile(self, filename: str, expected_size: int | None = None, content: str | None = None) -> None:
         filepath = self.browser.driver.download_dir / filename
+        testlib.wait(filepath.exists)
 
-        # Big downloads can take a while
-        testlib.wait(filepath.exists, tries=120)
         if expected_size is not None:
             testlib.wait(lambda: filepath.stat().st_size == expected_size)
 
@@ -49,24 +48,8 @@ host={host}
 port={port}
 delete-this-file=1
 fullscreen=0
-
-[...............................GraphicsConsole]
 """
-        # HACK: Due to a bug in cockpit-machines, Firefox downloads the desktop
-        # viewer file as a randomly generated file while chromium as
-        # "download". As we want to download this as "$vmName.vv" in the end
-        # work around the issue for now.
-
-        def ready_downloads():
-            return list(filter(lambda p: not p.endswith(".part"), os.listdir(self.browser.driver.download_dir)))
-
-        if self.browser.browser == "chromium":
-            fname = "download"
-        else:
-            testlib.wait(lambda: len(ready_downloads()) == 1)
-            fname = ready_downloads()[0]
-
-        self.waitDownloadFile(fname, content=content, expected_size=len(content))
+        self.waitDownloadFile("console.vv", content=content, expected_size=len(content))
 
     @testlib.skipImage('SPICE not supported on RHEL', "rhel-*", "centos-*")
     def testExternalConsole(self):


### PR DESCRIPTION
By combining the two old ideas: Instead of deciding between clicking on a link (needs CSP), or loading a "data:" URL into a nested iframe (omits filename), we click on a link in a nested iframe.

This should make the "Launch viewer" button work with Chrome and in other contexts where the extension of the filename is needed to find the right external application.

Fixes #1952

-----------------

### Machines: Launching remote viewers works better now

The "Launch viewer" button in Cockpit Machines works by letting the browser download a small file that should be recognized by the browser to be of the specific `application/x-virt-viewer` type used to launch the virt-viewer application. This did not always work reliably since Cockpit would not pass a filename along with the content of the file. This has been fixed and the "Launch viewer" button should not work in all situations (where virt-viewer has been correctly installed).
