### PR TITLE
force ASCII output for `virt-host-validate`

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -103,7 +103,7 @@ export const App = () => {
         (async () => {
             try {
                 const hardwareVirtCheck = await cockpit.script(
-                    "virt-host-validate qemu | grep 'Checking for hardware virtualization'");
+                    "LANG=C.UTF-8 virt-host-validate qemu | grep 'Checking for hardware virtualization'");
                 setVirtualizationEnabled(hardwareVirtCheck.includes('PASS'));
             } catch (ex) {
                 // That line doesn't exist on some architectures, so the grep may fail


### PR DESCRIPTION
I use `zh_CN.UTF-8` as my computer's locale, which makes the output of `virt-host-validate` look like

```
QEMU: Checking for hardware virtualization                                 : 通过
```

instead of

```
QEMU: Checking for hardware virtualization                                 : PASS
```

This prevents cockpit-machine from passing the hardware virtualization support check. So we should set `LANG=C.UTF-8` to ensure `virt-host-validate` outputs in ASCII, making the 'grep' check for hardware virtualization reliable regardless of system locale.