### PR TITLE
consoles: Enable fullscreen functionality

### DIFF
--- a/src/components/vm/consoles/consoles.css
+++ b/src/components/vm/consoles/consoles.css
@@ -36,6 +36,8 @@
 
     .vm-console-vnc {
         grid-area: main;
+        /* Overflow auto to enxure that larger sized VNC windows don't make it difficult with scrollbars */
+        overflow: auto;
     }
 
     .vm-console-serial {

--- a/src/components/vm/consoles/consoles.jsx
+++ b/src/components/vm/consoles/consoles.jsx
@@ -21,7 +21,7 @@ import cockpit from 'cockpit';
 import { StateObject } from './state';
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core/dist/esm/components/Card';
-import { ExpandIcon, CompressIcon } from "@patternfly/react-icons";
+import { ExpandIcon, CompressIcon, UnknownIcon } from "@patternfly/react-icons";
 import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core/dist/esm/components/ToggleGroup';
 import { Split, SplitItem } from "@patternfly/react-core/dist/esm/layouts/Split/index.js";
 
@@ -226,6 +226,32 @@ export const ConsoleCard = ({ state, vm, config, onAddErrorNotification, isExpan
             iconPosition="right">{isExpanded ? _("Compress") : _("Expand")}
         </Button>
     );
+
+    // Verify browser has fullscreen capability
+    if (document.fullscreenEnabled) {
+        actions.push(
+            <Button
+                id="vnc-fullscreen"
+                key="vnc-fullscreen"
+                variant="link"
+                onClick={() => {
+                    const isFullscreened = document.fullscreenElement;
+                    if (!isFullscreened) {
+                        document.getElementById("virtual-machines-page")?.requestFullscreen();
+                    } else {
+                        // Otherwise exit the full screen
+                        document.exitFullscreen?.();
+                    }
+                    const urlOptions = { name: vm.name, connection: vm.connectionName };
+                    const path = isFullscreened ? ["vm"] : ["vm", "console"];
+                    return cockpit.location.go(path, { ...cockpit.location.options, ...urlOptions });
+                }}
+                icon={document.fullscreenElement ? <UnknownIcon /> : <UnknownIcon />}
+                iconPosition="right">
+                {document.fullscreenElement ? _("Exit fullscreen") : _("Fullscreen")}
+            </Button>
+        );
+    }
 
     return (
         <Card


### PR DESCRIPTION
Having a way to fullscreen the VNC console would further improve the
usability of the VNC console. To start with this adds a fullscreen
button and makes sure that the VNC canvas doesn't cause the header to
wrap or disappear when scrollbars appear.

Fixes: #680
Related-to: https://issues.redhat.com/browse/COCKPIT-977
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
