### PR TITLE
api: Use domainModifyXML for more tasks

### DIFF
--- a/src/components/vm/disks/diskEdit.tsx
+++ b/src/components/vm/disks/diskEdit.tsx
@@ -174,8 +174,7 @@ const EditDisk = ({
 
         try {
             await domainUpdateDiskAttributes({
-                connectionName: vm.connectionName,
-                objPath: vm.id,
+                vm,
                 target: disk.target,
                 readonly: values.access.mode == "readonly",
                 shareable: disk.shareable,

--- a/src/components/vm/overview/bootOrder.tsx
+++ b/src/components/vm/overview/bootOrder.tsx
@@ -262,8 +262,7 @@ class BootOrderModal extends React.Component<BootOrderModalProps, BootOrderModal
         const devices = this.state.devices.filter((device) => device.checked);
 
         domainChangeBootOrder({
-            id: vm.id,
-            connectionName: vm.connectionName,
+            vm,
             devices,
         })
                 .then(() => {

--- a/src/components/vm/overview/firmware.tsx
+++ b/src/components/vm/overview/firmware.tsx
@@ -61,8 +61,7 @@ class FirmwareModal extends React.Component<FirmwareModalProps, FirmwareModalSta
         const vm = this.props.vm;
         try {
             await domainSetOSFirmware({
-                connectionName: vm.connectionName,
-                objPath: vm.id,
+                vm,
                 loaderType: stateToXml(this.state.firmware)
             });
 

--- a/src/components/vm/overview/memoryModal.tsx
+++ b/src/components/vm/overview/memoryModal.tsx
@@ -109,8 +109,7 @@ export class MemoryModal extends React.Component<MemoryModalProps, MemoryModalSt
 
         if (vm.memory !== this.state.maxMemory) {
             domainSetMaxMemory({
-                id: vm.id,
-                connectionName: vm.connectionName,
+                vm,
                 maxMemory: this.state.maxMemory
             })
                     .then(() => {

--- a/src/libvirt-xml-parse.ts
+++ b/src/libvirt-xml-parse.ts
@@ -277,6 +277,13 @@ function get_enum_values(parent: Element | undefined, ...matches: Match[]): stri
     return get_texts(parent, ...matches.slice(0, -1), { tag: "enum", name }, "value");
 }
 
+export function getDocElement(doc: XMLDocument): Element {
+    const elem = doc.firstElementChild;
+    if (!elem)
+        throw new Error(`document is empty`);
+    return elem;
+}
+
 export function parsePoolCapabilities(capsXML: string): StoragePoolCapabilites {
     const poolCapsElem = getElem(capsXML);
     const poolElements = get_children(poolCapsElem, "pool");


### PR DESCRIPTION
Let's not duplicate the code for retrieving and saving the XML document.

- [x] #2334 
- [x] Pass the XMLDocument instead of the top-level element to the callback.