### PR TITLE
test: Remove mention of debian-stable

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -2308,9 +2308,6 @@ vnc_password= "{vnc_passwd}"
 
         self.allow_browser_errors("Failed when connecting: Connection closed")
         self.allow_journal_messages(".* couldn't shutdown fd: Transport endpoint is not connected")
-        # https://launchpad.net/bugs/1968187
-        if m.image == 'debian-stable':
-            self.allow_journal_messages('.*apparmor="DENIED".*name="/etc/ssl/openssl.cnf".*comm="swtpm".*')
 
     def testConfigureBeforeInstallBios(self):
         TestMachinesCreate.CreateVmRunner(self)
@@ -2423,10 +2420,6 @@ vnc_password= "{vnc_passwd}"
         # Install the VM
         b.click(f"#vm-{vmName}-system-install")
         b.wait_in_text(f"#vm-{vmName}-system-state", "Running")
-
-        # https://launchpad.net/bugs/1968187
-        if m.image == 'debian-stable':
-            self.allow_journal_messages('.*apparmor="DENIED".*name="/etc/ssl/openssl.cnf".*comm="swtpm".*')
 
     def testCreateDownloadRhel(self):
         runner = TestMachinesCreate.CreateVmRunner(self, rhel_download=True)

--- a/test/check-machines-manifest
+++ b/test/check-machines-manifest
@@ -33,7 +33,7 @@ class TestMachinesManifest(testlib.MachineCase):
         b.wait_in_text("#host-apps .pf-m-current", "Overview")
 
         # Cockpit with a C bridge
-        if m.image == "debian-stable" or m.image == "ubuntu-2204":
+        if m.image == "ubuntu-2204":
             self.assertIn("Virtual machines", b.text("#host-apps"))
         else:
             self.assertNotIn("Virtual machines", b.text("#host-apps"))

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -377,7 +377,7 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
 
         # Because of bug in debian-testing, attachment of virtio vNICs after restarting VM will fail
         # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1005284
-        if m.image not in ["debian-stable", "debian-testing"]:
+        if m.image not in ["debian-testing"]:
             # Test permanent attachment to running VM
             mac_address = self.get_next_mac(mac_address)
             self.NICAddDialog(

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -783,7 +783,7 @@ class TestMachinesSettings(machineslib.VirtualMachinesCase):
 
         m.execute("virsh destroy subVmTest1; virsh undefine subVmTest1")
         args = self.createVm("subVmTest1", os="linux2022")
-        has_watchdog = m.image not in ["debian-stable", "ubuntu-2204", "rhel-8-10"]
+        has_watchdog = m.image not in ["ubuntu-2204", "rhel-8-10"]
 
         self.goToVmPage("subVmTest1")
         if has_watchdog:
@@ -957,7 +957,7 @@ class TestMachinesSettings(machineslib.VirtualMachinesCase):
 
         # Because of bug in Debian, hotplug of vsock device fails
         # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1033872
-        if m.image not in ["debian-testing", "debian-stable", "debian-trixie"]:
+        if m.image not in ["debian-testing", "debian-trixie"]:
             # Test configuring vsock for running VM
             setVsockLive(new_auto=False, new_address="5")
             setVsockLive(new_auto=True, previous_auto=False, previous_address="5", reboot_machine=True)

--- a/test/check-machines-snapshots
+++ b/test/check-machines-snapshots
@@ -36,7 +36,7 @@ def supportsExternalSnapshots(image):
     # external memory snapshots introduced in libvirt 9.9.0
     return not (
         image.startswith("rhel-8") or
-        image in ["debian-stable", "ubuntu-2204"])
+        image in ["ubuntu-2204"])
 
 
 @testlib.nondestructive


### PR DESCRIPTION
It has been replaced by "debian-trixie".