### PR TITLE
test: move Fedora/RHEL specific package installs to main.fmf

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -6,14 +6,6 @@ cd "${0%/*}/../.."
 
 . /usr/lib/os-release
 
-# we don't need the H.264 codec, and it is sometimes not available (rhbz#2005760)
-DNF="dnf install --disablerepo=fedora-cisco-openh264 -y"
-
-# RHEL/CentOS 8 and Fedora have this, but not RHEL 9/10; tests check this more precisely
-if [ "${PLATFORM_ID:-}" = "platform:el8" ] || [ "$ID" = "fedora" ]; then
-    $DNF libvirt-daemon-driver-storage-iscsi-direct
-fi
-
 # HACK: this package creates bogus/broken sda → nvme symlinks; it's new in rawhide TF default instances, not required for
 # our tests, and only causes trouble; https://github.com/amazonlinux/amazon-ec2-utils/issues/37
 if rpm -q amazon-ec2-utils; then
@@ -56,16 +48,6 @@ if [ "${PLATFORM_ID:-}" != "platform:el8" ]; then
     systemctl start virtnetworkd.socket
     systemctl start virtnodedevd.socket
     systemctl start virtstoraged.socket
-fi
-
-# Fedora split out qemu-virtiofsd
-if [ "$ID" = fedora ]; then
-    dnf install -y virtiofsd
-fi
-
-# Split of from qemu-kvm in RHEL 9
-if [ "$ID" = rhel ]; then
-   dnf install -y qemu-kvm-block-curl
 fi
 
 # Run tests in the cockpit tasks container, as unprivileged user

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -15,6 +15,18 @@
   test: ./browser.sh basic
   duration: 60m
 
+  adjust:
+    # RHEL
+    - require+:
+        # required by TestMachinesCreate.testCreateUrlSource
+        - qemu-kvm-block-curl
+      when: distro ~ rhel
+
+    # Fedora split out qemu-virtiofsd
+    - require+:
+        - virtiofsd
+      when: distro ~ fedora
+
 /network:
   summary: Run browser integration for network functionality
   require:
@@ -29,6 +41,12 @@
     - firewalld
   test: ./browser.sh network
   duration: 60m
+
+  adjust:
+    # Fedora split out qemu-virtiofsd
+    - require+:
+        - virtiofsd
+      when: distro ~ fedora
 
 /storage:
   summary: Run browser integration for storage functionality
@@ -47,3 +65,10 @@
     - targetcli
   test: ./browser.sh storage
   duration: 60m
+
+  adjust:
+    # Fedora split out qemu-virtiofsd
+    - require+:
+        - virtiofsd
+        - libvirt-daemon-driver-storage-iscsi-direct
+      when: distro ~ fedora


### PR DESCRIPTION
Declaratively specify additional Fedora or RHEL specific (test) dependencies.

---

In theory we could use [yaml anchors and labels](https://tmt.readthedocs.io/en/stable/guide.html#anchors-and-aliases) but I couldn't find an easy way to do it for virtiofsd.