### PR TITLE
disks: Use correct domainstat property for the "Used" column

### DIFF
--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -284,7 +284,7 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         self.wait_for_disk_stats("subVmTest1", "vda")
         if b.is_present("#vm-subVmTest1-disks-vda-used"):
             b.wait_in_text("#vm-subVmTest1-disks-vda-used", "GiB")
-            self.assertRegex(b.text("#vm-subVmTest1-disks-vda-used"), r"^(0|0\.0|0\.01) GiB$")
+            self.assertRegex(b.text("#vm-subVmTest1-disks-vda-used"), r"^(0|0\.0|0\.09) GiB$")
 
         # Test add disk by external action
         m.execute("qemu-img create -f raw /var/lib/libvirt/images/image3.img 128M")


### PR DESCRIPTION
We want the actual space used in the host filesystem, as reported by "du".  This is either the "allocation" property or the "physical" property, depending on whether the VM is running or not.

Fixes #1423