### PR TITLE
vm: Don't touch the "shareable" attribute of disks

### DIFF
--- a/src/components/vm/disks/diskEdit.jsx
+++ b/src/components/vm/disks/diskEdit.jsx
@@ -114,7 +114,7 @@ const AccessRow = ({ onValueChanged, dialogValues, diskDevice, driverType, idPre
                        onValueChanged("access", event.currentTarget.value);
                    }}
                    label={_("Read-only")} />
-            {diskDevice != "cdrom" && <>
+            {diskDevice != "cdrom" &&
                 <Radio id={`${idPrefix}-writable`}
                        name="access"
                        value="writable"
@@ -122,17 +122,7 @@ const AccessRow = ({ onValueChanged, dialogValues, diskDevice, driverType, idPre
                        onChange={(event, _) => {
                            onValueChanged("access", event.currentTarget.value);
                        }}
-                       label={_("Writeable")} />
-                {(driverType === "raw") &&
-                <Radio id={`${idPrefix}-writable-shareable`}
-                       name="access"
-                       value="shareable"
-                       isChecked={dialogValues.access == "shareable" }
-                       onChange={(event, _) => {
-                           onValueChanged("access", event.currentTarget.value);
-                       }}
-                       label={_("Writeable and shared")} />}
-            </>}
+                       label={_("Writeable")} />}
         </FormGroup>
     );
 };
