### PR TITLE
test: work around rhel-8-10 space issue

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -2407,6 +2407,7 @@ class TestMachinesCreate(machineslib.VirtualMachinesCase):
                                                                           os_short_id=config.RHEL_8_1_SHORTID,
                                                                           offline_token="invalid_token",
                                                                           offline_token_autofilled=False,
+                                                                          location=config.VALID_DISK_IMAGE_PATH,
                                                                           create_and_run=True),
                                               "Error",
                                               True)


### PR DESCRIPTION
TestMachinesCreate.testCreateDownloadRhel fails in a new image refresh of rhel-8-10 error'ing out about not enough space being available (10G being required for rhel 8-10). However the test tries to validate the `offline_token`, apparently semantics for validation changed a bit making this become an issue. Therefore always configure the 500M volume so we actually test the token validation and not lack of free space on our images.

```
The requested volume capacity will exceed the available pool space when
the volume is fully allocated. (10240 M requested capacity > 10074 M
available)
```