### PR TITLE
api: Preserve passwords when updating domain XML

### DIFF
--- a/src/libvirtApi/domain.ts
+++ b/src/libvirtApi/domain.ts
@@ -339,7 +339,7 @@ export async function domainChangeBootOrder({
     connectionName: ConnectionName,
     devices: BootOrderDevice[],
 }): Promise<void> {
-    const [domXml] = await call<[string]>(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_INACTIVE], { timeout, type: 'u' });
+    const [domXml] = await call<[string]>(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_INACTIVE | Enum.VIR_DOMAIN_XML_SECURE], { timeout, type: 'u' });
     const updatedXML = updateBootOrder(domXml, devices);
     await call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'DomainDefineXML', [updatedXML], { timeout, type: 's' });
 }
@@ -1272,7 +1272,7 @@ export async function domainSetMaxMemory({
     connectionName: ConnectionName,
     maxMemory: number // in KiB
 }): Promise<void> {
-    const [domXml] = await call<[string]>(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [0], { timeout, type: 'u' });
+    const [domXml] = await call<[string]>(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_SECURE], { timeout, type: 'u' });
     const updatedXML = updateMaxMemory(domXml, maxMemory);
     await call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'DomainDefineXML', [updatedXML], { timeout, type: 's' });
 }
@@ -1286,7 +1286,7 @@ export async function domainSetOSFirmware({
     objPath: string,
     loaderType: optString;
 }): Promise<void> {
-    const [domXml] = await call<[string]>(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_INACTIVE], { timeout, type: 'u' });
+    const [domXml] = await call<[string]>(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_INACTIVE | Enum.VIR_DOMAIN_XML_SECURE], { timeout, type: 'u' });
     const s = new XMLSerializer();
     const doc = getDoc(domXml);
     const domainElem = doc.firstElementChild;
@@ -1430,7 +1430,7 @@ export async function domainUpdateDiskAttributes({
     existingTargets: string[],
     cache: optString,
 }): Promise<void> {
-    const [domXml] = await call<[string]>(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_INACTIVE], { timeout, type: 'u' });
+    const [domXml] = await call<[string]>(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_INACTIVE | Enum.VIR_DOMAIN_XML_SECURE], { timeout, type: 'u' });
     const updatedXML = updateDisk({ diskTarget: target, domXml, readonly, shareable, busType, existingTargets, cache });
     await call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'DomainDefineXML', [updatedXML], { timeout, type: 's' });
 }
@@ -1444,7 +1444,7 @@ export async function domainReplaceSpice({
 }): Promise<void> {
     /* Ideally this would be done by virt-xml, but it doesn't offer that functionality yet
      * see https://issues.redhat.com/browse/RHEL-17436 */
-    const [domXML] = await call<[string]>(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_INACTIVE], { timeout, type: 'u' });
+    const [domXML] = await call<[string]>(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_INACTIVE | Enum.VIR_DOMAIN_XML_SECURE], { timeout, type: 'u' });
     const updatedXML = replaceSpice(domXML);
 
     // check that updatedXML is valid; if not, throw; it needs to be updated manually

--- a/test/check-machines-settings
+++ b/test/check-machines-settings
@@ -976,6 +976,46 @@ class TestMachinesSettings(machineslib.VirtualMachinesCase):
             b.mouse("#vsock-dialog-apply", "mouseenter")
             b.wait_visible("#vsock-live-edit-tooltip")
 
+    def testBootOrderPreservesPasswords(self):
+        """Test that changing boot order preserves sensitive data like VNC passwords in domain XML"""
+        b = self.browser
+        m = self.machine
+
+        # Create a VM
+        self.createVm("bootOrderTestVM", graphics="vnc", running=False)
+
+        # Add VNC with password using virt-xml
+        vnc_password = "secret12"
+        m.execute(f"virt-xml bootOrderTestVM --edit --graphics vnc,passwd={vnc_password}")
+
+        # Verify the VNC password is present
+        original_xml = m.execute("virsh dumpxml bootOrderTestVM --security-info")
+        self.assertIn(vnc_password, original_xml)
+
+        self.login_and_go("/machines")
+        self.waitPageInit()
+        self.waitVmRow("bootOrderTestVM")
+
+        # Go to VM page
+        self.goToVmPage("bootOrderTestVM")
+
+        # Get current boot order
+        bootOrder = b.text("#vm-bootOrderTestVM-boot-order")
+
+        # Open boot order dialog and make a change
+        b.click("#vm-bootOrderTestVM-boot-order button")
+        b.wait_visible("#vm-bootOrderTestVM-order-modal-window")
+        b.click("#vm-bootOrderTestVM-order-modal-device-row-0 #vm-bootOrderTestVM-order-modal-down")
+        b.click("#vm-bootOrderTestVM-order-modal-save")
+        b.wait_not_present("#vm-bootOrderTestVM-order-modal-window")
+
+        # Verify boot order changed (indicating the API call succeeded)
+        b.wait_not_in_text("#vm-bootOrderTestVM-boot-order", bootOrder)
+
+        # Verify that VNC password is still present in the XML
+        updated_xml = m.execute("virsh dumpxml bootOrderTestVM --security-info")
+        self.assertIn(vnc_password, updated_xml, "VNC password should be preserved after boot order change")
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
Add VIR_DOMAIN_XML_SECURE flag to GetXMLDesc calls that modify XML before calling DomainDefineXML to ensure sensitive data like passwords are preserved during domain updates.

🤖 Generated with [Claude Code](https://claude.ai/code) for $2.04