### PR TITLE
libvirtApi: Use String() to turn error objects into text

### DIFF
--- a/src/libvirtApi/interface.ts
+++ b/src/libvirtApi/interface.ts
@@ -34,8 +34,7 @@ export async function interfaceGetAll(): Promise<void> {
         const ipData = await cockpit.spawn(["ip", "--json", "a"], { err: "message" });
         ifaces = JSON.parse(ipData);
     } catch (ex) {
-        if (ex instanceof Error)
-            console.warn("Failed to get interfaces with ip command:", ex.toString());
+        console.warn("Failed to get interfaces with ip command:", String(ex));
     }
 
     for (const iface of ifaces) {

--- a/src/libvirtApi/network.ts
+++ b/src/libvirtApi/network.ts
@@ -105,8 +105,7 @@ export async function networkGetAll({
         const [objPaths]: [string[]] = await call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'ListNetworks', [0], { timeout, type: 'u' });
         await Promise.all(objPaths.map(path => networkGet({ connectionName, id: path })));
     } catch (ex) {
-        if (ex instanceof Error)
-            console.warn('GET_ALL_NETWORKS action failed:', ex.toString());
+        console.warn('GET_ALL_NETWORKS action failed:', String(ex));
         throw ex;
     }
 }
@@ -148,8 +147,7 @@ export async function networkGet({
         const network = parseNetDumpxml(xml);
         store.dispatch(updateOrAddNetwork(Object.assign(props, network), !!updateOnly));
     } catch (ex) {
-        if (ex instanceof Error)
-            console.warn('GET_NETWORK action failed for path', objPath, ex.toString());
+        console.warn('GET_NETWORK action failed for path', objPath, String(ex));
     }
 }
 

--- a/src/libvirtApi/nodeDevice.ts
+++ b/src/libvirtApi/nodeDevice.ts
@@ -67,8 +67,7 @@ export async function nodeDeviceGet({
             store.dispatch(updateOrAddNodeDevice(deviceXmlObject));
         }
     } catch (ex) {
-        if (ex instanceof Error)
-            console.warn('GET_NODE_DEVICE action failed for path', objPath, ex.toString());
+        console.warn('GET_NODE_DEVICE action failed for path', objPath, String(ex));
     }
 }
 
@@ -87,8 +86,7 @@ export async function nodeDeviceGetAll({
             await Promise.all(objPathsChunked.map(path => nodeDeviceGet({ connectionName, id: path })));
         }
     } catch (ex) {
-        if (ex instanceof Error)
-            console.warn('GET_ALL_NODE_DEVICES action failed:', ex.toString());
+        console.warn('GET_ALL_NODE_DEVICES action failed:', String(ex));
         throw ex;
     }
 }

--- a/src/libvirtApi/snapshot.ts
+++ b/src/libvirtApi/snapshot.ts
@@ -137,12 +137,10 @@ export async function snapshotGetAll({
             snaps: snaps.sort((a, b) => Number(a.creationTime) - Number(b.creationTime))
         }));
     } catch (ex) {
-        if (ex instanceof Error) {
-            if (ex.name === 'org.freedesktop.DBus.Error.UnknownMethod')
-                logDebug("LIST_DOMAIN_SNAPSHOTS action failed for domain", domainPath, ", not supported by libvirt-dbus");
-            else
-                console.warn("LIST_DOMAIN_SNAPSHOTS action failed for domain", domainPath, ":", JSON.stringify(ex), "name:", ex.name);
-        }
+        if (ex && typeof ex === 'object' && 'name' in ex && ex.name === 'org.freedesktop.DBus.Error.UnknownMethod')
+            logDebug("LIST_DOMAIN_SNAPSHOTS action failed for domain", domainPath, ", not supported by libvirt-dbus");
+        else
+            console.warn("LIST_DOMAIN_SNAPSHOTS action failed for domain", domainPath, ":", String(ex));
         store.dispatch(updateDomainSnapshots({
             connectionName,
             domainPath,

--- a/src/libvirtApi/storagePool.ts
+++ b/src/libvirtApi/storagePool.ts
@@ -127,8 +127,7 @@ export async function storagePoolGet({
         }
         store.dispatch(updateOrAddStoragePool(Object.assign({}, dumpxmlParams, props), !!updateOnly));
     } catch (ex) {
-        if (ex instanceof Error)
-            console.warn('GET_STORAGE_POOL action failed for path', objPath, ex.toString());
+        console.warn('GET_STORAGE_POOL action failed for path', objPath, String(ex));
     }
 }
 
@@ -150,8 +149,7 @@ export async function storagePoolGetAll({
                 return storagePoolGet({ connectionName, id: path });
         }));
     } catch (ex) {
-        if (ex instanceof Error)
-            console.warn('GET_ALL_STORAGE_POOLS action failed:', ex.toString());
+        console.warn('GET_ALL_STORAGE_POOLS action failed:', String(ex));
         throw ex;
     }
 }
@@ -168,8 +166,7 @@ export async function storagePoolGetCapabilities({ connectionName } : { connecti
             });
         return parsePoolCapabilities(poolCapabilities);
     } catch (ex) {
-        if (ex instanceof Error)
-            console.warn('virsh pool-capabilities failed:', ex.toString());
+        console.warn('virsh pool-capabilities failed:', String(ex));
         throw ex;
     }
 }

--- a/src/libvirtApi/storageVolume.ts
+++ b/src/libvirtApi/storageVolume.ts
@@ -129,7 +129,6 @@ export async function storageVolumeGetAll({
                 .filter(vol => vol.status === 'fulfilled')
                 .map(vol => parseStorageVolumeDumpxml(connectionName, vol.value[0]));
     } catch (ex) {
-        if (ex instanceof Error)
-            console.warn("GET_STORAGE_VOLUMES action failed for pool", poolName, ":", ex.toString());
+        console.warn("GET_STORAGE_VOLUMES action failed for pool", poolName, ":", String(ex));
     }
 }


### PR DESCRIPTION
Checking whether they are an instance of "Error" was wrong. Our cockpit.ProcessError and the unexported DBusError are not derived from Error.

This was done with Cursor, using these prompts:

- Find places that use "instanceof Error" in a catch clause.

- In all these places, remove the "instanceof" check and use "String()" to safely convert the error to a string.

- There is an error in snapshot.ts, `ex.name` can not be replaced with "String()". Explicitly check whether the "name" field exists and keep the original comparison.