### PR TITLE
fmf: Install nfs-utils explicitly

### DIFF
--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -44,6 +44,7 @@
     - firewalld
     - libvirt-daemon-driver-storage-iscsi
     - libvirt-daemon-driver-storage-logical
+    - nfs-utils
     - targetcli
   test: ./browser.sh storage
   duration: 60m


### PR DESCRIPTION
They are required for the nfs-server.service unit on Fedora 43.