### PR TITLE
nics: Don't render "0" when there are no IP addresses

### DIFF
--- a/src/components/vm/nics/vmNicsCard.tsx
+++ b/src/components/vm/nics/vmNicsCard.tsx
@@ -487,7 +487,7 @@ export class VmNetworkTab extends React.Component<VmNetworkTabProps, VmNetworkTa
 
                     return (
                         <DescriptionList isHorizontal isFluid>
-                            {inetIps.length && <DescriptionListGroup>
+                            {inetIps.length > 0 && <DescriptionListGroup>
                                 {inetIps.map((ip, index) => (
                                     <React.Fragment key={ip.ip}>
                                         <DescriptionListTerm>
@@ -499,7 +499,7 @@ export class VmNetworkTab extends React.Component<VmNetworkTabProps, VmNetworkTa
                                     </React.Fragment>
                                 ))}
                             </DescriptionListGroup>}
-                            {inet6Ips.length && <DescriptionListGroup>
+                            {inet6Ips.length > 0 && <DescriptionListGroup>
                                 {inet6Ips.map((ip, index) => (
                                     <React.Fragment key={ip.ip}>
                                         <DescriptionListTerm>


### PR DESCRIPTION
We render "Unknown" when there are no IP addresses of any IP version, but if there are IPv4 addresses but no IPv6 addresses, the code for the IPv6 addresses would render a "0". (And the other way around.)