### PR TITLE
test: the console now forcefully disconnects on ubuntu-stable

### DIFF
--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -708,7 +708,7 @@ fullscreen=0
 
         b2.select_PF("#vm-console-vnc-scaling", "Remote resizing")
 
-        if not m.image.startswith(("ubuntu-", "debian-trixie")):
+        if m.image not in ["ubuntu-2204", "ubuntu-2404", "debian-trixie"]:
             # Cockpit will make a non-shared connection.  The embedded
             # console will be forcefully disconnected.
             b.wait_in_text(".consoles-card", "Disconnected")


### PR DESCRIPTION
ubuntu-stable now has Cockpit > 346 which fixed the websocket channel close behaviour, see:

https://github.com/cockpit-project/cockpit/commit/3ef9f72a29608b97d66a6073166ed6b09d452b6f