### PR TITLE
[rhel-10-0] nics: Allow managing source mode of directly attached network interfaces

### DIFF
--- a/src/components/common/needsShutdown.jsx
+++ b/src/components/common/needsShutdown.jsx
@@ -51,6 +51,13 @@ export function needsShutdownIfaceSource(vm, iface) {
         getIfaceSourceName(inactiveIface) !== getIfaceSourceName(iface);
 }
 
+export function needsShutdownIfaceSourceMode(vm, iface) {
+    const inactiveIface = nicLookupByMAC(vm.inactiveXML.interfaces, iface.mac);
+
+    return inactiveIface && inactiveIface.type == "direct" && iface.type == "direct" &&
+        inactiveIface.source.mode !== iface.source.mode;
+}
+
 export function needsShutdownVcpu(vm) {
     return ((vm.vcpus.count !== vm.inactiveXML.vcpus.count) ||
             (vm.vcpus.max !== vm.inactiveXML.vcpus.max) ||
@@ -103,7 +110,8 @@ export function getDevicesRequiringShutdown(vm) {
     for (const iface of vm.interfaces) {
         if (needsShutdownIfaceType(vm, iface) ||
             needsShutdownIfaceModel(vm, iface) ||
-            needsShutdownIfaceSource(vm, iface)) {
+            needsShutdownIfaceSource(vm, iface) ||
+            needsShutdownIfaceSourceMode(vm, iface)) {
             devices.push(_("Network interface"));
             break;
         }

--- a/src/components/vm/nics/nicAdd.jsx
+++ b/src/components/vm/nics/nicAdd.jsx
@@ -107,6 +107,7 @@ export class AddNIC extends React.Component {
             dialogError: undefined,
             networkType: "network",
             networkSource: props.availableSources.network.length > 0 ? props.availableSources.network[0] : undefined,
+            networkSourceMode: "bridge",
             networkModel: "virtio",
             setNetworkMac: false,
             networkMac: "",
@@ -160,6 +161,7 @@ export class AddNIC extends React.Component {
             model: this.state.networkModel,
             sourceType: this.state.networkType,
             source: this.state.networkSource,
+            sourceMode: this.state.networkSourceMode,
             // Generate our own random MAC address because virt-xml has bug which generates different MAC for online and offline XML
             // https://github.com/virt-manager/virt-manager/issues/305
             mac: this.state.setNetworkMac ? this.state.networkMac : getRandomMac(vms),

--- a/src/components/vm/nics/nicBody.jsx
+++ b/src/components/vm/nics/nicBody.jsx
@@ -26,6 +26,7 @@ import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/co
 import { Popover, PopoverPosition } from "@patternfly/react-core/dist/esm/components/Popover";
 import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/esm/components/Text";
 import { ExternalLinkSquareAltIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { Radio } from "@patternfly/react-core/dist/esm/components/Radio";
 
 import cockpit from 'cockpit';
 
@@ -202,6 +203,22 @@ export const NetworkTypeAndSourceRow = ({ idPrefix, onValueChanged, dialogValues
                                 value={defaultNetworkSource}>
                         {networkSourcesContent}
                     </FormSelect>
+                </FormGroup>
+            )}
+            {dialogValues.networkType == "direct" && (
+                <FormGroup id={`${idPrefix}-source-mode`} label={_("Mode")} hasNoPaddingTop isInline
+                           data-value={dialogValues.networkSourceMode}>
+                    {["vepa", "bridge", "private", "passthrough"].map(mode =>
+                        <Radio
+                            key={mode}
+                            id={`${idPrefix}-source-mode-${mode}`}
+                            name={`mode-${mode}`}
+                            isChecked={dialogValues.networkSourceMode == mode}
+                            // The label is not translated since the
+                            // documentation we link to is always in
+                            // English.
+                            label={<pre>{mode}</pre>}
+                            onChange={() => onValueChanged('networkSourceMode', mode)} />)}
                 </FormGroup>
             )}
         </>

--- a/src/components/vm/nics/nicEdit.jsx
+++ b/src/components/vm/nics/nicEdit.jsx
@@ -76,6 +76,7 @@ export class EditNICModal extends React.Component {
             dialogError: undefined,
             networkType: props.network.type,
             networkSource: defaultNetworkSource,
+            networkSourceMode: props.network.type == "direct" ? props.network.source.mode : "bridge",
             networkModel: props.network.model,
             networkMac: props.network.mac,
             saveDisabled: false,
@@ -139,6 +140,7 @@ export class EditNICModal extends React.Component {
             networkModel: this.state.networkModel,
             networkType: this.state.networkType,
             networkSource: this.state.networkSource,
+            networkSourceMode: this.state.networkSourceMode,
         })
                 .then(() => {
                     domainGet({ connectionName: vm.connectionName, id: vm.id });

--- a/src/components/vm/nics/vmNicsCard.jsx
+++ b/src/components/vm/nics/vmNicsCard.jsx
@@ -145,6 +145,16 @@ const NetworkSource = ({ network, networkId, vm, hostDevices }) => {
                         {needsShutdownIfaceSource(vm, network) && <NeedsShutdownTooltip iconId={`${id}-network-${networkId}-source-tooltip`} tooltipId="tip-network" />}
                     </Flex>
                 </DescriptionListDescription>
+                { network.source.mode &&
+                    <>
+                        <DescriptionListTerm>
+                            {_("Mode")}
+                        </DescriptionListTerm>
+                        <DescriptionListDescription id={`${id}-network-${networkId}-source-mode`}>
+                            {network.source.mode}
+                        </DescriptionListDescription>
+                    </>
+                }
             </DescriptionListGroup>
         );
     };

--- a/src/libvirtApi/domain.js
+++ b/src/libvirtApi/domain.js
@@ -157,9 +157,9 @@ export function domainAttachHostDevices({ connectionName, vmName, live, devices 
     return cockpit.spawn(args, options);
 }
 
-export function domainAttachIface({ connectionName, vmName, mac, permanent, hotplug, sourceType, source, model }) {
+export function domainAttachIface({ connectionName, vmName, mac, permanent, hotplug, sourceType, source, sourceMode, model }) {
     const macArg = mac ? "mac=" + mac + "," : "";
-    const args = ['virt-xml', '-c', `qemu:///${connectionName}`, vmName, '--add-device', '--network', `${macArg}type=${sourceType},source=${source},source.mode=bridge,model=${model}`];
+    const args = ['virt-xml', '-c', `qemu:///${connectionName}`, vmName, '--add-device', '--network', `${macArg}type=${sourceType},source=${source},source.mode=${sourceMode},model=${model}`];
     const options = { err: "message" };
 
     if (connectionName === "system")
@@ -183,6 +183,7 @@ export function domainChangeInterfaceSettings({
     newMacAddress,
     networkType,
     networkSource,
+    networkSourceMode,
     networkModel,
     state,
 }) {
@@ -203,6 +204,8 @@ export function domainChangeInterfaceSettings({
         }
         if (networkSource)
             networkParams += `source=${networkSource},`;
+        if (networkSourceMode)
+            networkParams += `source.mode=${networkSourceMode},`;
         if (networkModel)
             networkParams += `model=${networkModel},`;
     }

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -322,6 +322,15 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
             self,
             mac=mac_address,
             source_type="direct",
+            source_mode="bridge",
+        ).execute()
+
+        mac_address = self.get_next_mac(mac_address)
+        self.NICAddDialog(
+            self,
+            mac=mac_address,
+            source_type="direct",
+            source_mode="passthrough",
         ).execute()
 
         # Test Bridge
@@ -415,6 +424,7 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
             nic_num=1,
             source=None,
             source_type=None,
+            source_mode=None,
             xfail_error=None,
         ):
             self.assertEqual = test_obj.assertEqual
@@ -425,6 +435,7 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
             self.nic_num = nic_num
             self.source = source
             self.source_type = source_type
+            self.source_mode = source_mode
             self.xfail_error = xfail_error
             self.vm_state = "running" if "running" in m.execute("virsh domstate subVmTest1") else "shut off"
 
@@ -448,6 +459,9 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
             # select widget options are never visible for the headless chrome,
             # call therefore directly the js function
             self.source_type_current = b.attr(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-type", "data-value")
+            if self.source_type_current == "direct":
+                self.source_mode_current = b.attr(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-source-mode",
+                                                  "data-value")
             self.source_current = b.attr(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-source", "data-value")
             self.mac_current = b.val(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-mac")
             self.model_current = b.attr(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-model", "data-value")
@@ -457,6 +471,8 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
 
             if self.source_type:
                 b.select_from_dropdown(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-type", self.source_type)
+            if self.source_mode:
+                b.click(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-source-mode-{self.source_mode}")
             if self.source:
                 b.select_from_dropdown(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-source", self.source)
             if self.model:
@@ -470,6 +486,7 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
             if (self.vm_state == "running" and
                     ((self.source_type is not None and self.source_type != self.source_type_current) or
                         (self.source is not None and self.source != self.source_current) or
+                        (self.source_mode is not None and self.source_mode != self.source_mode_current) or
                         (self.model is not None and self.model != self.model_current) or
                         (self.mac is not None and self.mac != self.mac_current))):
                 b.wait_visible(f"#vm-subVmTest1-network-{self.nic_num}-edit-dialog-idle-message")
@@ -509,6 +526,10 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
                     "direct" if self.vm_state == "shut off" else self.source_type_current,
                     self.machine.execute(xmllint_element.format(prop='@type')).strip()
                 )
+                if self.source_mode:
+                    self.assertEqual(
+                        self.source_mode if self.vm_state == "shut off" else self.source_mode_current,
+                        self.machine.execute(xmllint_element.format(prop='source/@mode')).strip())
                 if self.source:
                     self.assertEqual(
                         self.source,
@@ -523,10 +544,20 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
         def verify_overview(self):
             b = self.browser
 
+            if self.source_type and self.vm_state == "shut off":
+                source_type = self.source_type
+            else:
+                source_type = self.source_type_current
+
             b.wait_in_text(
                 f"#vm-subVmTest1-network-{self.nic_num}-type",
-                self.source_type if self.source_type and self.vm_state == "shut off" else self.source_type_current
+                source_type
             )
+            if source_type == "direct":
+                b.wait_in_text(
+                    f"#vm-subVmTest1-network-{self.nic_num}-source-mode",
+                    self.source_mode if self.source_mode and self.vm_state == "shut off" else self.source_mode_current
+                )
             b.wait_in_text(
                 f"#vm-subVmTest1-network-{self.nic_num}-source",
                 self.source if self.source and self.vm_state == "shut off" else self.source_current
@@ -634,6 +665,18 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
         self.NICEditDialog(
             self,
             source_type="direct",
+            source_mode="passthrough",
+            source="eth43",
+        ).execute()
+        self.NICEditDialog(
+            self,
+            source_type="direct",
+            source_mode="bridge",
+            source="eth43",
+        ).execute()
+        self.NICEditDialog(
+            self,
+            source_type="direct",
             source="eth43",
         ).execute()
         # Check "Source" of the 'direct' NIC
@@ -673,13 +716,14 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
         def __init__(
             # We have always have to specify mac and source_type to identify the device in xml
             # and $virsh detach-interface
-            self, test_obj, source_type="direct", source=None, model=None, nic_num=1,
+            self, test_obj, source_type="direct", source_mode=None, source=None, model=None, nic_num=1,
             permanent=False, mac=None, remove=True, persistent_vm=True,
             xfail=False, xfail_error=None, pixel_test_tag=None
         ):
             ip_output = json.loads(test_obj.machine.execute("ip -j link show type bridge"))
             self.bridge_devices = (entry['ifname'] for entry in ip_output)
             self.source_type = source_type
+            self.source_mode = source_mode
             self.source = source
             self.model = model
             self.permanent = permanent
@@ -723,6 +767,8 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
                 else:
                     self.browser._wait_present(f"#vm-subVmTest1-add-iface-source option[value={bridge}]")
 
+            if self.source_mode:
+                self.browser.click(f"#vm-subVmTest1-add-iface-source-mode-{self.source_mode}")
             if self.source:
                 self.browser.select_from_dropdown("#vm-subVmTest1-add-iface-source", self.source)
             if self.model:
@@ -770,6 +816,9 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
                                      self.machine.execute(xmllint_element.format(prop='source/@network')).strip())
             elif (self.source_type == "direct"):
                 self.assertEqual("direct", self.machine.execute(xmllint_element.format(prop='@type')).strip())
+                if self.source_mode:
+                    self.assertEqual(self.source_mode,
+                                     self.machine.execute(xmllint_element.format(prop='source/@mode')).strip())
                 if self.source:
                     self.assertEqual(self.source,
                                      self.machine.execute(xmllint_element.format(prop='source/@dev')).strip())
@@ -785,6 +834,8 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
                 self.browser.wait_in_text(f"#vm-subVmTest1-network-{self.nic_num}-model", self.model)
             if self.source:
                 self.browser.wait_in_text(f"#vm-subVmTest1-network-{self.nic_num}-source", self.source)
+            if self.source_mode:
+                self.browser.wait_in_text(f"#vm-subVmTest1-network-{self.nic_num}-source-mode", self.source_mode)
             if self.mac:
                 self.browser.wait_in_text(f"#vm-subVmTest1-network-{self.nic_num}-mac", self.mac)
 


### PR DESCRIPTION
Virtual functions from SR-IOV devices might require "passthrough" to work, so let's surface the mode property of directly attached devices fully.

See https://issues.redhat.com/browse/RHEL-88407