### PR TITLE
Drop pf-m-redhat-font

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -13,7 +13,7 @@
     <script type="text/javascript" src="../manifests.js"></script>
   </head>
 
-  <body class="pf-m-redhat-font pf-v5-m-tabular-nums">
+  <body class="pf-v5-m-tabular-nums">
     <div class="ct-page-fill" id="app">
     </div>
   </body>


### PR DESCRIPTION
This no longer exists as class in PF since the PF 3->4 migration.

See also https://github.com/cockpit-project/cockpit/commit/517c8e05fed676a6bc7751a01debfdf4f644fe1b