### PR TITLE
packaging: suggest qemu-kvm-block-curl on RHEL

### DIFF
--- a/packaging/cockpit-machines.spec.in
+++ b/packaging/cockpit-machines.spec.in
@@ -47,6 +47,7 @@ Requires: libvirt-daemon-config-network
 Recommends: libvirt-daemon-driver-storage-disk
 %if 0%{?rhel}
 Requires: qemu-kvm
+Suggests: qemu-kvm-block-curl
 %else
 # smaller footprint on Fedora, as qemu-kvm is really expensive on a server
 Requires: qemu-kvm-core

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -63,6 +63,11 @@ if [ "$ID" = fedora ]; then
     dnf install -y virtiofsd
 fi
 
+# Split of from qemu-kvm in RHEL 9
+if [ "$ID" = rhel ]; then
+   dnf install -y qemu-kvm-block-curl
+fi
+
 # Run tests in the cockpit tasks container, as unprivileged user
 # TODO: Run in "host" network ns, as some tests fail on unexpected veth/bridge claimed by the container
 # fix these and then use the isolation in starter-kit and friends


### PR DESCRIPTION
Fixes not being able to install an iso file over http(s), the dependency on qemu-kvm-block-curl was removed from qemu-kvm in RHEL 9. With the suggestion to move to ndkit but that was never finalised.

https://github.com/cockpit-project/bots/issues/2538 https://bugzilla.redhat.com/show_bug.cgi?id=2014229