@@ -169,8 +159,6 @@ export class EditDiskModal extends React.Component {
         let access;
         if (props.disk.readonly)
             access = "readonly";
-        else if (props.disk.shareable)
-            access = "shareable";
         else
             access = "writable";
 
@@ -202,7 +190,7 @@ export class EditDiskModal extends React.Component {
             objPath: vm.id,
             target: disk.target,
             readonly: this.state.access == "readonly",
-            shareable: this.state.access == "shareable",
+            shareable: this.props.disk.shareable,
             busType: this.state.busType,
             cache: this.state.cacheMode,
             existingTargets

--- a/src/components/vm/disks/vmDisksCard.jsx
+++ b/src/components/vm/disks/vmDisksCard.jsx
@@ -213,7 +213,7 @@ export const VmDisksCard = ({ vm, vms, disks, renderCapacity, supportedDiskBusTy
         if (renderAccess) {
             const access = (
                 <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }} id={`${idPrefixRow}-access`}>
-                    <FlexItem>{ disk.readonly ? _("Read-only") : disk.shareable ? _("Writeable and shared") : _("Writeable") }</FlexItem>
+                    <FlexItem>{ disk.readonly ? _("Read-only") : disk.shareable ? _("Concurrently writeable") : _("Writeable") }</FlexItem>
                     { needsShutdownDiskAccess(vm, disk.target) && <NeedsShutdownTooltip iconId={`${idPrefixRow}-access-tooltip`} tooltipId={`tip-${idPrefixRow}-access`} /> }
                 </Flex>
             );

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -1501,7 +1501,7 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         self.goToMainPage()
         self.waitVmRow("subVmTest2")
         self.goToVmPage("subVmTest2")
-        # Adding a raw disk to multiple VMs should make it 'shared'
+        # Adding a raw disk to multiple VMs, should not make it 'shared'
         self.VMAddDiskDialog(
             self,
             vm_name="subVmTest2",
@@ -1509,27 +1509,8 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             volume_name='rawVol',
             mode='use-existing',
             expected_target='vdb',
-            expected_access="Writeable and shared",
-            volume_format='raw',
-        ).execute()
-
-        # QCOW2 disks cannot be 'shared', so even after adding it to multiple VMs,
-        # it's access should be only "writeable"
-        m.execute("""
-                  virsh attach-disk --domain subVmTest1 --source myPoolOne/qcowVol \
-                  --target vdg --targetbus virtio --config
-                  """)
-        self.VMAddDiskDialog(
-            self,
-            vm_name="subVmTest2",
-            pool_name='myPoolOne',
-            volume_name='qcowVol',
-            mode='use-existing',
-            expected_target='vdc',
             expected_access="Writeable",
-            volume_format='qcow2',
-            serial="UseExisting",
-            expected_serial="UseExisting",
+            volume_format='raw',
         ).execute()
 
     def testDetachDisk(self):

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -123,11 +123,10 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         b.click("#vm-subVmTest1-disks-vdg-edit-dialog > .pf-v6-c-modal-box__close button")
         b.wait_not_present("#vm-subVmTest1-disks-vdg-edit-dialog")
 
-        # Test qcow2 disk has only readonly attribute configurable
+        # Test qcow2 disk has both read-only and writeable configurable
         openDialog("vdg")
         b.wait_visible("#vm-subVmTest1-disks-vdg-edit-readonly")
         b.wait_visible("#vm-subVmTest1-disks-vdg-edit-writable")
-        b.wait_not_present("#vm-subVmTest1-disks-vdg-edit-writable-shareable")
         cancel("vdg")
 
         # Test configuration of readonly and shareable attributes
@@ -153,18 +152,22 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         b.wait_not_present("#vm-subVmTest1-disks-vde-access-tooltip")
         b.wait_not_present("#vm-subVmTest1-needs-shutdown")
 
-        # Test configuration of readonly and shareable attributes for Shut off VM
         openDialog("vde")
-        # Changing readonly
-        b.set_checked("#vm-subVmTest1-disks-vde-edit-writable-shareable", True)
+        # Changing to writeable
+        b.set_checked("#vm-subVmTest1-disks-vde-edit-writable", True)
         # Tooltip in dialog should not be present
         b.wait_not_present("#vm-subVmTest1-disks-vde-edit-idle-message")
 
         # Close dialog
         save("vde")
-        b.wait_in_text("#vm-subVmTest1-disks-vde-access", "Writeable and shared")
+        b.wait_in_text("#vm-subVmTest1-disks-vde-access", "Writeable")
         b.wait_not_present("#vm-subVmTest1-disks-vde-access-tooltip")
         b.wait_not_present("#vm-subVmTest1-needs-shutdown")
+
+        # Set "shareable" attribute externally
+        testlib.sit()
+        m.execute("virt-xml --edit target=vde --disk shareable=on subVmTest1")
+        b.wait_in_text("#vm-subVmTest1-disks-vde-access", "Concurrently writeable")
 
         b.wait_in_text("#vm-subVmTest1-disks-vde-bus", "virtio")
         b.wait_not_present("#vm-subVmTest1-disks-vde-cache")
@@ -221,7 +224,6 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         # As CDROMs are readonly access mode editing should be disabled
         b.wait_visible("#vm-subVmTest1-disks-hda-edit-readonly")
         b.wait_not_present("#vm-subVmTest1-disks-hda-edit-writable")
-        b.wait_not_present("#vm-subVmTest1-disks-hda-edit-writable-shareable")
         cancel("hda")
 
         # Start Vm


### PR DESCRIPTION
This is deemed too dangerous to do it by default.

Fixes #2011

-----------------

### Machines: The "shareable" attribute of disks is no longer modified by Cockpit

By default, libvirt can attach a disk to multiple virtual machines, but if the disk allows writing, only a single one of these machines can be running at a given time. Writing to a disk concurrently from multiple VMs at the same time can easily lead to data corruption, and libvirt prevents this unless the "shareable" attribute of a disk is set. Previously, Cockpit would set this attribute without much fuzz and would thus invite data corruption. To avoid this, Cockpit no longer mark disks as "shareable" when attaching them to multiple VMs.

Moreover, the "Edit attributes" dialog no longer allows setting the "shareable" attribute either. We now believe this attribute is to dangerous to be exposed in such an easy way. If you really need it, you can use "virt-xml" on the command line. Cockpit will show disks with the "shareable" attribute as "Concurrently writable" in the UI.
