### PR TITLE
consoles: Make "Expand"/"Compress" a real link

### DIFF
--- a/src/components/vm/consoles/consoles.tsx
+++ b/src/components/vm/consoles/consoles.tsx
@@ -331,15 +331,16 @@ export const ConsoleCard = ({
     }
 
     if (!isStandalone) {
+        const options = { ...cockpit.location.options, name: vm.name, connection: vm.connectionName };
+        const path = isExpanded ? ["vm"] : ["vm", "console"];
+        const href = "#" + cockpit.location.encode(path, options);
+
         actions.push(
             <Button
                 key="expand-compress"
                 variant="link"
-                onClick={() => {
-                    const urlOptions = { name: vm.name, connection: vm.connectionName };
-                    const path = isExpanded ? ["vm"] : ["vm", "console"];
-                    return cockpit.location.go(path, { ...cockpit.location.options, ...urlOptions });
-                }}
+                component="a"
+                href={href}
                 icon={isExpanded ? <CompressIcon /> : <ExpandIcon />}
                 iconPosition="right">{isExpanded ? _("Compress") : _("Expand")}
             </Button>
@@ -347,9 +348,9 @@ export const ConsoleCard = ({
     }
 
     if (!isStandalone && type == "graphical") {
-        const urlOptions = { name: vm.name, connection: vm.connectionName };
+        const options = { ...cockpit.location.options, name: vm.name, connection: vm.connectionName };
         const path = ["vm", "vnc"];
-        const href = "#" + cockpit.location.encode(path, { ...cockpit.location.options, ...urlOptions });
+        const href = "#" + cockpit.location.encode(path, options);
 
         actions.push(
             <Button

--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -163,11 +163,11 @@ fullscreen=0
         # Make sure the console keeps their content when navigating
         # around
 
-        b.click(".consoles-card button:contains(Expand)")
+        b.click(".consoles-card a:contains(Expand)")
         b.wait_visible(".consoles-page-expanded")
         wait_for_alpine_greeting()
 
-        b.click(".consoles-card button:contains(Compress)")
+        b.click(".consoles-card a:contains(Compress)")
         b.wait_visible(".consoles-card")
         wait_for_alpine_greeting()
 
@@ -508,7 +508,7 @@ fullscreen=0
         self.waitVmRow(name)
         self.goToVmPage(name)
 
-        b.click(".consoles-card button:contains(Expand)")
+        b.click(".consoles-card a:contains(Expand)")
         b.wait_visible(".consoles-page-expanded")
         b.assert_pixels(".consoles-card", "expanded", ignore=[".vm-console-vnc"], chrome_hack_double_shots=True)
 
@@ -522,7 +522,7 @@ fullscreen=0
         # Compress, Serial should still be selected and VNC should stay
         # disconnected
 
-        b.click(".consoles-card button:contains(Compress)")
+        b.click(".consoles-card a:contains(Compress)")
         b.wait_visible("#vm-details")
         b.wait_visible(".consoles-card .vm-terminal")
         b.click('.consoles-card .pf-v6-c-toggle-group button:contains("Graphical")')
@@ -634,7 +634,7 @@ fullscreen=0
         # When collapsing and expanding again, nothing should have
         # changed.
 
-        b.click(".consoles-card button:contains(Compress)")
+        b.click(".consoles-card a:contains(Compress)")
         b.wait_visible("#vm-details")
         b.wait_not_present("#vm-console-vnc-scaling")
         b.click(".consoles-card button:contains(Expand)")


### PR DESCRIPTION
So that people can bookmark it and open it in a new tab, just like the "Detach" link.

This is not at all important, imo.  Bookmarking the "Detach" link or opening it in a new tab is probably always preferable for VNC. But for consistency and for getting the serial console into a tab this might be an improvement.