### PR TITLE
workflows: sync cockpit-lib-update workflow with starter-kit

### DIFF
--- a/.github/workflows/cockpit-lib-update.yml
+++ b/.github/workflows/cockpit-lib-update.yml
@@ -6,11 +6,10 @@ on:
   workflow_dispatch:
 jobs:
   cockpit-lib-update:
-    environment: self
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      statuses: write
+      contents: write
     steps:
       - name: Set up dependencies
         run: |
@@ -24,8 +23,6 @@ jobs:
 
       - name: Clone repository
         uses: actions/checkout@v6
-        with:
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Run cockpit-lib-update
         run: |


### PR DESCRIPTION
The starter-kit workflow never required a deploy_key for cloning the repo as we create the pull request via GitHub token in tasklib.