### PR TITLE
nics: Support PASST user mode backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,4 +103,4 @@ ignore_names = [
 
 [tool.codespell]
 skip = './node_modules,./dist'
-ignore-words-list = 'doubleclick,medias'
+ignore-words-list = 'doubleclick,medias,passt'

--- a/src/components/common/needsShutdown.tsx
+++ b/src/components/common/needsShutdown.tsx
@@ -81,6 +81,20 @@ export function needsShutdownIfaceSourceMode(vm: VM, iface: VMInterface) {
         inactiveIface.source.mode !== iface.source.mode;
 }
 
+export function needsShutdownIfaceBackend(vm: VM, iface: VMInterface) {
+    const inactiveIface = nicLookupByMAC(vm.inactiveXML.interfaces, iface.mac);
+
+    return inactiveIface && inactiveIface.type == "user" && iface.type == "user" &&
+        inactiveIface.backend !== iface.backend;
+}
+
+export function needsShutdownIfacePortForward(vm: VM, iface: VMInterface) {
+    const inactiveIface = nicLookupByMAC(vm.inactiveXML.interfaces, iface.mac);
+
+    return inactiveIface && inactiveIface.type == "user" && iface.type == "user" &&
+        JSON.stringify(inactiveIface.portForward) !== JSON.stringify(iface.portForward);
+}
+
 export function needsShutdownVcpu(vm: VM) {
     return ((vm.vcpus.count !== vm.inactiveXML.vcpus.count) ||
             (vm.vcpus.max !== vm.inactiveXML.vcpus.max) ||
@@ -179,7 +193,9 @@ export function getDevicesRequiringShutdown(vm: VM) {
         if (needsShutdownIfaceType(vm, iface) ||
             needsShutdownIfaceModel(vm, iface) ||
             needsShutdownIfaceSource(vm, iface) ||
-            needsShutdownIfaceSourceMode(vm, iface)) {
+            needsShutdownIfaceSourceMode(vm, iface) ||
+            needsShutdownIfaceBackend(vm, iface) ||
+            needsShutdownIfacePortForward(vm, iface)) {
             devices.push(_("Network interface"));
             break;
         }

--- a/src/components/vm/nics/nic.css
+++ b/src/components/vm/nics/nic.css
@@ -6,3 +6,51 @@
 .nic-add-mac-setting-manual {
   margin-block-start: var(--pf-t--global--spacer--md);
 }
+
+
+.nic-dynamic-form-group {
+    .pf-v6-c-empty-state {
+        padding: 0;
+    }
+
+    .pf-v6-c-form__label {
+        /* Don't allow labels to wrap */
+        white-space: nowrap;
+    }
+
+    .remove-button-group {
+        /* Move 'Remove' button the the end of the row */
+        grid-column: -1;
+
+        /* Align it with the other form fields, starting at the top. This
+           allows for helper text to appear below the fields. */
+        display: flex;
+        flex-direction: row;
+        align-items: flex-start;
+
+        button {
+            margin-block-start: calc(var(--pf-v6-c-form__label--LineHeight) * var(--pf-v6-c-form__label--FontSize) + var(--pf-v6-c-form__group--Gap) + var(--pf-t--global--spacer--xs));
+        }
+    }
+
+    /* Set check to the same height as input widgets and vertically align */
+    .pf-v6-c-form__group-control > .pf-v6-c-check {
+        /* Set height to the same as inputs
+         * Font height is font size * line height (1rem * 1.5)
+         * Widgets have 5px padding, 1px border (top & bottom): (5 + 1) * 2 = 12
+         * This all equals to 36px
+         */
+        block-size: calc(var(--pf-t--global--font--size--md) * var(--pf-t--global--font--line-height--body) + 12px);
+        align-content: center;
+    }
+
+    /* We use FormFieldGroup PF component for the nested look and for ability to add buttons to the header
+     * However we want to save space and not add indent to the left so we need to override it
+     */
+    .pf-v6-c-form__field-group-body {
+        /* Stretch content fully */
+        --pf-v6-c-form__field-group-body--GridColumn: 1 / -1;
+        /* Reduce padding at the top */
+        --pf-v6-c-form__field-group-body--PaddingTop: var(--pf-t--global--spacer--xs);
+    }
+}

--- a/src/components/vm/nics/nicBody.tsx
+++ b/src/components/vm/nics/nicBody.tsx
@@ -19,34 +19,67 @@
 
 import React from 'react';
 
-import type { optString, ConnectionName } from '../../../types';
+import * as ipaddr from "ipaddr.js";
+
+import type { optString, VM, VMInterfacePortForward } from '../../../types';
 import type { AvailableSources } from './vmNicsCard';
 
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { EmptyState, EmptyStateBody } from "@patternfly/react-core/dist/esm/components/EmptyState";
 import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex";
-import { FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
+import { FormGroup, FormFieldGroup, FormFieldGroupHeader } from "@patternfly/react-core/dist/esm/components/Form";
 import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
 import { Radio } from "@patternfly/react-core/dist/esm/components/Radio";
 import { PopoverPosition } from "@patternfly/react-core/dist/esm/components/Popover";
 import { Content, ContentVariants } from "@patternfly/react-core/dist/esm/components/Content";
-import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
+import { ExternalLinkSquareAltIcon, TrashIcon } from '@patternfly/react-icons';
+import { Grid } from "@patternfly/react-core/dist/esm/layouts/Grid";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 
 import { InfoPopover } from '../../common/infoPopover.jsx';
 
 import cockpit from 'cockpit';
+import { FormHelper } from "cockpit-components-form-helper";
 
 import './nic.css';
 
 const _ = cockpit.gettext;
+
+export interface DialogComplexPortForward {
+    kind: "complex";
+    config: VMInterfacePortForward;
+}
+
+export interface DialogSimplePortForward {
+    kind: "simple";
+    address: string;
+    proto: string;
+    host: string;
+    guest: string;
+}
+
+interface ValidationSimplePortForward {
+    address: string | undefined;
+    host: string | undefined;
+    guest: string | undefined;
+}
+
+type DialogPortForward = DialogSimplePortForward | DialogComplexPortForward;
+type ValidationPortForward = ValidationSimplePortForward;
 
 export interface DialogBodyValues {
     networkModel: string;
     networkType: string;
     networkSource: string;
     networkSourceMode: string;
+    portForwards: DialogPortForward[];
 }
 
 type OnValueChanged = <K extends keyof DialogBodyValues>(key: K, value: DialogBodyValues[K]) => void;
+
+export interface ValidationBody {
+    portForwards: (ValidationPortForward | undefined)[];
+}
 
 export const NetworkModelRow = ({
     idPrefix,
@@ -90,15 +123,15 @@ export const NetworkModelRow = ({
 };
 
 export const NetworkTypeAndSourceRow = ({
+    vm,
     idPrefix,
     onValueChanged,
     dialogValues,
-    connectionName
 } : {
+    vm: VM,
     idPrefix: string,
     onValueChanged: OnValueChanged,
     dialogValues: DialogBodyValues & { availableSources: AvailableSources },
-    connectionName: ConnectionName,
 }) => {
     interface NetworkTypeDescription {
         name: string,
@@ -122,7 +155,7 @@ export const NetworkTypeAndSourceRow = ({
         detailHeadline: _("This is the recommended type for general guest connectivity on hosts with dynamic / wireless networking configs."),
         detailParagraph: _("Provides a connection whose details are described by the named network definition.")
     }];
-    if (connectionName !== 'session') {
+    if (vm.connectionName !== 'session') {
         availableNetworkTypes = [
             ...virtualNetwork,
             {
@@ -271,3 +304,364 @@ export const NetworkTypeAndSourceRow = ({
         </>
     );
 };
+
+export function portForwardText(pf: VMInterfacePortForward): string {
+    let text = "";
+
+    if (pf.address)
+        text += pf.address + ":";
+    if (pf.dev)
+        text += pf.dev + ":";
+    if (!pf.range.some(r => r.exclude != "yes"))
+        text += _("all");
+    for (let i = 0; i < pf.range.length; i++) {
+        const r = pf.range[i];
+        if (i > 0)
+            text += ",";
+        if (r.exclude == "yes")
+            text += _(" excluding ");
+        text += r.start;
+        if (r.end)
+            text += "-" + r.end;
+        if (!r.exclude)
+            text += " → " + (r.to || r.start) + (r.end ? "-" + (Number(r.to || r.start) + Number(r.end) - Number(r.start)).toString() : "");
+    }
+    text += "/" + pf.proto;
+
+    return text;
+}
+
+export function interfacePortForwardsToDialog(portForwards: VMInterfacePortForward[]): DialogPortForward[] {
+    return portForwards.map(pf => {
+        if (!pf.dev && pf.range.length == 1 && pf.range[0].exclude != "yes") {
+            const r = pf.range[0];
+            return {
+                kind: "simple",
+                address: pf.address || "",
+                proto: pf.proto || "",
+                host: r.start + (r.end ? "-" + r.end : ""),
+                guest: r.to || "",
+            };
+        } else {
+            return {
+                kind: "complex",
+                config: pf,
+            };
+        }
+    });
+}
+
+export function dialogPortForwardsToInterface(portForwards: DialogPortForward[]): VMInterfacePortForward[] {
+    // NOTE: We have to set every field here, none of them can be
+    // "null". Our return value is passed to virt-xml, and we want
+    // virt-xml to set everything and not leave anything behind from
+    // the previous portForward XML element.
+    return portForwards.map((pf: DialogPortForward) => {
+        if (pf.kind == "simple") {
+            const range = pf.host.split("-");
+            return {
+                address: pf.address,
+                dev: "",
+                proto: pf.proto,
+                range: [
+                    {
+                        start: range[0],
+                        end: range[1] || "",
+                        to: pf.guest,
+                        exclude: "",
+                    }
+                ],
+            };
+        } else {
+            return pf.config;
+        }
+    });
+}
+
+function validateAddress(addr: string): string | undefined {
+    if (addr && !ipaddr.isValid(addr))
+        return _("Invalid IP address");
+    return undefined;
+}
+
+function validatePort(port: string): string | undefined {
+    const p = Number(port);
+    if (isNaN(p))
+        return _("Port must be a number.");
+    if (p <= 0 || p > 65535)
+        return _("Port must be 1 to 65535.");
+    return undefined;
+}
+
+function validateHostPort(port: string): string | undefined {
+    if (!port)
+        return _("Host port can not be empty.");
+    const parts = port.split("-");
+    return validatePort(parts[0]) || (parts[1] && validatePort(parts[1]));
+}
+
+function validateGuestPort(port: string): string | undefined {
+    if (port)
+        return validatePort(port);
+    return undefined;
+}
+
+function validateDialogPortForward(d: DialogPortForward): ValidationPortForward | undefined {
+    if (d.kind == "simple") {
+        const v: ValidationPortForward = {
+            address: validateAddress(d.address),
+            host: validateHostPort(d.host),
+            guest: validateGuestPort(d.guest),
+        };
+        if (!v.address && !v.host && !v.guest)
+            return undefined;
+        return v;
+    } else
+        return undefined;
+}
+
+const SimplePortForward = ({
+    id,
+    item,
+    validation,
+    onChange,
+    idx,
+    removeitem,
+} : {
+    id: string,
+    item: DialogSimplePortForward,
+    validation: ValidationSimplePortForward | undefined,
+    onChange: <K extends keyof DialogSimplePortForward>(idx: number, key: K, value: DialogSimplePortForward[K]) => void,
+    idx: number,
+    removeitem: (idx: number) => void,
+}) => {
+    return (
+        <Grid hasGutter id={id}>
+            <FormGroup className="pf-m-3-col-on-md"
+                id={id + "-ip-address-group"}
+                label={_("IP address")}
+                fieldId={id + "-ip-address"}
+                labelHelp={
+                    <InfoPopover
+                        aria-label={_("IP address help")}
+                        enableFlip
+                        bodyContent={_("If host IP is set to 0.0.0.0 or not set at all, the port will be bound on all IPs on the host.")}
+                    />
+                }>
+                <TextInput
+                    id={id + "-ip-address"}
+                    value={item.address}
+                    onChange={(_event, value) => {
+                        onChange(idx, 'address', value);
+                    }}
+                />
+                <FormHelper helperTextInvalid={validation?.address} />
+            </FormGroup>
+            <FormGroup
+                className="pf-m-4-col-on-md"
+                id={id + "-host-port-group"}
+                label={_("Host port")}
+                fieldId={id + "-host-port"}
+                isRequired
+                labelHelp={
+                    <InfoPopover
+                        aria-label={_("Host port help")}
+                        enableFlip
+                        bodyContent={_("The port on the host that is fotwarded into the guest. You can also specify a range of ports like 4000-4050.")}
+                    />
+                }>
+                <TextInput
+                    id={id + "-host-port"}
+                    step={1}
+                    value={item.host}
+                    onChange={(_event, value) => {
+                        onChange(idx, 'host', value);
+                    }}
+                />
+                <FormHelper helperTextInvalid={validation?.host} />
+            </FormGroup>
+            <FormGroup
+                className="pf-m-3-col-on-md"
+                id={id + "-guest-port-group"}
+                label={_("Guest port")}
+                fieldId={id + "-guest-port"}
+                labelHelp={
+                    <InfoPopover
+                        aria-label={_("Guest port help")}
+                        enableFlip
+                        bodyContent={_("The port on the guest. If left empty, the same port as on the host is used.")}
+                    />
+                }>
+                <TextInput
+                    id={id + "-guest-port"}
+                    value={item.guest}
+                    onChange={(_event, value) => {
+                        onChange(idx, 'guest', value);
+                    }}
+                />
+                <FormHelper helperTextInvalid={validation?.guest} />
+            </FormGroup>
+            <FormGroup
+                className="pf-m-2-col-on-md"
+                label={_("Protocol")}
+                fieldId={id + "-protocol"}
+            >
+                <FormSelect
+                    className='pf-v6-c-form-control'
+                    id={id + "-protocol"}
+                    value={item.proto}
+                    onChange={(_event, value) => onChange(idx, 'proto', value)}
+                >
+                    <FormSelectOption value='tcp' label={_("TCP")} />
+                    <FormSelectOption value='udp' label={_("UDP")} />
+                </FormSelect>
+            </FormGroup>
+            <FormGroup className="pf-m-1-col-on-md remove-button-group">
+                <Button
+                    variant='plain'
+                    className="btn-close"
+                    id={id + "-btn-close"}
+                    size="sm"
+                    aria-label={_("Remove item")}
+                    icon={<TrashIcon />}
+                    onClick={() => removeitem(idx)}
+                />
+            </FormGroup>
+        </Grid>
+    );
+};
+
+const ComplexPortForward = ({
+    id,
+    item,
+    idx,
+    removeitem,
+} : {
+    id: string,
+    item: DialogComplexPortForward,
+    idx: number,
+    removeitem: (idx: number) => void,
+}) => {
+    return (
+        <Grid hasGutter id={id}>
+            <div className="pf-m-12-col-on-md">
+                {
+                    cockpit.format(
+                        _("Complex rule \"$0\" can not be edited here."),
+                        portForwardText(item.config))
+                }
+            </div>
+            <FormGroup className="pf-m-1-col-on-md remove-button-group">
+                <Button
+                    variant='plain'
+                    className="btn-close"
+                    id={id + "-btn-close"}
+                    size="sm"
+                    aria-label={_("Remove item")}
+                    icon={<TrashIcon />}
+                    onClick={() => removeitem(idx)}
+                />
+            </FormGroup>
+        </Grid>
+    );
+};
+
+export const NetworkPortForwardsRow = ({
+    idPrefix,
+    onValueChanged,
+    dialogValues,
+    validation,
+} : {
+    idPrefix: string,
+    onValueChanged: OnValueChanged,
+    dialogValues: DialogBodyValues,
+    validation: ValidationBody | undefined,
+}) => {
+    const simple_default: DialogPortForward = {
+        kind: "simple",
+        address: "",
+        proto: "tcp",
+        host: "",
+        guest: "",
+    };
+
+    function addSimple() {
+        onValueChanged('portForwards', dialogValues.portForwards.concat({ ...simple_default }));
+    }
+
+    function remItem(idx: number) {
+        dialogValues.portForwards.splice(idx, 1);
+        onValueChanged('portForwards', dialogValues.portForwards);
+    }
+
+    function onSimpleChange<K extends keyof DialogSimplePortForward>(idx: number, key: K, value: DialogSimplePortForward[K]) {
+        if (dialogValues.portForwards[idx].kind == "simple") {
+            dialogValues.portForwards[idx][key] = value;
+            onValueChanged('portForwards', dialogValues.portForwards);
+        }
+    }
+
+    const action = (
+        <Button variant="secondary" onClick={addSimple}>
+            {_("Add")}
+        </Button>
+    );
+
+    return (
+        <FormFieldGroup
+            id={`${idPrefix}-port-forwards`}
+            className="nic-dynamic-form-group"
+            header={
+                <FormFieldGroupHeader
+                    titleText={{ id: `${idPrefix}-port-forwards-header`, text: _("Forwarded ports") }}
+                    actions={action}
+                />
+            }
+        >
+            {dialogValues.portForwards.length == 0 &&
+                <EmptyState>
+                    <EmptyStateBody>
+                        {_("No ports forwarded")}
+                    </EmptyStateBody>
+                </EmptyState>
+            }
+            {
+                dialogValues.portForwards.map((pf, idx) => {
+                    if (pf.kind == "simple")
+                        return (
+                            <SimplePortForward
+                                key={idx}
+                                id={`${idPrefix}-port-forwards-${idx}`}
+                                item={pf}
+                                validation={validation?.portForwards ? validation.portForwards[idx] : undefined}
+                                onChange={onSimpleChange}
+                                idx={idx}
+                                removeitem={() => remItem(idx)}
+                            />
+                        );
+                    else
+                        return (
+                            <ComplexPortForward
+                                key={idx}
+                                id={`${idPrefix}-port-forwards-${idx}`}
+                                item={pf}
+                                idx={idx}
+                                removeitem={() => remItem(idx)}
+                            />
+                        );
+                })
+            }
+        </FormFieldGroup>
+    );
+};
+
+export function validateDialogBodyValues(d: DialogBodyValues): ValidationBody | undefined {
+    const v: ValidationBody = {
+        portForwards: d.portForwards.map(validateDialogPortForward),
+    };
+
+    if (!v.portForwards.some(pf => !!pf))
+        return undefined;
+
+    return v;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,20 @@ export interface VMDisk {
     removable: optString;
 }
 
+export interface VMInterfacePortForwardRange {
+    start: optString;
+    end: optString;
+    to: optString;
+    exclude: optString;
+}
+
+export interface VMInterfacePortForward {
+    address: optString;
+    dev: optString;
+    proto: optString;
+    range: VMInterfacePortForwardRange[];
+}
+
 export interface VMInterface {
     type: string;
     managed: optString;
@@ -107,6 +121,7 @@ export interface VMInterface {
     target: optString;
     mac: optString;
     model: optString;
+    backend: optString;
     aliasName: optString;
     virtualportType: optString;
     driverName: optString;
@@ -132,6 +147,7 @@ export interface VMInterface {
         slot: optString;
         domain: optString;
     },
+    portForward: VMInterfacePortForward[],
 }
 
 export interface VMRedirectedDevice {
@@ -395,6 +411,7 @@ export interface DomainCapabilities {
     supportedDiskBusTypes: string[];
     supportsSpice: boolean;
     supportsTPM: boolean;
+    interfaceBackends: string[];
 }
 
 export interface VM extends VMXML {

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -908,6 +908,179 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
                     self.browser.wait_not_present(f"#vm-subVmTest1-network-{self.nic_num}-mac")
                 self.browser.wait_not_present(".pf-v6-c-modal-box")
 
+    @testlib.skipImage('PASST not supported', "rhel-8-*", "ubuntu-2204", "ubuntu-2404")
+    def testPortForwards(self):
+        b = self.browser
+
+        # Ubuntu produces AppArmor denials...
+        self.allow_journal_messages('.*apparmor="DENIED".*operation="sendmsg".*comm="passt.avx2".*')
+
+        self.login_and_go("/machines", superuser=False)
+        self.waitPageInit()
+
+        self.createVm("subVmTest1", connection="session", running=False)
+        self.goToVmPage("subVmTest1", "session")
+
+        # Machine should have a NIC with "default" backend.
+
+        self.expandNicRow(1)
+        b.wait_in_text("#vm-subVmTest1-network-1-type", "user")
+        b.wait_in_text("#vm-subVmTest1-network-1-backend", "default")
+
+        # Add port forwards for 8080-8090 -> 80/udp and 127.0.0.1 2222 -> 22/tcp
+
+        b.click("#vm-subVmTest1-network-1-edit-dialog")
+        b.wait_visible("#vm-subVmTest1-network-1-edit-dialog-modal-window")
+        b.click("#vm-subVmTest1-network-1-edit-dialog-port-forwards button:contains(Add)")
+        b.set_input_text("#vm-subVmTest1-network-1-edit-dialog-port-forwards-0-host-port", "8080-8090")
+        b.set_input_text("#vm-subVmTest1-network-1-edit-dialog-port-forwards-0-guest-port", "80")
+        b.select_from_dropdown("#vm-subVmTest1-network-1-edit-dialog-port-forwards-0-protocol", "udp")
+        b.click("#vm-subVmTest1-network-1-edit-dialog-port-forwards button:contains(Add)")
+        b.set_input_text("#vm-subVmTest1-network-1-edit-dialog-port-forwards-1-ip-address", "127.0.0.1")
+        b.set_input_text("#vm-subVmTest1-network-1-edit-dialog-port-forwards-1-host-port", "2222")
+        b.set_input_text("#vm-subVmTest1-network-1-edit-dialog-port-forwards-1-guest-port", "22")
+        b.click("#vm-subVmTest1-network-1-edit-dialog-port-forwards button:contains(Add)")
+        b.set_input_text("#vm-subVmTest1-network-1-edit-dialog-port-forwards-2-ip-address", "localhost")
+        b.set_input_text("#vm-subVmTest1-network-1-edit-dialog-port-forwards-2-host-port", "")
+        b.set_input_text("#vm-subVmTest1-network-1-edit-dialog-port-forwards-2-guest-port", "ssh")
+        b.click("#vm-subVmTest1-network-1-edit-dialog-save")
+        b.wait_in_text("#vm-subVmTest1-network-1-edit-dialog-port-forwards-2-ip-address-group",
+                       "Invalid IP address")
+        b.wait_in_text("#vm-subVmTest1-network-1-edit-dialog-port-forwards-2-host-port-group",
+                       "Host port can not be empty")
+        b.wait_in_text("#vm-subVmTest1-network-1-edit-dialog-port-forwards-2-guest-port-group",
+                       "Port must be a number")
+        b.set_input_text("#vm-subVmTest1-network-1-edit-dialog-port-forwards-2-host-port", "xxx")
+        b.wait_in_text("#vm-subVmTest1-network-1-edit-dialog-port-forwards-2-host-port-group",
+                       "Port must be a number")
+        b.click("#vm-subVmTest1-network-1-edit-dialog-port-forwards-2-btn-close")
+        b.click("#vm-subVmTest1-network-1-edit-dialog-save")
+        b.wait_not_present("#vm-subVmTest1-network-1-edit-dialog-modal-window")
+
+        # Backend should now be "passt"
+
+        b.wait_in_text("#vm-subVmTest1-network-1-backend", "passt")
+        b.wait_in_text("#vm-subVmTest1-network-1-port-forward-0", "8080-8090 → 80-90/udp")
+        b.wait_in_text("#vm-subVmTest1-network-1-port-forward-1", "127.0.0.1:2222 → 22/tcp")
+
+        # Remove the forwards
+
+        b.click("#vm-subVmTest1-network-1-edit-dialog")
+        b.wait_visible("#vm-subVmTest1-network-1-edit-dialog-modal-window")
+        b.click("#vm-subVmTest1-network-1-edit-dialog-port-forwards-1-btn-close")
+        b.click("#vm-subVmTest1-network-1-edit-dialog-port-forwards-0-btn-close")
+        b.click("#vm-subVmTest1-network-1-edit-dialog-save")
+        b.wait_not_present("#vm-subVmTest1-network-1-edit-dialog-modal-window")
+
+        # Backend should still be "passt"
+
+        b.wait_in_text("#vm-subVmTest1-network-1-port-forward", "none")
+        b.wait_in_text("#vm-subVmTest1-network-1-backend", "passt")
+
+        # Add a complex port forward rule via virt-xml
+
+        self.run_admin(
+            "virt-xml -c qemu:///session subVmTest1 --edit 1 --network "
+            "portForward0.proto=tcp,"
+            "portForward0.range0.start=4000,portForward0.range0.end=4050,portForward0.range0.to=40,"
+            "portForward0.range1.start=4040,portForward0.range1.exclude=yes",
+            "session")
+        b.wait_in_text("#vm-subVmTest1-network-1-port-forward-0", "4000-4050 → 40-90, excluding 4040/tcp")
+
+        # Delete the complex rule
+
+        b.click("#vm-subVmTest1-network-1-edit-dialog")
+        b.wait_visible("#vm-subVmTest1-network-1-edit-dialog-modal-window")
+        b.wait_in_text("#vm-subVmTest1-network-1-edit-dialog-port-forwards-0",
+                       'Complex rule "4000-4050 → 40-90, excluding 4040/tcp" can not be edited here.')
+        b.click("#vm-subVmTest1-network-1-edit-dialog-port-forwards-0-btn-close")
+        b.click("#vm-subVmTest1-network-1-edit-dialog-save")
+        b.wait_not_present("#vm-subVmTest1-network-1-edit-dialog-modal-window")
+        b.wait_in_text("#vm-subVmTest1-network-1-port-forward", "none")
+
+        # Add new NIC without port forward
+
+        b.click("#vm-subVmTest1-add-iface-button")
+        b.wait_visible("#vm-subVmTest1-add-iface-dialog")
+        self.browser.click("#vm-subVmTest1-add-iface-set-mac")
+        self.browser.set_input_text("#vm-subVmTest1-add-iface-mac", "52:54:01:00:00:01")
+        b.click("#vm-subVmTest1-add-iface-add")
+        b.wait_not_present("#vm-subVmTest1-add-iface-dialog")
+
+        # Backend of new NICs should be "passt"
+
+        self.expandNicRow(2)
+        b.wait_in_text("#vm-subVmTest1-network-2-type", "user")
+        b.wait_in_text("#vm-subVmTest1-network-2-backend", "passt")
+
+        # Add another one with port forward, check it.
+
+        b.click("#vm-subVmTest1-add-iface-button")
+        b.wait_visible("#vm-subVmTest1-add-iface-dialog")
+        self.browser.click("#vm-subVmTest1-add-iface-set-mac")
+        self.browser.set_input_text("#vm-subVmTest1-add-iface-mac", "52:54:01:00:00:02")
+        b.click("#vm-subVmTest1-add-iface-port-forwards button:contains(Add)")
+        b.set_input_text("#vm-subVmTest1-add-iface-port-forwards-0-host-port", "8080")
+        b.set_input_text("#vm-subVmTest1-add-iface-port-forwards-0-guest-port", "80")
+        b.click("#vm-subVmTest1-add-iface-add")
+        b.wait_not_present("#vm-subVmTest1-add-iface-dialog")
+        self.expandNicRow(3)
+        b.wait_in_text("#vm-subVmTest1-network-3-type", "user")
+        b.wait_in_text("#vm-subVmTest1-network-3-backend", "passt")
+        b.wait_in_text("#vm-subVmTest1-network-3-port-forward-0", "8080 → 80/tcp")
+
+        # Start VM
+        b.click("#vm-subVmTest1-session-run")
+        b.wait_in_text("#vm-subVmTest1-session-state", "Running")
+
+        # Change port forward of a NIC, check "pending".
+        b.click("#vm-subVmTest1-network-3-edit-dialog")
+        b.wait_visible("#vm-subVmTest1-network-3-edit-dialog-modal-window")
+        b.set_input_text("#vm-subVmTest1-network-3-edit-dialog-port-forwards-0-guest-port", "88")
+        b.click("#vm-subVmTest1-network-3-edit-dialog-save")
+        b.wait_not_present("#vm-subVmTest1-network-3-edit-dialog-modal-window")
+        b.wait_visible("#vm-subVmTest1-network-3-port-forward-tooltip")
+
+    def testSession(self):
+        b = self.browser
+
+        self.login_and_go("/machines", superuser=False)
+        self.waitPageInit()
+
+        self.createVm("subVmTest1", connection="session", running=False)
+        self.goToVmPage("subVmTest1", "session")
+
+        # Machine should have a NIC with type "user" and model "virtio".
+
+        self.expandNicRow(1)
+        b.wait_in_text("#vm-subVmTest1-network-1-type", "user")
+        b.wait_in_text("#vm-subVmTest1-network-1-model", "virtio")
+
+        # Changing model should work
+
+        b.click("#vm-subVmTest1-network-1-edit-dialog")
+        b.wait_visible("#vm-subVmTest1-network-1-edit-dialog-modal-window")
+        b.select_from_dropdown("#vm-subVmTest1-network-1-edit-dialog-model", "e1000e")
+        b.click("#vm-subVmTest1-network-1-edit-dialog-save")
+        b.wait_not_present("#vm-subVmTest1-network-1-edit-dialog-modal-window")
+        b.wait_in_text("#vm-subVmTest1-network-1-model", "e1000e")
+
+        # Adding should work
+
+        b.click("#vm-subVmTest1-add-iface-button")
+        b.wait_visible("#vm-subVmTest1-add-iface-dialog")
+        self.browser.click("#vm-subVmTest1-add-iface-set-mac")
+        self.browser.set_input_text("#vm-subVmTest1-add-iface-mac", "52:54:01:00:00:01")
+        b.click("#vm-subVmTest1-add-iface-add")
+        b.wait_not_present("#vm-subVmTest1-add-iface-dialog")
+        self.expandNicRow(2)
+        b.wait_in_text("#vm-subVmTest1-network-2-type", "user")
+        b.wait_in_text("#vm-subVmTest1-network-2-model", "virtio")
+
+        # Removing should work
+
+        self.deleteIface(1)
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
Fixes #2186 
Demo: https://youtu.be/L-EWj0dmgoo
Obsolete demo with choice, shows more about port forwarding: https://youtu.be/mhwTZ3CW8iI

- [x] Validate inputs, tests
- [x] Don't clear old port forwards when new ones will not be accepted by virt-xml. Done by first letting virt-xml override the old elements we want to keep, and then explicitly removing the old ones we don't want to keep.
 - [x] coverage

----

### Machines: Support for network port forwarding

Cockpit can now configure port forwarding for virtual machines on the user session.

<img width="849" height="542" alt="image" src="https://github.com/user-attachments/assets/f98779c9-5d33-4d18-aa46-f24537c6120f" />
