### PR TITLE
consoles: Measure the card robustly

### DIFF
--- a/src/components/vm/consoles/consoles.tsx
+++ b/src/components/vm/consoles/consoles.tsx
@@ -197,6 +197,21 @@ export const ConsoleCard = ({
 
     add_console_selector("graphical", _("Graphical"));
 
+    function get_card_element(selector: string) {
+        let element;
+
+        try {
+            element = document.getElementById(`${vmId(vm.name)}-consoles`)?.querySelector(selector);
+            if (!element)
+                console.error("Can't find card element:", selector);
+        } catch (e) {
+            element = null;
+            console.error("Error looking for card element:", selector, String(e));
+        }
+
+        return element;
+    }
+
     if (type == "graphical") {
         if (vm.state != "running") {
             if (!inactive_vnc && !inactive_spice) {
@@ -231,13 +246,15 @@ export const ConsoleCard = ({
                                 return;
                             lastVncRemoteSize.current = [w, h];
                             if (isStandalone && mode == "none") {
-                                // First we guess the height of the
-                                // header (53px), and then we measure
-                                // it.
-                                let header_height = 53;
-                                const title = document.querySelector(`#${vmId(vm.name)}-consoles .pf-v6-c-card__header`);
+                                // If we can't measure the height, we
+                                // guess it to be 53px, which is what
+                                // it currently is.
+                                let header_height;
+                                const title = get_card_element(".pf-v6-c-card__header");
                                 if (title && title instanceof HTMLElement)
                                     header_height = title.offsetHeight;
+                                else
+                                    header_height = 53;
                                 const delta_width = window.outerWidth - window.innerWidth;
                                 const delta_height = window.outerHeight - window.innerHeight;
                                 window.resizeTo(w + delta_width, h + header_height + delta_height);
@@ -341,12 +358,15 @@ export const ConsoleCard = ({
                 component="a"
                 href={href}
                 onClick={(event) => {
-                    let header_height = 53;
-                    const title = document.querySelector(`#${vmId(vm.name)}-consoles .pf-v6-c-card__header-main`);
+                    event.preventDefault();
+
+                    let header_height;
+                    const title = get_card_element(".pf-v6-c-card__header-main");
                     if (title && title instanceof HTMLElement) {
                         // The 8 below is the padding of the expanded version and fixed in consoles.css
                         header_height = 8 + title.offsetHeight + 8;
-                    }
+                    } else
+                        header_height = 53;
                     const sz = lastVncRemoteSize.current;
                     const options = `popup,width=${sz[0]},height=${sz[1] + header_height}`;
                     console.debug("Detaching VNC:", href, options);
@@ -354,8 +374,6 @@ export const ConsoleCard = ({
 
                     if (body_state)
                         body_state.setConnected(false);
-
-                    event.preventDefault();
                 }}
                 icon={<ExternalLinkAltIcon />}
                 iconPosition="right">{_("Detach")}

--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -647,7 +647,10 @@ fullscreen=0
         b = self.browser
         m = self.machine
 
-        name = "subVmTest1"
+        # We use a name with funny characters to test that this
+        # doesn't trip up anything.
+
+        name = "subVm#Test.1"
         self.createVm(name, graphics="vnc")
 
         self.login_and_go("/machines")


### PR DESCRIPTION
The code for measuring the card header was brittle and would build invalid CSS selectors for VM names that contain funny characters such as ".".  This would then crash and open the URL for the detached console inside the iframe.

Let's do this more robustly by using getElementId and catching exceptions.

Also, let's move the `preventDefault` call to the beginning of the event handler so that nothing happens when the rest of the handler crashes.