### PR TITLE
test: Stop installing EOL CentOS 7

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -91,7 +91,7 @@ class TestMachinesCreate(machineslib.VirtualMachinesCase):
                                                             location=config.TREE_URL,
                                                             memory_size=128, memory_size_unit='MiB',
                                                             storage_pool=NO_STORAGE,
-                                                            os_name=config.CENTOS_7,
+                                                            os_name=config.RHEL_8_10,
                                                             create_and_run=False,
                                                             expected_os_name=config.FEDORA_28,
                                                             pixel_test_tag="auto"))
@@ -969,13 +969,11 @@ vnc_password= "{vnc_passwd}"
 
         FEDORA_29 = 'Fedora 29'
 
-        RHEL_8_1 = 'Red Hat Enterprise Linux 8.1 (Ootpa)'
-        RHEL_8_1_SHORTID = 'rhel8.1'
         RHEL_8_2 = 'Red Hat Enterprise Linux 8.2 (Ootpa)'
         RHEL_8_2_SHORTID = 'rhel8.2'
+        RHEL_8_10 = 'Red Hat Enterprise Linux 8.10 (Ootpa)'
+        RHEL_8_10_SHORTID = 'rhel8.10'
         RHEL_7_1 = 'Red Hat Enterprise Linux 7.1'
-
-        CENTOS_7 = 'CentOS 7'
 
     class VmDialog:
         vmId = 0
@@ -1230,7 +1228,7 @@ vnc_password= "{vnc_passwd}"
             b.set_input_text("#os-select-group input", "Red Hat")
 
             # Check only RHEL >= 8 is shown
-            b.wait_visible(f"#os-select li button:contains('{TestMachinesCreate.TestCreateConfig.RHEL_8_1}')")
+            b.wait_visible(f"#os-select li button:contains('{TestMachinesCreate.TestCreateConfig.RHEL_8_10}')")
             b.wait_not_present(f"#os-select li button:contains('{TestMachinesCreate.TestCreateConfig.RHEL_7_1}')")
             # make the select list go away to not obscure other elements
             b.click("#os-select-group button.pf-v6-c-menu-toggle__button")
@@ -1423,8 +1421,8 @@ vnc_password= "{vnc_passwd}"
             if self.expected_os_name:
                 b.wait_attr("#os-select-group input", "value", self.expected_os_name)
 
-            if self.sourceType == "os" and self.os_name in [TestMachinesCreate.TestCreateConfig.RHEL_8_1,
-                                                            TestMachinesCreate.TestCreateConfig.RHEL_8_2]:
+            if self.sourceType == "os" and self.os_name in [TestMachinesCreate.TestCreateConfig.RHEL_8_2,
+                                                            TestMachinesCreate.TestCreateConfig.RHEL_8_10]:
                 if not self.offline_token_autofilled:
                     b.set_input_text("#offline-token", self.offline_token)
                 b.wait_in_text("#offline-token", self.offline_token)
@@ -1746,7 +1744,7 @@ vnc_password= "{vnc_passwd}"
 
             final_state = "Running" if dialog.create_and_run else "Shut off"
             # Test downloading RHEL image shows the progress of the download
-            if dialog.os_name == TestMachinesCreate.TestCreateConfig.RHEL_8_1:
+            if dialog.os_name == TestMachinesCreate.TestCreateConfig.RHEL_8_10:
                 # Check download percentage is shown as a whole number 0-100 followed by '%'
                 if dialog.create_and_run:
                     b.wait_in_text(f"#vm-{dialog.name}-{dialog.connection}-state", "Downloading")
@@ -1878,7 +1876,7 @@ vnc_password= "{vnc_passwd}"
 
             # check disks
             # Test disk got imported/created
-            if dialog.sourceType == 'disk_image' or (dialog.os_name == TestMachinesCreate.TestCreateConfig.RHEL_8_1):
+            if dialog.sourceType == 'disk_image' or (dialog.os_name == TestMachinesCreate.TestCreateConfig.RHEL_8_10):
                 b.wait_visible(".disks-card table tbody:first-of-type")
                 if b.is_present(f"#vm-{name}-disks-vda-device"):
                     b.wait_in_text(f"#vm-{name}-disks-vda-source-file", dialog.location.strip())
