### PR TITLE
consoles: Make a non-shared connection when asking remote to resize

### DIFF
--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -685,6 +685,32 @@ fullscreen=0
         with b2.wait_timeout(60):
             b2.wait_attr(".vm-console-vnc canvas", "width", str(initial_remote))
 
+        # The embedded console has been disconnected now, but we can
+        # connect again.
+
+        b.wait_in_text(".consoles-card", "Disconnected")
+        b.click('.consoles-card button:contains("Connect")')
+        b.wait_visible(".vm-console-vnc canvas")
+
+        # But if we switch the detached console into "Remote
+        # resizing", the embedded one will be disconnected again
+        # because the detached now uses a non-shared connection. (On
+        # images that have the necessary cockpit-ws fix.)
+
+        b2.select_PF("#vm-console-vnc-scaling", "Remote resizing")
+
+        if not m.image.startswith(("rhel-9", "centos-9", "ubuntu-", "debian-trixie", "opensuse-tumbleweed")):
+            # Cockpit will make a non-shared connection.  The embedded
+            # console will be forcefully disconnected.
+            b.wait_in_text(".consoles-card", "Disconnected")
+        else:
+            # If Cockpit doesn't make a non-shared connection, check
+            # that we can re-connect.
+            b.click('.consoles-card button:contains("Disconnect")')
+            b.wait_in_text(".consoles-card", "Disconnected")
+            b.click('.consoles-card button:contains("Connect")')
+            b.wait_visible(".vm-console-vnc canvas")
+
         # Logging out should close both of the detached windows, the
         # one in "b" from the click on "Detach", and the explicitly
         # opened one in "b2".  We detect this by looking for another


### PR DESCRIPTION
It doesn't feel like a good idea to let multiple clients each try to resize the remote end.

This also gives us a easy way to make non-shared connections in our tests, which we will use in the future.

- [x] Fix the bug that keeps vnc connections open until the session ends. I think the novnc websocket connection is correctly closed, must be something in the bridge. Was in ws: https://github.com/cockpit-project/cockpit/pull/22310
- [x] https://github.com/cockpit-project/cockpit/pull/22376
- [x] Tests
- [x] Wait for #22376 to be released into at least one of our images.

-----

### Machines: Cockpit can make exclusive VNC connections

A VNC viewer can tell the VNC server whether or not it wants exclusive access to it, or whether it is okay that multiple viewers display and interact with the same console. Until now, Cockpit has always allowed shared access when it connects.

Now, Cockpit will request exclusive access when it is in the "Remote resizing" mode, to avoid having multiple viewers make conflicting resize requests.

The feature requires the web server from Cockpit 346.
