### PR TITLE
details: Simplify empty state texts

### DIFF
--- a/src/components/vm/disks/vmDisksCard.tsx
+++ b/src/components/vm/disks/vmDisksCard.tsx
@@ -291,7 +291,7 @@ export const VmDisksCard = ({
     return (
         <ListingTable variant='compact'
                 gridBreakPoint='grid-lg'
-                emptyCaption={_("No disks defined for this VM")}
+                emptyCaption={_("No disks")}
                 aria-label={`VM ${vm.name} Disks`}
                 columns={columnTitles}
                 rows={rows} />

--- a/src/components/vm/filesystems/vmFilesystemsCard.tsx
+++ b/src/components/vm/filesystems/vmFilesystemsCard.tsx
@@ -100,7 +100,7 @@ export const VmFilesystemsCard = ({
     return (
         <ListingTable variant='compact'
                           gridBreakPoint='grid-lg'
-                          emptyCaption={_("No directories shared between the host and this VM")}
+                          emptyCaption={_("No shared directories")}
                           columns={columnTitles}
                           rows={rows} />
     );

--- a/src/components/vm/hostdevs/hostDevCard.tsx
+++ b/src/components/vm/hostdevs/hostDevCard.tsx
@@ -328,7 +328,7 @@ export const VmHostDevCard = ({
         <ListingTable aria-label={cockpit.format(_("VM $0 Host Devices"), vm.name)}
                       gridBreakPoint='grid-lg'
                       variant='compact'
-                      emptyCaption={_("No host devices assigned to this VM")}
+                      emptyCaption={_("No host devices")}
                       rows={rows}
                       columns={columnTitles} />
     );

--- a/src/components/vm/nics/vmNicsCard.tsx
+++ b/src/components/vm/nics/vmNicsCard.tsx
@@ -650,7 +650,7 @@ export class VmNetworkTab extends React.Component<VmNetworkTabProps, VmNetworkTa
             <ListingTable aria-label={`VM ${vm.name} Network Interface Cards`}
                           gridBreakPoint='grid-lg'
                           variant='compact'
-                          emptyCaption={_("No network interfaces defined for this VM")}
+                          emptyCaption={_("No network interfaces")}
                           columns={columnTitles}
                           rows={rows} />
         );

--- a/src/components/vm/snapshots/vmSnapshotsCard.tsx
+++ b/src/components/vm/snapshots/vmSnapshotsCard.tsx
@@ -267,8 +267,8 @@ export class VmSnapshotsCard extends React.Component<VmSnapshotsCardProps> {
             <ListingTable aria-label={`VM ${vm.name} Snapshots Cards`}
                           gridBreakPoint='grid-lg'
                           variant="compact"
-                          emptyCaption={_("No snapshots defined for this VM")}
-                          emptyCaptionDetail={_("Previously taken snapshots allow you to revert to an earlier state if something goes wrong")}
+                          emptyCaption={_("No snapshots")}
+                          emptyCaptionDetail={_("Snapshots allow you to revert to an earlier state")}
                           columns={columnTitles}
                           rows={rows} />
         );

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1865,7 +1865,7 @@ class TestMachinesCreate(machineslib.VirtualMachinesCase):
                 else:
                     raise AssertionError("Unknown disk device")
             else:
-                b.wait_in_text(f"#vm-{name}-disks .pf-v6-c-empty-state", "No disks defined")
+                b.wait_in_text(f"#vm-{name}-disks .pf-v6-c-empty-state", "No disks")
                 b.click(f"#vm-{name}-disks-adddisk")
                 b.click(f"#vm-{name}-disks-adddisk-dialog-cancel")
 

--- a/test/check-machines-hostdevs
+++ b/test/check-machines-hostdevs
@@ -172,7 +172,7 @@ class TestMachinesHostDevs(machineslib.VirtualMachinesCase):
 
         self.goToVmPage("subVmTest1")
 
-        b.wait_in_text("#vm-subVmTest1-hostdevs .pf-v6-c-empty-state__body", "No host devices assigned to this VM")
+        b.wait_in_text("#vm-subVmTest1-hostdevs .pf-v6-c-empty-state__body", "No host devices")
 
         # Test hot plug of USB host device
         # A usb device might not always be present


### PR DESCRIPTION
Avoid the repetitive and redundant "for this VM" and use active voice for explaining snapshots.

Fixes: #764 