### PR TITLE
Log the libvirt error when state changes fail

### DIFF
--- a/src/components/common/stateIcon.tsx
+++ b/src/components/common/stateIcon.tsx
@@ -87,14 +87,16 @@ export const StateIcon = ({
         </Flex>
     );
 
-    if (error)
+    if (error) {
+        console.warn("virtual machine state error: ", error.text, error.detail);
         return (
             <Popover headerContent={error.text} bodyContent={error.detail} className="ct-popover-alert">
                 {label}
             </Popover>
         );
-    else
+    } else {
         return label;
+    }
 };
 
 export default StateIcon;

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -502,6 +502,7 @@ class TestMachinesSettings(machineslib.VirtualMachinesCase):
 
         # Add TPM to running VM
         b.click("#vm-subVmTest1-system-run")
+        print('should fail here')
         b.wait_in_text("#vm-subVmTest1-system-state", "Running")
         self.assertNotIn("tpm", m.execute("virsh dumpxml subVmTest1"))
         self.assertNotIn("tpm", m.execute("virsh dumpxml --inactive subVmTest1"))


### PR DESCRIPTION
For example for RHEL-10-1 in CI turning a machine off sometimes errors out without any details.

---

Issue is probably a random hard triggered:

```
Jun 02 03:29:28 rhel-10-1-127-0-0-2-2201 setroubleshoot[50308]: SELinux is preventing /usr/bin/swtpm from read access on the file /tmp/.swtpm_setup.pidfile.10HG72. For complete SELinux messages run: sealert -l ee0e4922-4767-4308-bbe3-6001dc7a887a
Jun 02 03:29:28 rhel-10-1-127-0-0-2-2201 setroubleshoot[50308]: SELinux is preventing /usr/bin/swtpm from read access on the file /tmp/.swtpm_setup.pidfile.10HG72.
                                                                
                                                                *****  Plugin catchall (100. confidence) suggests   **************************
                                                                
                                                                If you believe that swtpm should be allowed read access on the .swtpm_setup.pidfile.10HG72 file by default.
                                                                Then you should report this as a bug.
                                                                You can generate a local policy module to allow this access.
                                                                Do
                                                                allow this access for now by executing:
                                                                # ausearch -c 'swtpm' --raw | audit2allow -M my-swtpm
                                                                # semodule -X 300 -i my-swtpm.pp
```