### PR TITLE
pyproject: set pyright extra import paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,10 @@ module = [
    "machineslib",
 ]
 
+[tool.pyright]
+strict = ["**"]
+extraPaths = ["test/common", "bots"]
+
 [tool.ruff]
 exclude = [
     ".git/",


### PR DESCRIPTION
Our custom test shebang is not compatible with pyright so we have to like mypy teach it about bots/ our custom testlib.

---

Same as podman, already applied in files.