### PR TITLE
Add CPU and Memory usage metrics to Host VM List

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -337,6 +337,8 @@ class AppActive extends React.Component {
                     networks={networks}
                     actions={vmActions}
                     resourceHasError={this.state.resourceHasError}
+                    onUsageStartPollingVMS={() => vms.filter(vm => !vm.isUi).forEach(vm => {usageStartPolling({name: vm.name, id: vm.id, connectionName: vm.connectionName })})}
+                    onUsageStopPollingVMS={() => vms.filter(vm => !vm.isUi).forEach(vm => {usageStopPolling({name: vm.name, connectionName: vm.connectionName })})}
                     onAddErrorNotification={this.onAddErrorNotification} />
                 }
                 {path.length > 0 && path[0] == 'storages' &&

--- a/src/types.ts
+++ b/src/types.ts
@@ -415,6 +415,7 @@ export interface VM extends VMXML {
 
     rssMemory: number | undefined;
     cpuTime: number | undefined;
+    cpuUsage: number | undefined;
     actualTimeInMs: number | undefined;
     disksStats: Record<string, VMDiskStat> | undefined;
 


### PR DESCRIPTION
Currently, the VM list does not display resource usage metrics for  virtual machines. This makes it difficult to identify VMs that are consuming excessive CPU or memory.

This patch adds CPU and memory usage statistics for each VM in the VM list. Similar functionality is available in other virtualization management solutions and improves visibility and resource management.

![HostVmListUsage](https://github.com/user-attachments/assets/139927e7-3fd6-4bc4-8677-f02cbc2a4685)
