### PR TITLE
nics: Fix listing of host interfaces via NetworkManager

### DIFF
--- a/src/components/vm/nics/vmNicsCard.tsx
+++ b/src/components/vm/nics/vmNicsCard.tsx
@@ -282,7 +282,7 @@ export class VmNetworkTab extends React.Component<VmNetworkTabProps, VmNetworkTa
         this.deviceProxyHandler = this.deviceProxyHandler.bind(this);
         this.getIpAddr = this.getIpAddr.bind(this);
         this.client = cockpit.dbus("org.freedesktop.NetworkManager");
-        const proxies = this.client.proxies("org.freedesktop.NetworkManager.Device");
+        const proxies = this.client.proxies("org.freedesktop.NetworkManager.Device", "/org/freedesktop");
         proxies.addEventListener('changed', this.deviceProxyHandler);
         proxies.addEventListener('removed', this.deviceProxyHandler);
         this.hostDevices = proxies as unknown as Record<string, NetworkManagerDeviceProxy>;

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -567,6 +567,9 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
                 f"#vm-subVmTest1-network-{self.nic_num}-source",
                 self.source if self.source and self.vm_state == "shut off" else self.source_current
             )
+            if self.source_type == "direct":
+                # The source should be a link
+                b.wait_visible(f"#vm-subVmTest1-network-{self.nic_num}-source button.pf-m-link")
             b.wait_in_text(
                 f"#vm-subVmTest1-network-{self.nic_num}-model",
                 self.model if self.model and self.vm_state == "shut off" else self.model_current


### PR DESCRIPTION
The Python bridge does not fall back to emulating a ObjectManager with introspection if it is told to watch a path namespace. So we need to get our proxies from the path where the NetworkManager has its object manager, which is "/org/freedesktop".

