### PR TITLE
test: Wait longer for Alpine to boot

### DIFF
--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -437,7 +437,9 @@ fullscreen=0
         self.performAction("subVmTest1", "forceOff")
         assert_state("Start the virtual machine to access the console")
         self.performAction(name, "run")
-        testlib.wait(lambda: "Welcome to Alpine Linux" in b.text(f"#{name}-terminal .xterm-accessibility-tree"))
+        testlib.wait(lambda: ("Welcome to Alpine Linux" in
+                              b.text(f"#{name}-terminal .xterm-accessibility-tree")),
+                     delay=5)
 
     def testExpandedConsole(self):
         b = self.browser


### PR DESCRIPTION
The wait time was previoulsy increased for the first boot in this test, but not for the second one.

The failures this tries to fix look like this: https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-2015-f1c49f90-20250717-114922-rhel-8-10-ws-container/log.html#89