### PR TITLE
console: Use a link for expanding the console card

### DIFF
--- a/src/components/vm/consoles/consoles.jsx
+++ b/src/components/vm/consoles/consoles.jsx
@@ -213,15 +213,19 @@ export const ConsoleCard = ({ state, vm, config, onAddErrorNotification, isExpan
         );
     }
 
+    const urlOptions = { name: vm.name, connection: vm.connectionName };
+    const path = isExpanded ? ["vm"] : ["vm", "console"];
+    const href = cockpit.location.encode(path, { ...cockpit.location.options, ...urlOptions });
+    const name_parts = window.name.split("/");
+    const parent_pathname = name_parts.length > 0 ? "/" + name_parts[name_parts.length - 1] : "";
+
     actions.push(
         <Button
             key="expand-compress"
             variant="link"
-            onClick={() => {
-                const urlOptions = { name: vm.name, connection: vm.connectionName };
-                const path = isExpanded ? ["vm"] : ["vm", "console"];
-                return cockpit.location.go(path, { ...cockpit.location.options, ...urlOptions });
-            }}
+            component="a"
+            href={parent_pathname + "#" + href}
+            target="_parent"
             icon={isExpanded ? <CompressIcon /> : <ExpandIcon />}
             iconPosition="right">{isExpanded ? _("Compress") : _("Expand")}
         </Button>


### PR DESCRIPTION
This allows people to easily open the expanded console in a new tab or new window, like they can with other links.

[COCKPIT-1297](https://issues.redhat.com/browse/COCKPIT-1297)