### PR TITLE
console: Allow detaching the console card into its own popup window

### DIFF
--- a/src/components/vm/consoles/VncConsole.jsx
+++ b/src/components/vm/consoles/VncConsole.jsx
@@ -55,6 +55,7 @@ export const VncConsole = ({
     repeaterID = '',
     vncLogging = 'warn',
     consoleContainerId,
+    onConnected = (element) => {},
     onDisconnected = () => {},
     onInitFailed,
     onSecurityFailure,
@@ -128,6 +129,7 @@ export const VncConsole = ({
         initLogging(vncLogging);
         try {
             connect();
+            onConnected(novncElem.current);
         } catch (e) {
             onInitFailed && onInitFailed(e);
             rfb.current = undefined;
@@ -138,7 +140,7 @@ export const VncConsole = ({
             removeEventListeners();
             rfb.current = undefined;
         };
-    }, [connect, onInitFailed, removeEventListeners, vncLogging]);
+    }, [connect, onInitFailed, onConnected, removeEventListeners, vncLogging]);
 
     const disconnect = () => {
         if (!rfb.current) {

--- a/src/components/vm/consoles/consoles.css
+++ b/src/components/vm/consoles/consoles.css
@@ -60,3 +60,33 @@
         overflow: auto;
     }
 }
+
+/* Standalone console
+ */
+
+.consoles-page-standalone {
+    block-size: 100%;
+    background: var(--pf-t--global--background--color--primary--default);
+
+    .consoles-card {
+        block-size: 100%;
+        border-radius: 0;
+    }
+
+    .consoles-card .pf-v6-c-card__header {
+        /* NOTE: The 8 pixels padding is hard coded into consoles.jsx as
+           well. It needs to be changed there as well if it is changed here.
+         */
+        padding-block-start: 8px !important;
+        padding-block-end: 8px !important;
+        padding-inline-start: 1rem !important;
+        padding-inline-end: 1rem !important;
+    }
+
+    .consoles-card .pf-v6-c-card__body {
+        padding-inline-start: 0;
+        padding-inline-end: 0;
+        padding-block-end: 0;
+        overflow: auto;
+    }
+}

--- a/src/components/vm/consoles/vnc.jsx
+++ b/src/components/vm/consoles/vnc.jsx
@@ -238,6 +238,7 @@ export const VncActiveActions = ({ state, vm, vnc, isExpanded, onAddErrorNotific
                 }
                 selected={state.sizeMode}
                 onSelect={val => state.setSizeMode(val)}
+                popperProps={{ position: "end" }}
             />
         );
     }
@@ -292,6 +293,7 @@ export const VncActiveActions = ({ state, vm, vnc, isExpanded, onAddErrorNotific
                     </MenuToggle>
                 )}
                 isOpen={isOpen}
+                popperProps={{ position: "end" }}
             >
                 <DropdownList>
                     {dropdownItems}

--- a/src/components/vm/vmDetailsPage.tsx
+++ b/src/components/vm/vmDetailsPage.tsx
@@ -124,6 +124,26 @@ export const VmDetailsPage = ({
         );
     }
 
+    if (cockpit.location.path[1] == "vnc") {
+        document.title = cockpit.format(_("$0 console"), vm.name);
+        return (
+            <WithDialogs key="vm-details">
+                <div
+                    id={"vm-" + vm.name + "-consoles-page"}
+                    className="consoles-page-standalone"
+                >
+                    <ConsoleCard
+                        state={consoleState}
+                        vm={vm}
+                        config={config}
+                        onAddErrorNotification={onAddErrorNotification}
+                        isStandalone
+                    />
+                </div>
+            </WithDialogs>
+        );
+    }
+
     interface CardContentCard {
         card: NonNullable<React.ReactNode>;
     }

--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -589,6 +589,60 @@ fullscreen=0
         b.wait_text("#vm-console-vnc-scaling", "Remote resizing")
         wait_widths(lambda remote, local, ui: remote == ui and local == ui)
 
+    def testDetached(self):
+        b = self.browser
+        m = self.machine
+
+        name = "subVmTest1"
+        self.createVm(name, graphics="vnc")
+
+        self.login_and_go("/machines")
+        self.waitPageInit()
+        self.waitVmRow(name)
+        self.goToVmPage(name)
+
+        b2 = self.new_browser()
+        cookie = b.cookie("cockpit")
+
+        initial_remote = 1280
+        if m.image in ["ubuntu-2204", "rhel-8-10"]:
+            initial_remote = 1024
+
+        with b.wait_timeout(60):
+            b.wait_attr(".vm-console-vnc canvas", "width", str(initial_remote))
+
+        href = b.attr(".consoles-card a:contains(Detach)", "href")
+        b.click(".consoles-card a:contains(Detach)")
+
+        # HACK - We can't control the new window that was opened by
+        # the click on "Detach" because of limitations in our
+        # testlib. So we open a second one explicitly with a new
+        # Browser instance. But there is a debug message that will
+        # tell us what the click on "Detach" has done.
+
+        def is_detach_message(msg):
+            return (msg.startswith("> debug: Detaching VNC: ") and
+                    href in msg and
+                    f"width={initial_remote}" in msg)
+
+        testlib.wait(lambda: any(is_detach_message(msg) for msg in b.get_js_log()))
+
+        b2.open("/cockpit/@localhost/machines/index.html" + href, cookie=cookie)
+        with b2.wait_timeout(60):
+            b2.wait_attr(".vm-console-vnc canvas", "width", str(initial_remote))
+
+        # Logging out should close both of the detached windows, the
+        # one in "b" from the click on "Detach", and the explicitly
+        # opened one in "b2".  We detect this by looking for another
+        # debug message.
+
+        b.logout()
+        testlib.wait(lambda: "> debug: Closing detached VNC" in b.get_js_log())
+        testlib.wait(lambda: "> debug: Closing detached VNC" in b2.get_js_log())
+
+        # cleanup expects self.browser to be logged in.
+        self.login_and_go("/machines")
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
Long and rambling demo: https://youtu.be/eqAaXCJc3e4
Short and sweet: https://youtu.be/Z9RyJn9f1go

Fixes: #965
Related: [COCKPIT-1235](https://issues.redhat.com/browse/COCKPIT-1235)

Followups:

 - Rewrite the whole thing as its own `machines/vnc` bundle.
 - Better support for multi-browser-window testing, including coverage.

----------------------

### Machines: The VNC console of a virtual machine can be detached

If expanding it is not enough, you can now also detach the VNC console of a virtual machine. This allows it to use almost all pixels of a browser window (or tab). The window can then of course be made fullscreen with browser controls to give (almost) all pixels of a monitor to the console. 
