### PR TITLE
vm: Don't crash if parent of a host device is missing

### DIFF
--- a/src/components/vm/hostdevs/hostDevAdd.jsx
+++ b/src/components/vm/hostdevs/hostDevAdd.jsx
@@ -70,7 +70,7 @@ function devicesHaveAChild(selectableDevices) {
     });
 
     Object.values(all).forEach(item => {
-        if (item.parent && item.parent !== "computer" && (item.capability.type === "usb_device" || item.capability.type === "pci")) {
+        if (item.parent && all[item.parent] && item.parent !== "computer" && (item.capability.type === "usb_device" || item.capability.type === "pci")) {
             all[item.parent].hasChildren = true;
         }
     });


### PR DESCRIPTION
Host devices that are referenced by the "parent" attribute of other host devices are probably always reported by libvirt, but their retrieval by us might still fail.  Let's not crash in this case.

See https://issues.redhat.com/browse/RHEL-88405