### PR TITLE
nics: Allow managing source mode of directly attached network interfaces

### DIFF
--- a/src/components/common/needsShutdown.tsx
+++ b/src/components/common/needsShutdown.tsx
@@ -70,6 +70,13 @@ export function needsShutdownIfaceSource(vm: VM, iface: VMInterface) {
         getIfaceSourceName(inactiveIface) !== getIfaceSourceName(iface);
 }
 
+export function needsShutdownIfaceSourceMode(vm: VM, iface: VMInterface) {
+    const inactiveIface = nicLookupByMAC(vm.inactiveXML.interfaces, iface.mac);
+
+    return inactiveIface && inactiveIface.type == "direct" && iface.type == "direct" &&
+        inactiveIface.source.mode !== iface.source.mode;
+}
+
 export function needsShutdownVcpu(vm: VM) {
     return ((vm.vcpus.count !== vm.inactiveXML.vcpus.count) ||
             (vm.vcpus.max !== vm.inactiveXML.vcpus.max) ||
@@ -122,7 +129,8 @@ export function getDevicesRequiringShutdown(vm: VM) {
     for (const iface of vm.interfaces) {
         if (needsShutdownIfaceType(vm, iface) ||
             needsShutdownIfaceModel(vm, iface) ||
-            needsShutdownIfaceSource(vm, iface)) {
+            needsShutdownIfaceSource(vm, iface) ||
+            needsShutdownIfaceSourceMode(vm, iface)) {
             devices.push(_("Network interface"));
             break;
         }

--- a/src/components/vm/nics/nicAdd.jsx
+++ b/src/components/vm/nics/nicAdd.jsx
@@ -109,6 +109,7 @@ export class AddNIC extends React.Component {
             dialogError: undefined,
             networkType: "network",
             networkSource: props.availableSources.network.length > 0 ? props.availableSources.network[0] : undefined,
+            networkSourceMode: "bridge",
             networkModel: "virtio",
             setNetworkMac: false,
             networkMac: "",
@@ -162,6 +163,7 @@ export class AddNIC extends React.Component {
             model: this.state.networkModel,
             sourceType: this.state.networkType,
             source: this.state.networkSource,
+            sourceMode: this.state.networkSourceMode,
             // Generate our own random MAC address because virt-xml has bug which generates different MAC for online and offline XML
             // https://github.com/virt-manager/virt-manager/issues/305
             mac: this.state.setNetworkMac ? this.state.networkMac : getRandomMac(vms),

--- a/src/components/vm/nics/nicBody.jsx
+++ b/src/components/vm/nics/nicBody.jsx
@@ -19,13 +19,12 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex";
 import { FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
 import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
+import { Radio } from "@patternfly/react-core/dist/esm/components/Radio";
 import { PopoverPosition } from "@patternfly/react-core/dist/esm/components/Popover";
 import { Content, ContentVariants } from "@patternfly/react-core/dist/esm/components/Content";
-import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
 
 import { InfoPopover } from '../../common/infoPopover.jsx';
 
@@ -83,7 +82,7 @@ export const NetworkTypeAndSourceRow = ({ idPrefix, onValueChanged, dialogValues
     const virtualNetwork = [{
         name: 'network',
         desc: 'Virtual network',
-        detailHeadline: _("This is the recommended config for general guest connectivity on hosts with dynamic / wireless networking configs."),
+        detailHeadline: _("This is the recommended type for general guest connectivity on hosts with dynamic / wireless networking configs."),
         detailParagraph: _("Provides a connection whose details are described by the named network definition.")
     }];
     if (connectionName !== 'session') {
@@ -92,26 +91,13 @@ export const NetworkTypeAndSourceRow = ({ idPrefix, onValueChanged, dialogValues
             {
                 name: 'bridge',
                 desc: 'Bridge to LAN',
-                detailHeadline: _("This is the recommended config for general guest connectivity on hosts with static wired networking configs."),
+                detailHeadline: _("This is the recommended type for general guest connectivity on hosts with static wired networking configs."),
                 detailParagraph: _("Provides a bridge from the guest virtual machine directly onto the LAN. This needs a bridge device on the host with one or more physical NICs.")
             },
             {
                 name: 'direct',
                 desc: 'Direct attachment',
-                detailHeadline: _("This is the recommended config for high performance or enhanced security."),
-                detailParagraph: _("In the default 'vepa' mode, switching is offloaded to the external switch. If the switch is not VEPA-capable, communication between guest virtual machines, or between a guests and the host is not possible."),
-                externalDocs: (
-                    <Button isInline
-                            className='ct-external-docs-link'
-                            variant="link"
-                            component="a"
-                            icon={<ExternalLinkSquareAltIcon />}
-                            iconPosition="right"
-                            target="__blank"
-                            href="https://libvirt.org/formatdomain.html#direct-attachment-to-physical-interface">
-                        {_("more info")}
-                    </Button>
-                )
+                detailParagraph: _("This is the recommended type for high performance or enhanced security."),
             },
         ];
     } else {
@@ -170,10 +156,7 @@ export const NetworkTypeAndSourceRow = ({ idPrefix, onValueChanged, dialogValues
                                         {availableNetworkTypes.map(type => (<Content key={type.name}>
                                             <Content component={ContentVariants.h4}>{type.desc}</Content>
                                             <strong>{type.detailHeadline}</strong>
-                                            <p>
-                                                {type.detailParagraph}
-                                                {type.externalDocs}
-                                            </p>
+                                            <p>{type.detailParagraph}</p>
                                         </Content>))}
                                     </Flex>}
                            />
@@ -201,6 +184,65 @@ export const NetworkTypeAndSourceRow = ({ idPrefix, onValueChanged, dialogValues
                                 value={defaultNetworkSource}>
                         {networkSourcesContent}
                     </FormSelect>
+                </FormGroup>
+            )}
+            {dialogValues.networkType == "direct" && (
+                <FormGroup id={`${idPrefix}-source-mode`} label={_("Mode")} hasNoPaddingTop isInline
+                    data-value={dialogValues.networkSourceMode}
+                       labelHelp={
+                           <InfoPopover
+                               aria-label={_("Mode help")}
+                               position={PopoverPosition.bottom}
+                               enableFlip={false}
+                               bodyContent={
+                                   <Content>
+                                       <Content component={ContentVariants.h4}>
+                                           VEPA
+                                       </Content>
+                                       <Content component={ContentVariants.p}>
+                                           {_("All VMs' packets are sent to the external bridge. Packets whose destination is a VM on the same host as where the packet originates from are sent back to the host by the VEPA capable bridge (today's bridges are typically not VEPA capable)")}.
+                                       </Content>
+                                       <Content component={ContentVariants.h4}>
+                                           {_("Bridge")}
+                                       </Content>
+                                       <Content component={ContentVariants.p}>
+                                           {_("Packets whose destination is on the same host as where they originate from are directly delivered to the target macvtap device. Both origin and destination devices need to be in bridge mode for direct delivery. If either one of them is in \"VEPA\" mode, a VEPA capable bridge is required.")}
+                                       </Content>
+                                       <Content component={ContentVariants.h4}>
+                                           {_("Private")}
+                                       </Content>
+                                       <Content component={ContentVariants.p}>
+                                           {_("All packets are sent to the external bridge and will only be delivered to a target VM on the same host if they are sent through an external router or gateway and that device sends them back to the host. This procedure is followed if either the source or destination device is in \"Private\" mode.")}
+                                       </Content>
+                                       <Content component={ContentVariants.h4}>
+                                           {_("Passthrough")}
+                                       </Content>
+                                       <Content component={ContentVariants.p}>
+                                           {_("This feature attaches a virtual function of a SRIOV capable NIC directly to a VM without losing the migration capability. All packets are sent to the VF/IF of the configured network device. Depending on the capabilities of the device additional prerequisites or limitations may apply.")}
+                                       </Content>
+                                   </Content>}
+                           />
+                       }>
+                    <Radio id={`${idPrefix}-source-mode-vepa`}
+                        name="mode-vepa"
+                        isChecked={dialogValues.networkSourceMode == "vepa"}
+                        label="VEPA"
+                        onChange={() => onValueChanged('networkSourceMode', "vepa")} />
+                    <Radio id={`${idPrefix}-source-mode-bridge`}
+                        name="mode-bridge"
+                        isChecked={dialogValues.networkSourceMode == "bridge"}
+                        label={_("Bridge")}
+                        onChange={() => onValueChanged('networkSourceMode', "bridge")} />
+                    <Radio id={`${idPrefix}-source-mode-private`}
+                        name="mode-private"
+                        isChecked={dialogValues.networkSourceMode == "private"}
+                        label={_("Private")}
+                        onChange={() => onValueChanged('networkSourceMode', "private")} />
+                    <Radio id={`${idPrefix}-source-mode-passthrough`}
+                        name="mode-passthrough"
+                        isChecked={dialogValues.networkSourceMode == "passthrough"}
+                        label={_("Passthrough")}
+                        onChange={() => onValueChanged('networkSourceMode', "passthrough")} />
                 </FormGroup>
             )}
         </>

--- a/src/components/vm/nics/nicEdit.jsx
+++ b/src/components/vm/nics/nicEdit.jsx
@@ -78,6 +78,7 @@ export class EditNICModal extends React.Component {
             dialogError: undefined,
             networkType: props.network.type,
             networkSource: defaultNetworkSource,
+            networkSourceMode: props.network.type == "direct" ? props.network.source.mode : "bridge",
             networkModel: props.network.model,
             networkMac: props.network.mac,
             saveDisabled: false,
@@ -141,6 +142,7 @@ export class EditNICModal extends React.Component {
             networkModel: this.state.networkModel,
             networkType: this.state.networkType,
             networkSource: this.state.networkSource,
+            networkSourceMode: this.state.networkSourceMode,
         })
                 .then(() => {
                     domainGet({ connectionName: vm.connectionName, id: vm.id });

--- a/src/components/vm/nics/vmNicsCard.jsx
+++ b/src/components/vm/nics/vmNicsCard.jsx
@@ -145,6 +145,16 @@ const NetworkSource = ({ network, networkId, vm, hostDevices }) => {
                         {needsShutdownIfaceSource(vm, network) && <NeedsShutdownTooltip iconId={`${id}-network-${networkId}-source-tooltip`} tooltipId="tip-network" />}
                     </Flex>
                 </DescriptionListDescription>
+                { network.source.mode &&
+                    <>
+                        <DescriptionListTerm>
+                            {_("Mode")}
+                        </DescriptionListTerm>
+                        <DescriptionListDescription id={`${id}-network-${networkId}-source-mode`}>
+                            {network.source.mode}
+                        </DescriptionListDescription>
+                    </>
+                }
             </DescriptionListGroup>
         );
     };

--- a/src/libvirtApi/domain.ts
+++ b/src/libvirtApi/domain.ts
@@ -226,6 +226,7 @@ interface InterfaceSpec {
     hotplug: boolean,
     sourceType: string,
     source: string,
+    sourceMode: string,
     model: string,
 }
 
@@ -237,10 +238,11 @@ export function domainAttachIface({
     hotplug,
     sourceType,
     source,
+    sourceMode,
     model
 }: { connectionName: ConnectionName, vmName: string } & InterfaceSpec): cockpit.Spawn<string> {
     const macArg = mac ? "mac=" + mac + "," : "";
-    const args = ['virt-xml', '-c', `qemu:///${connectionName}`, vmName, '--add-device', '--network', `${macArg}type=${sourceType},source=${source},source.mode=bridge,model=${model}`];
+    const args = ['virt-xml', '-c', `qemu:///${connectionName}`, vmName, '--add-device', '--network', `${macArg}type=${sourceType},source=${source},source.mode=${sourceMode},model=${model}`];
 
     if (hotplug) {
         args.push("--update");
@@ -258,6 +260,7 @@ interface InterfaceChangeSpec {
     newMacAddress?: string,
     networkType?: string,
     networkSource?: string,
+    networkSourceMode?: string,
     networkModel?: string,
     state?: string,
 }
@@ -271,6 +274,7 @@ export function domainChangeInterfaceSettings({
     newMacAddress,
     networkType,
     networkSource,
+    networkSourceMode,
     networkModel,
     state,
 }: { connectionName: ConnectionName, vmName: string } & InterfaceChangeSpec): cockpit.Spawn<string> {
@@ -287,6 +291,8 @@ export function domainChangeInterfaceSettings({
         }
         if (networkSource)
             networkParams += `source=${networkSource},`;
+        if (networkSourceMode)
+            networkParams += `source.mode=${networkSourceMode},`;
         if (networkModel)
             networkParams += `model=${networkModel},`;
     }

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -327,6 +327,15 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
             self,
             mac=mac_address,
             source_type="direct",
+            source_mode="bridge",
+        ).execute()
+
+        mac_address = self.get_next_mac(mac_address)
+        self.NICAddDialog(
+            self,
+            mac=mac_address,
+            source_type="direct",
+            source_mode="passthrough",
         ).execute()
 
         # Test Bridge
@@ -420,6 +429,7 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
             nic_num=1,
             source=None,
             source_type=None,
+            source_mode=None,
             xfail_error=None,
         ):
             self.assertEqual = test_obj.assertEqual
@@ -430,6 +440,7 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
             self.nic_num = nic_num
             self.source = source
             self.source_type = source_type
+            self.source_mode = source_mode
             self.xfail_error = xfail_error
             self.vm_state = "running" if "running" in m.execute("virsh domstate subVmTest1") else "shut off"
 
@@ -453,6 +464,9 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
             # select widget options are never visible for the headless chrome,
             # call therefore directly the js function
             self.source_type_current = b.attr(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-type", "data-value")
+            if self.source_type_current == "direct":
+                self.source_mode_current = b.attr(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-source-mode",
+                                                  "data-value")
             self.source_current = b.attr(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-source", "data-value")
             self.mac_current = b.val(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-mac")
             self.model_current = b.attr(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-model", "data-value")
@@ -462,6 +476,8 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
 
             if self.source_type:
                 b.select_from_dropdown(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-type", self.source_type)
+            if self.source_mode:
+                b.click(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-source-mode-{self.source_mode}")
             if self.source:
                 b.select_from_dropdown(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-source", self.source)
             if self.model:
@@ -475,6 +491,7 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
             if (self.vm_state == "running" and
                     ((self.source_type is not None and self.source_type != self.source_type_current) or
                         (self.source is not None and self.source != self.source_current) or
+                        (self.source_mode is not None and self.source_mode != self.source_mode_current) or
                         (self.model is not None and self.model != self.model_current) or
                         (self.mac is not None and self.mac != self.mac_current))):
                 b.wait_visible(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-idle-message")
@@ -514,6 +531,10 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
                     "direct" if self.vm_state == "shut off" else self.source_type_current,
                     self.machine.execute(xmllint_element.format(prop='@type')).strip()
                 )
+                if self.source_mode:
+                    self.assertEqual(
+                        self.source_mode if self.vm_state == "shut off" else self.source_mode_current,
+                        self.machine.execute(xmllint_element.format(prop='source/@mode')).strip())
                 if self.source:
                     self.assertEqual(
                         self.source,
@@ -528,10 +549,20 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
         def verify_overview(self):
             b = self.browser
 
+            if self.source_type and self.vm_state == "shut off":
+                source_type = self.source_type
+            else:
+                source_type = self.source_type_current
+
             b.wait_in_text(
                 f"#vm-subVmTest1-network-{self.nic_num}-type",
-                self.source_type if self.source_type and self.vm_state == "shut off" else self.source_type_current
+                source_type
             )
+            if source_type == "direct":
+                b.wait_in_text(
+                    f"#vm-subVmTest1-network-{self.nic_num}-source-mode",
+                    self.source_mode if self.source_mode and self.vm_state == "shut off" else self.source_mode_current
+                )
             b.wait_in_text(
                 f"#vm-subVmTest1-network-{self.nic_num}-source",
                 self.source if self.source and self.vm_state == "shut off" else self.source_current
@@ -639,6 +670,18 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
         self.NICEditDialog(
             self,
             source_type="direct",
+            source_mode="passthrough",
+            source="eth43",
+        ).execute()
+        self.NICEditDialog(
+            self,
+            source_type="direct",
+            source_mode="bridge",
+            source="eth43",
+        ).execute()
+        self.NICEditDialog(
+            self,
+            source_type="direct",
             source="eth43",
         ).execute()
         # Check "Source" of the 'direct' NIC
@@ -678,13 +721,14 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
         def __init__(
             # We have always have to specify mac and source_type to identify the device in xml
             # and $virsh detach-interface
-            self, test_obj, source_type="direct", source=None, model=None, nic_num=1,
+            self, test_obj, source_type="direct", source_mode=None, source=None, model=None, nic_num=1,
             permanent=False, mac=None, remove=True, persistent_vm=True,
             xfail=False, xfail_error=None, pixel_test_tag=None
         ):
             ip_output = json.loads(test_obj.machine.execute("ip -j link show type bridge"))
             self.bridge_devices = (entry['ifname'] for entry in ip_output)
             self.source_type = source_type
+            self.source_mode = source_mode
             self.source = source
             self.model = model
             self.permanent = permanent
@@ -728,6 +772,8 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
                 else:
                     self.browser._wait_present(f"#vm-subVmTest1-add-iface-source option[value={bridge}]")
 
+            if self.source_mode:
+                self.browser.click(f"#vm-subVmTest1-add-iface-source-mode-{self.source_mode}")
             if self.source:
                 self.browser.select_from_dropdown("#vm-subVmTest1-add-iface-source", self.source)
             if self.model:
@@ -775,6 +821,9 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
                                      self.machine.execute(xmllint_element.format(prop='source/@network')).strip())
             elif (self.source_type == "direct"):
                 self.assertEqual("direct", self.machine.execute(xmllint_element.format(prop='@type')).strip())
+                if self.source_mode:
+                    self.assertEqual(self.source_mode,
+                                     self.machine.execute(xmllint_element.format(prop='source/@mode')).strip())
                 if self.source:
                     self.assertEqual(self.source,
                                      self.machine.execute(xmllint_element.format(prop='source/@dev')).strip())
@@ -790,6 +839,8 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
                 self.browser.wait_in_text(f"#vm-subVmTest1-network-{self.nic_num}-model", self.model)
             if self.source:
                 self.browser.wait_in_text(f"#vm-subVmTest1-network-{self.nic_num}-source", self.source)
+            if self.source_mode:
+                self.browser.wait_in_text(f"#vm-subVmTest1-network-{self.nic_num}-source-mode", self.source_mode)
             if self.mac:
                 self.browser.wait_in_text(f"#vm-subVmTest1-network-{self.nic_num}-mac", self.mac)
 


### PR DESCRIPTION
Virtual functions from SR-IOV devices might require "passthrough" to work, so let's surface the mode property of directly attached devices fully.

See https://issues.redhat.com/browse/RHEL-88407

Demo:  https://youtu.be/rhm3MDBZXV0

Screenshot:

![image](https://github.com/user-attachments/assets/fb82eee3-a9ea-479c-a41a-9568f6868888)

------------

### Machines: The source mode for network interfaces can now be managed

Previously, Cockpit Machines would always use the "Bridge" mode for directly attached network interfaces. Some devices require other modes, however, and Cockpit Machines now let's you set them explicitly when adding or editing directly attached network interfaces.