@@ -2430,8 +2428,8 @@ vnc_password= "{vnc_passwd}"
         m.execute(f"qemu-img create {TestMachinesCreate.TestCreateConfig.VALID_DISK_IMAGE_PATH} 500M")
 
         runner.checkDialogInvalidOfflineToken(TestMachinesCreate.VmDialog(self, sourceType='os',
-                                                                          os_name=config.RHEL_8_1,
-                                                                          os_short_id=config.RHEL_8_1_SHORTID,
+                                                                          os_name=config.RHEL_8_10,
+                                                                          os_short_id=config.RHEL_8_10_SHORTID,
                                                                           offline_token="invalid_token",
                                                                           offline_token_autofilled=False,
                                                                           create_and_run=True),
@@ -2442,8 +2440,8 @@ vnc_password= "{vnc_passwd}"
         # Check create buttons do not get disabled when RHEL is selected for sourceType != 'os' (Download an OS)
         dialog = TestMachinesCreate.VmDialog(self, sourceType='url',
                                              location=config.VALID_URL,
-                                             os_name=config.RHEL_8_1,
-                                             os_short_id=config.RHEL_8_1_SHORTID) \
+                                             os_name=config.RHEL_8_10,
+                                             os_short_id=config.RHEL_8_10_SHORTID) \
             .open() \
             .fill()
         b.wait_visible(".pf-v6-c-modal-box__footer button:not([aria-disabled=false]):contains(Create and run)")
@@ -2460,25 +2458,25 @@ vnc_password= "{vnc_passwd}"
         self.allow_browser_errors("spawn 'vm creation' returned error:.*No image available for RHEL 8.2")
 
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='os',
-                                                      os_name=config.RHEL_8_1,
-                                                      os_short_id=config.RHEL_8_1_SHORTID,
+                                                      os_name=config.RHEL_8_10,
+                                                      os_short_id=config.RHEL_8_10_SHORTID,
                                                       offline_token="valid_token",
                                                       offline_token_autofilled=False,
                                                       create_and_run=False))
 
-        m.execute("rm /var/lib/libvirt/images/rhel-8-1-boot.iso")
+        m.execute("rm /var/lib/libvirt/images/rhel-8-10-boot.iso")
 
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='os',
-                                                      os_name=config.RHEL_8_1,
-                                                      os_short_id=config.RHEL_8_1_SHORTID,
+                                                      os_name=config.RHEL_8_10,
+                                                      os_short_id=config.RHEL_8_10_SHORTID,
                                                       offline_token="valid_token",
                                                       offline_token_autofilled=True,
                                                       create_and_run=True))
 
         # If run on different connection, the downloaded iso should be stored in ~/.local/share/libvirt/images/
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='os',
-                                                      os_name=config.RHEL_8_1,
-                                                      os_short_id=config.RHEL_8_1_SHORTID,
+                                                      os_name=config.RHEL_8_10,
+                                                      os_short_id=config.RHEL_8_10_SHORTID,
                                                       offline_token="valid_token",
                                                       create_and_run=True,
                                                       connection="session"),
@@ -2490,8 +2488,8 @@ vnc_password= "{vnc_passwd}"
         # Change token saved at localStorage to imitate expiration of a token
         b.call_js_func("localStorage.setItem", "rhsm-offline-token", "expired_token")
         runner.checkDialogInvalidOfflineToken(TestMachinesCreate.VmDialog(self, sourceType='os',
-                                                                          os_name=config.RHEL_8_1,
-                                                                          os_short_id=config.RHEL_8_1_SHORTID,
+                                                                          os_name=config.RHEL_8_10,
+                                                                          os_short_id=config.RHEL_8_10_SHORTID,
                                                                           offline_token_autofilled=True),
                                               "expired",
                                               False)

--- a/test/files/mock-rhsm-rest
+++ b/test/files/mock-rhsm-rest
@@ -26,13 +26,13 @@ class handler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         authorization = self.headers['Authorization']
-        m = self.match("/management/v1/images/rhel/8.1/.*")
+        m = self.match("/management/v1/images/rhel/8.10/.*")
 
         if m and authorization == 'Bearer my_access_token':
             self.send_response(200)
             self.end_headers()
             self.wfile.write(b'{ "body": [\
-                {"imageName": "RHEL 8.1 Boot ISO", "filename": "rhel-8-1-boot.iso",\
+                {"imageName": "RHEL 8.10 Boot ISO", "filename": "rhel-8-10-boot.iso",\
                 "downloadHref": "https://api.access.redhat.com/management/v1/images/my_image_checksum/download"}\
             ] }\n')
             return


### PR DESCRIPTION
In osinfo-db, CentOS 7 is marked as EOL on 2024-06-30. We still show EOL versions, but we didn't in the rhel-8 branch yet, and in general we should not rely on outdated OSes. Move the test to RHEL 8.10.

Similarly, RHEL 8.1 has been EOL for quite a while. Move everything to RHEL 8.10, which is supported for many years still.

---

Forward port of #2211. It's not broken on main, but probably better to keep them in sync.