### PR TITLE
test: temporarily install gobject-introspection on Fedora

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -6,6 +6,12 @@ cd "${0%/*}/../.."
 
 . /usr/lib/os-release
 
+
+# HACK: workaround https://bugzilla.redhat.com/show_bug.cgi?id=2412451
+if [ "$ID" = fedora ]; then
+    dnf install -y gobject-introspection
+fi
+
 # HACK: this package creates bogus/broken sda → nvme symlinks; it's new in rawhide TF default instances, not required for
 # our tests, and only causes trouble; https://github.com/amazonlinux/amazon-ec2-utils/issues/37
 if rpm -q amazon-ec2-utils; then


### PR DESCRIPTION
This is no longer pulled in via python3-gobject-base after the following change.

https://src.fedoraproject.org/rpms/pygobject3/c/6a4422642c746e124fc6b0bcecd40b74e4217510?branch=rawhide