### PR TITLE
test: the console now forcefully disconnects on tumbleweed

### DIFF
--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -702,7 +702,7 @@ fullscreen=0
 
         b2.select_PF("#vm-console-vnc-scaling", "Remote resizing")
 
-        if not m.image.startswith(("ubuntu-", "debian-trixie", "opensuse-tumbleweed")):
+        if not m.image.startswith(("ubuntu-", "debian-trixie")):
             # Cockpit will make a non-shared connection.  The embedded
             # console will be forcefully disconnected.
             b.wait_in_text(".consoles-card", "Disconnected")


### PR DESCRIPTION
tumbleweed now has Cockpit > 346 which fixed the websocket channel close behaviour, see:

https://github.com/cockpit-project/cockpit/commit/3ef9f72a29608b97d66a6073166ed6b09d452b6f