### PR TITLE
networks: Fix spacing of helper text in "Create" dialog

### DIFF
--- a/src/components/networks/createNetworkDialog.tsx
+++ b/src/components/networks/createNetworkDialog.tsx
@@ -258,7 +258,7 @@ const IpRow = ({
     validationFailed: ValidationFailed,
 }) => {
     return (
-        <FormGroup fieldId='create-network-ip-configuration' label={_("IP configuration")} isStack>
+        <FormGroup fieldId='create-network-ip-configuration' label={_("IP configuration")}>
             <FormSelect id='create-network-ip-configuration'
                         value={dialogValues.ip}
                         onChange={(_event, value) => onValueChanged('ip', value)}>


### PR DESCRIPTION
The "IP configuration" FormGroup had the isStack property set, which in turn would change the top margin of FormHelperText inside that FormGroup from 4 pixels to -4 pixels.

The isStack property does not seem to have any other effect, so let's remove it.

Fixes: #1164