### PR TITLE
nics: Improve the dialog experience with new framework components

### DIFF
--- a/src/components/vm/nics/nicAdd.tsx
+++ b/src/components/vm/nics/nicAdd.tsx
@@ -10,7 +10,6 @@ import { useDialogs } from 'dialogs';
 import type { VM } from '../../../types';
 import type { AvailableSources } from './vmNicsCard';
 
-import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
 import {
     Modal, ModalBody, ModalFooter, ModalHeader
@@ -19,19 +18,20 @@ import { Radio } from "@patternfly/react-core/dist/esm/components/Radio";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 
 import {
-    NetworkTypeAndSourceValue, NetworkTypeAndSourceRow,
-    init_NetworkTypeAndSourceRow, validate_NetworkTypeAndSourceRow,
+    NetworkTypeAndSourceValue, NetworkTypeAndSourceRow, init_NetworkTypeAndSourceRow,
     NetworkModelRow,
     PortForwardsValue, NetworkPortForwardsRow, validate_PortForwards,
     dialogPortForwardsToInterface,
 } from './nicBody.jsx';
 import { virtXmlHotAdd, domainGet, domainIsRunning } from '../../../libvirtApi/domain.js';
+
 import { appState } from '../../../state';
 
 import {
-    useDialogState, DialogField, DialogError,
+    useDialogState_async, DialogState, DialogField, DialogError,
     DialogErrorMessage, DialogHelperText,
-    DialogActionButton, DialogCancelButton
+    DialogActionButton, DialogCancelButton,
+    DialogCheckbox,
 } from 'cockpit/dialog';
 
 import './nic.css';
@@ -130,18 +130,11 @@ const PermanentChange = ({
     // down only. Enable permanent change of the domain.xml
 
     return (
-        <FormGroup
-            fieldId={field.id()}
-            label={_("Persistence")}
-            hasNoPaddingTop
-        >
-            <Checkbox
-                id={field.id()}
-                isChecked={field.get()}
-                label={_("Always attach")}
-                onChange={(_event, checked) => field.set(checked)}
-            />
-        </FormGroup>
+        <DialogCheckbox
+            field_label={_("Persistence")}
+            checkbox_label={_("Always attach")}
+            field={field}
+        />
     );
 };
 
@@ -164,7 +157,7 @@ export const AddNIC = ({
 }) => {
     const Dialogs = useDialogs();
 
-    function init(): AddNICValues {
+    async function init(): Promise<AddNICValues> {
         return {
             model: "virtio",
             type_and_source: init_NetworkTypeAndSourceRow(vm, null, availableSources),
@@ -174,9 +167,8 @@ export const AddNIC = ({
         };
     }
 
-    function validate() {
+    function validate(dlg: DialogState<AddNICValues>) {
         validate_NetworkMacRow(dlg.field("mac"));
-        validate_NetworkTypeAndSourceRow(dlg.field("type_and_source"));
         if (dlg.values.type_and_source.type == "user")
             validate_PortForwards(dlg.field("portForwards"));
     }
@@ -227,34 +219,37 @@ export const AddNIC = ({
         }
     }
 
-    const dlg = useDialogState(init, validate);
+    const dlg = useDialogState_async(init, validate);
 
-    const defaultBody = (
-        <>
-            <Form onSubmit={e => e.preventDefault()} isHorizontal>
-                <NetworkTypeAndSourceRow field={dlg.field("type_and_source")} />
+    let defaultBody: React.ReactNode;
+    if (dlg instanceof DialogState) {
+        defaultBody = (
+            <>
+                <Form onSubmit={e => e.preventDefault()} isHorizontal>
+                    <NetworkTypeAndSourceRow field={dlg.field("type_and_source").at(dlg.values.type_and_source)} />
 
-                <NetworkModelRow
-                    field={dlg.field("model")}
-                    osTypeArch={vm.arch}
-                    osTypeMachine={vm.emulatedMachine}
-                />
+                    <NetworkModelRow
+                        field={dlg.field("model")}
+                        osTypeArch={vm.arch}
+                        osTypeMachine={vm.emulatedMachine}
+                    />
 
-                <NetworkMacRow field={dlg.field("mac")} />
+                    <NetworkMacRow field={dlg.field("mac")} />
 
-                { domainIsRunning(vm.state) && vm.persistent &&
-                    <PermanentChange field={dlg.field("permanent")} />
-                }
-            </Form>
-            { dlg.values.type_and_source.type == "user" &&
-                vm.capabilities.interfaceBackends.includes("passt") &&
-                <Form>
-                    <br />
-                    <NetworkPortForwardsRow field={dlg.field("portForwards")} />
+                    { domainIsRunning(vm.state) && vm.persistent &&
+                        <PermanentChange field={dlg.field("permanent")} />
+                    }
                 </Form>
-            }
-        </>
-    );
+                { dlg.values.type_and_source.type == "user" &&
+                    vm.capabilities.interfaceBackends.includes("passt") &&
+                    <Form>
+                        <br />
+                        <NetworkPortForwardsRow field={dlg.field("portForwards")} />
+                    </Form>
+                }
+            </>
+        );
+    }
 
     return (
         <Modal

--- a/src/components/vm/nics/nicBody.tsx
+++ b/src/components/vm/nics/nicBody.tsx
@@ -13,12 +13,8 @@ import type { AvailableSources } from './vmNicsCard';
 
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { EmptyState, EmptyStateBody } from "@patternfly/react-core/dist/esm/components/EmptyState";
-import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex";
 import { FormGroup, FormFieldGroup, FormFieldGroupHeader } from "@patternfly/react-core/dist/esm/components/Form";
 import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
-import { Radio } from "@patternfly/react-core/dist/esm/components/Radio";
-import { PopoverPosition } from "@patternfly/react-core/dist/esm/components/Popover";
-import { Content, ContentVariants } from "@patternfly/react-core/dist/esm/components/Content";
 import { ExternalLinkSquareAltIcon, TrashIcon } from '@patternfly/react-icons';
 import { Grid } from "@patternfly/react-core/dist/esm/layouts/Grid";
 
@@ -27,9 +23,11 @@ import { InfoPopover } from '../../common/infoPopover.jsx';
 import cockpit from 'cockpit';
 
 import {
+    DialogError,
     DialogField,
     DialogTextInput,
-    DialogHelperText,
+    DialogDropdownSelect, DialogDropdownSelectOption,
+    DialogRadioSelect, DialogRadioSelectOption
 } from 'cockpit/dialog';
 
 import './nic.css';
@@ -45,68 +43,83 @@ export const NetworkModelRow = ({
     osTypeArch: optString,
     osTypeMachine: optString,
 }) => {
-    const availableModelTypes: { name: string, desc?: string }[] = [
-        { name: 'virtio', desc: 'Linux, perf' },
-        { name: 'e1000e', desc: 'PCI' },
-        { name: 'e1000', desc: 'PCI, legacy' },
-        { name: 'rtl8139', desc: 'PCI, legacy' }];
-    const defaultModelType = field.get();
+    const availableModelTypes = [
+        { value: 'virtio', label: 'virtio (Linux, perf)' },
+        { value: 'e1000e', label: 'e1000e (PCI)' },
+        { value: 'e1000', label: 'e1000 (PCI, legacy)' },
+        { value: 'rtl8139', label: 'rtl8139 (PCI, legacy)' }];
 
     if (osTypeArch == 'ppc64' && osTypeMachine == 'pseries')
-        availableModelTypes.push({ name: 'spapr-vlan' });
+        availableModelTypes.push({ value: 'spapr-vlan', label: 'spapr-vlan' });
 
     return (
-        <FormGroup fieldId={field.id()} label={_("Model")}>
-            <FormSelect
-                id={field.id()}
-                onChange={(_event, val) => field.set(val)}
-                data-value={defaultModelType}
-                value={defaultModelType}
-            >
-                {availableModelTypes
-                        .map(networkModel => {
-                            return (
-                                <FormSelectOption value={networkModel.name} key={networkModel.name}
-                                                  label={networkModel.name + ' (' + networkModel.desc + ')'} />
-                            );
-                        })}
-            </FormSelect>
-        </FormGroup>
+        <DialogDropdownSelect
+            label={_("Model")}
+            field={field}
+            options={availableModelTypes}
+        />
     );
 };
 
-interface NetworkTypeDescription {
-    name: string,
-    desc: string,
-    detailHeadline?: React.ReactNode,
-    detailParagraph?: React.ReactNode,
-    externalDocs?: React.ReactNode,
-    disabled?: boolean,
+type NetworkType = "network" | "bridge" | "direct" | "user";
+
+export function isSupportedNetworkType(type: string): type is NetworkType {
+    return type == "network" || type == "bridge" || type == "direct" || type == "user";
 }
 
-function getAvailableNetworkTypes(vm: VM, availableSources: AvailableSources) {
+interface NetworkTypeDescription {
+    type: NetworkType,
+    desc: string,
+    detailHeadline?: React.ReactNode,
+    excuse: string | null,
+}
+
+interface AvailableSourcesForType {
+    network: string[];
+    bridge: string[];
+    direct: string[];
+    user: string[];
+}
+
+function getAvailableNetworkTypes(vm: VM, availableSources: AvailableSourcesForType) {
     let availableNetworkTypes: NetworkTypeDescription[] = [];
 
     // { name: 'ethernet', desc: 'Generic ethernet connection' }, Add back to the list when implemented
     const virtualNetwork: NetworkTypeDescription[] = [{
-        name: 'network',
+        type: 'network',
         desc: 'Virtual network',
-        detailHeadline: _("This is the recommended type for general guest connectivity on hosts with dynamic / wireless networking configs."),
-        detailParagraph: _("Provides a connection whose details are described by the named network definition.")
+        detailHeadline: _("For general guest connectivity on hosts with dynamic / wireless networking configs."),
+        excuse: availableSources.network.length == 0 ? _("No virtual networks") : null,
     }];
     if (vm.connectionName !== 'session') {
         availableNetworkTypes = [
             ...virtualNetwork,
             {
-                name: 'bridge',
+                type: 'bridge',
                 desc: 'Bridge to LAN',
-                detailHeadline: _("This is the recommended type for general guest connectivity on hosts with static wired networking configs."),
-                detailParagraph: _("Provides a bridge from the guest virtual machine directly onto the LAN. This needs a bridge device on the host with one or more physical NICs.")
+                detailHeadline: _("For general guest connectivity on hosts with static wired networking configs."),
+                excuse: availableSources.bridge.length == 0 ? _("No bridge devices") : null,
             },
             {
-                name: 'direct',
+                type: 'direct',
                 desc: 'Direct attachment',
-                detailParagraph: _("This is the recommended type for high performance or enhanced security."),
+                detailHeadline: (
+                    <>
+                        {_("Advanced interface type for high performance or enhanced security.")}
+                        {"\n"}
+                        <Button
+                            isInline
+                            variant="link"
+                            component="a"
+                            icon={<ExternalLinkSquareAltIcon />}
+                            iconPosition="right"
+                            target="__blank"
+                            href="https://libvirt.org/formatdomain.html#direct-attachment-to-physical-interface">
+                            {_("More info")}
+                        </Button>
+                    </>
+                ),
+                excuse: availableSources.direct.length == 0 ? _("No network devices") : null,
             },
         ];
     } else {
@@ -114,9 +127,10 @@ function getAvailableNetworkTypes(vm: VM, availableSources: AvailableSources) {
         if (availableSources.network.length > 0) {
             availableNetworkTypes = [
                 {
-                    name: 'user',
+                    type: 'user',
                     desc: 'Userspace stack',
-                    detailParagraph: _("Provides a virtual LAN with NAT to the outside world.")
+                    detailHeadline: _("Provides a virtual LAN with NAT to the outside world."),
+                    excuse: null,
                 },
                 ...virtualNetwork,
             ];
@@ -136,12 +150,12 @@ function getNetworkSource(network: VMInterface): optString {
 }
 
 export interface NetworkTypeAndSourceValue {
-    type: string;
+    type: NetworkType;
     source: string;
     mode: string;
 
     _availableTypes: NetworkTypeDescription[];
-    _availableSourcesForType: Record<string, string[]>;
+    _availableSourcesForType: AvailableSourcesForType;
 }
 
 export function init_NetworkTypeAndSourceRow(
@@ -149,33 +163,54 @@ export function init_NetworkTypeAndSourceRow(
     network: VMInterface | null,
     availableSources: AvailableSources
 ): NetworkTypeAndSourceValue {
-    const _availableSourcesForType: Record<string, string[]> = {
+    const _availableSourcesForType: AvailableSourcesForType = {
         network: availableSources.network,
         direct: Object.keys(availableSources.device)
                 .filter(dev => availableSources.device[dev].type != "bridge"),
         bridge: Object.keys(availableSources.device)
-                .filter(dev => availableSources.device[dev].type == "bridge")
+                .filter(dev => availableSources.device[dev].type == "bridge"),
+        user: [],
     };
 
-    const _availableTypes = getAvailableNetworkTypes(vm, availableSources);
+    const _availableTypes = getAvailableNetworkTypes(vm, _availableSourcesForType);
 
-    let type: string;
+    let type: NetworkType | "";
     let source: string;
     let mode: string;
 
     if (network) {
+        if (!isSupportedNetworkType(network.type))
+            throw new DialogError(cockpit.format(_("Network interfaces of type \"$0\" can not be edited here."), network.type));
+
         type = network.type;
         source = getNetworkSource(network) || "";
         mode = (type == "direct" ? (network.source.mode || "") : "bridge");
-    } else {
-        type = vm.connectionName == "session" ? "user" : "network";
+
+        // Make sure the current network source is available, no
+        // matter what.
+        const avail = _availableSourcesForType[network.type];
+        const src = getNetworkSource(network) || "";
+        if (!avail.includes(src))
+            avail.push(src);
+    } else if (vm.connectionName == "session") {
+        type = "user";
         source = "";
+        mode = "";
+    } else {
+        type = "";
+        source = "";
+        for (const t of _availableTypes) {
+            if (!t.excuse) {
+                type = t.type;
+                source = _availableSourcesForType[type][0];
+                break;
+            }
+        }
         mode = "bridge";
     }
 
-    const available = _availableSourcesForType[type] || [];
-    if (!available.includes(source))
-        source = available.length > 0 ? available[0] : "";
+    if (!type)
+        throw new DialogError(_("There are no sources for virtual network interfaces on this host. You might want to create a virtual network."));
 
     return {
         type,
@@ -193,145 +228,69 @@ export const NetworkTypeAndSourceRow = ({
     field: DialogField<NetworkTypeAndSourceValue>,
 }) => {
     const {
-        type, source, mode,
+        type,
         _availableTypes, _availableSourcesForType
     } = field.get();
 
-    let sourceValue = source;
-    let networkSourcesContent: React.ReactNode;
-    let networkSourceEnabled: boolean = true;
+    const sources = _availableSourcesForType[type];
+    const networkSourcesContent: DialogDropdownSelectOption<string>[] = sources.sort().map(networkSource => {
+        return {
+            value: networkSource,
+            label: networkSource
+        };
+    });
 
-    if (["network", "direct", "bridge"].includes(type)) {
-        const sources = _availableSourcesForType[type] || [];
-        if (sources.length > 0) {
-            networkSourcesContent = sources.sort().map(networkSource => {
-                return (
-                    <FormSelectOption value={networkSource} key={networkSource}
-                                      label={networkSource} />
-                );
-            });
-        } else {
-            if (type === "network")
-                sourceValue = _("No virtual networks");
-            else
-                sourceValue = _("No network devices");
-
-            networkSourcesContent = (
-                <FormSelectOption value='empty-list' key='empty-list'
-                                  label={sourceValue} />
-            );
-            networkSourceEnabled = false;
-        }
-    }
-
-    function setNetworkType(type: string) {
-        field.sub("type").set(type);
+    function updateType(type: NetworkType) {
         const sources = _availableSourcesForType[type] || [];
         field.sub("source").set(sources.length > 0 ? sources[0] : "");
+    }
+
+    function makeTypeOption(type: NetworkTypeDescription): DialogRadioSelectOption<NetworkType> {
+        return {
+            value: type.type,
+            label: type.desc,
+            excuse: type.excuse,
+            explanation: type.detailHeadline,
+        };
     }
 
     return (
         <>
             { _availableTypes.length > 0 &&
-                <FormGroup fieldId={field.sub("type").id()}
+                <DialogRadioSelect<NetworkType>
                     label={_("Interface type")}
-                    labelHelp={
-                        <InfoPopover aria-label={_("Interface type help")}
-                            position={PopoverPosition.bottom}
-                            enableFlip={false}
-                            bodyContent={
-                                <Flex direction={{ default: 'column' }}>
-                                    {_availableTypes.map(type => (
-                                        <Content key={type.name}>
-                                            <Content component={ContentVariants.h4}>{type.desc}</Content>
-                                            <strong>{type.detailHeadline}</strong>
-                                            <p>{type.detailParagraph}</p>
-                                        </Content>))}
-                                </Flex>
-                            }
-                        />
-                    }>
-                    <FormSelect id={field.sub("type").id()}
-                        onChange={(_event, value) => setNetworkType(value)}
-                        data-value={type}
-                        value={type}>
-                        {_availableTypes
-                                .map(networkType => {
-                                    return (
-                                        <FormSelectOption value={networkType.name} key={networkType.name}
-                                    isDisabled={networkType.disabled || false}
-                                    label={networkType.desc} />
-                                    );
-                                })}
-                    </FormSelect>
-                </FormGroup>
+                    field={field.sub("type", updateType)}
+                    options={_availableTypes.map(makeTypeOption)}
+                />
             }
             {["network", "direct", "bridge"].includes(type) && (
-                <FormGroup fieldId={field.sub("source").id()} label={_("Source")}>
-                    <FormSelect id={field.sub("source").id()}
-                        onChange={(_event, val) => field.sub("source").set(val)}
-                                isDisabled={!networkSourceEnabled}
-                                data-value={sourceValue}
-                                value={sourceValue}>
-                        {networkSourcesContent}
-                    </FormSelect>
-                    <DialogHelperText field={field.sub("source")} />
-                </FormGroup>
+                <DialogDropdownSelect
+                    label={_("Source")}
+                    field={field.sub("source")}
+                    options={networkSourcesContent}
+                />
             )}
             {type == "direct" && (
-                <FormGroup id={field.sub("mode").id()} label={_("Mode")} hasNoPaddingTop isInline
-                    data-value={mode}
-                    labelHelp={
-                        <InfoPopover
-                            aria-label={_("Mode help")}
-                            position={PopoverPosition.bottom}
-                            enableFlip={false}
-                            bodyContent={
-                                <Content>
-                                    <Content component={ContentVariants.p}>
-                                        {_("The mode influences the delivery of packets.")}
-                                    </Content>
-                                    <Content component={ContentVariants.p}>
-                                        <Button isInline
-                                            variant="link"
-                                            component="a"
-                                            icon={<ExternalLinkSquareAltIcon />}
-                                            iconPosition="right"
-                                            target="__blank"
-                                            href="https://libvirt.org/formatdomain.html#direct-attachment-to-physical-interface">
-                                            {_("More info")}
-                                        </Button>
-                                    </Content>
-                                </Content>}
-                        />
-                    }>
-                    {["vepa", "bridge", "private", "passthrough"].map(m =>
-                        <Radio
-                            key={m}
-                            id={field.sub("mode").id(m)}
-                            name={`mode-${m}`}
-                            isChecked={mode == m}
+                <DialogRadioSelect
+                    label={_("Mode")}
+                    isInline
+                    field={field.sub("mode")}
+                    options={
+                        [
                             // The label is not translated since the
                             // documentation we link to is always in
                             // English.
-                            label={<pre>{m}</pre>}
-                            onChange={() => field.sub("mode").set(m)} />)}
-                </FormGroup>
+                            { value: "vepa", label: <pre>vepa</pre> },
+                            { value: "bridge", label: <pre>bridge</pre> },
+                            { value: "private", label: <pre>private</pre> },
+                            { value: "passthrough", label: <pre>passthrough</pre> },
+                        ]
+                    }
+                />
             )}
         </>
     );
 };
-
-export function validate_NetworkTypeAndSourceRow(
-    field: DialogField<NetworkTypeAndSourceValue>,
-) {
-    const val = field.get();
-    if (val._availableTypes.length > 0)
-        field.sub("source").validate(v => {
-            if (v == "")
-                return _("No sources available");
-        });
-}
 
 export interface DialogComplexPortForward {
     kind: "complex";

--- a/src/components/vm/nics/nicEdit.tsx
+++ b/src/components/vm/nics/nicEdit.tsx
@@ -10,15 +10,13 @@ import { useDialogs } from 'dialogs';
 import type { optString, VM, VMInterface } from '../../../types';
 import type { AvailableSources } from './vmNicsCard';
 
-import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
+import { Form } from "@patternfly/react-core/dist/esm/components/Form";
 import {
     Modal, ModalBody, ModalFooter, ModalHeader
 } from '@patternfly/react-core/dist/esm/components/Modal';
-import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip";
 
 import {
-    NetworkTypeAndSourceValue, NetworkTypeAndSourceRow,
-    init_NetworkTypeAndSourceRow, validate_NetworkTypeAndSourceRow,
+    NetworkTypeAndSourceValue, NetworkTypeAndSourceRow, init_NetworkTypeAndSourceRow,
     NetworkModelRow,
     PortForwardsValue, NetworkPortForwardsRow, validate_PortForwards,
     interfacePortForwardsToDialog, dialogPortForwardsToInterface,
@@ -27,7 +25,7 @@ import { virtXmlEdit, domainModifyXML, domainGet } from '../../../libvirtApi/dom
 import { NeedsShutdownAlert } from '../../common/needsShutdown.jsx';
 
 import {
-    useDialogState, DialogField, DialogError,
+    useDialogState_async, DialogState, DialogField, DialogError,
     DialogErrorMessage,
     DialogTextInput,
     DialogActionButton, DialogCancelButton,
@@ -42,18 +40,12 @@ const NetworkMacRow = ({
     field: DialogField<string>,
     isShutoff: boolean,
 }) => {
-    let macInput = (
-        <DialogTextInput
-            field={field}
-            {...(!isShutoff ? { readOnlyVariant: "plain" } : {})} />
-    );
-    if (!isShutoff)
-        macInput = <Tooltip content={_("Only editable when the guest is shut off")}>{macInput}</Tooltip>;
-
     return (
-        <FormGroup fieldId={field.id()} label={_("MAC address")}>
-            {macInput}
-        </FormGroup>
+        <DialogTextInput
+            label={_("MAC address")}
+            field={field}
+            excuse={!isShutoff ? _("Only editable when the guest is shut off") : null}
+        />
     );
 };
 
@@ -67,8 +59,8 @@ function getNetworkSource(network: VMInterface): optString {
 }
 
 interface EditNICValues {
-    model: string,
     type_and_source: NetworkTypeAndSourceValue,
+    model: string,
     mac: string;
     portForwards: PortForwardsValue;
 }
@@ -86,17 +78,16 @@ export const EditNICModal = ({
 }) => {
     const Dialogs = useDialogs();
 
-    function init(): EditNICValues {
+    async function init(): Promise<EditNICValues> {
         return {
-            model: network.model || "",
             type_and_source: init_NetworkTypeAndSourceRow(vm, network, availableSources),
+            model: network.model || "",
             mac: network.mac || "",
             portForwards: interfacePortForwardsToDialog(network.portForward),
         };
     }
 
-    function validate() {
-        validate_NetworkTypeAndSourceRow(dlg.field("type_and_source"));
+    function validate(dlg: DialogState<EditNICValues>) {
         if (dlg.values.type_and_source.type == "user")
             validate_PortForwards(dlg.field("portForwards"));
     }
@@ -173,10 +164,11 @@ export const EditNICModal = ({
         }
     }
 
-    const dlg = useDialogState<EditNICValues>(init, validate);
+    const dlg = useDialogState_async<EditNICValues>(init, validate);
 
     const showWarning = () => {
-        if (vm.state === 'running' && (
+        if (vm.state === 'running' &&
+            dlg instanceof DialogState && (
             dlg.values.type_and_source.type !== network.type ||
                 dlg.values.type_and_source.source !== getNetworkSource(network) ||
                 dlg.values.model !== network.model)
@@ -185,30 +177,34 @@ export const EditNICModal = ({
         }
     };
 
-    const defaultBody = (
-        <>
-            <Form onSubmit={e => e.preventDefault()} isHorizontal>
-                <NetworkTypeAndSourceRow field={dlg.field("type_and_source")} />
-                <NetworkModelRow
-                    field={dlg.field("model")}
-                    osTypeArch={vm.arch}
-                    osTypeMachine={vm.emulatedMachine}
-                />
-                <NetworkMacRow
-                    field={dlg.field("mac")}
-                    isShutoff={vm.state == "shut off"}
-                />
-            </Form>
-            { dlg.values.type_and_source.type == "user" &&
-                vm.capabilities.interfaceBackends.includes("passt") &&
-                (!network.backend || network.backend == "passt") &&
-                <Form>
-                    <br />
-                    <NetworkPortForwardsRow field={dlg.field("portForwards")} />
+    let defaultBody: React.ReactNode;
+
+    if (dlg instanceof DialogState) {
+        defaultBody = (
+            <>
+                <Form onSubmit={e => e.preventDefault()} isHorizontal>
+                    <NetworkTypeAndSourceRow field={dlg.field("type_and_source")} />
+                    <NetworkModelRow
+                        field={dlg.field("model")}
+                        osTypeArch={vm.arch}
+                        osTypeMachine={vm.emulatedMachine}
+                    />
+                    <NetworkMacRow
+                        field={dlg.field("mac")}
+                        isShutoff={vm.state == "shut off"}
+                    />
                 </Form>
-            }
-        </>
-    );
+                { dlg.values.type_and_source.type == "user" &&
+                    vm.capabilities.interfaceBackends.includes("passt") &&
+                    (!network.backend || network.backend == "passt") &&
+                    <Form>
+                        <br />
+                        <NetworkPortForwardsRow field={dlg.field("portForwards")} />
+                    </Form>
+                }
+            </>
+        );
+    }
 
     return (
         <Modal

--- a/src/components/vm/nics/vmNicsCard.tsx
+++ b/src/components/vm/nics/vmNicsCard.tsx
@@ -40,7 +40,8 @@ const getNetworkDevices = async (): Promise<Record<string, NetworkDevice>> => {
 
         const devs: Record<string, NetworkDevice> = {};
         for (const dev of output.trim().split('\n')) {
-            devs[dev] = {};
+            if (dev)
+                devs[dev] = {};
         }
 
         const bridges = await cockpit.spawn(["ip", "-j", "link", "show", "type", "bridge"], { err: "message" });

--- a/test/check-machines-networks
+++ b/test/check-machines-networks
@@ -579,13 +579,13 @@ class TestMachinesNetworks(machineslib.VirtualMachinesCase):
         b.click("#vm-subVmTest1-network-2-edit-dialog")
 
         # Change network model type of a running domain
-        b.select_from_dropdown(d.field("model"), "e1000e")
+        d.set_DropdownSelect("model", "e1000e")
         # Wait for the dialog warning to appear
         b.wait_visible("#vm-subVmTest1-network-2-edit-dialog-idle-message")
         # Change network type and source of a running domain
-        b.wait_val(d.field("type_and_source.type"), "network")
-        b.wait_val(d.field("type_and_source.source"), "default")
-        b.select_from_dropdown(d.field("type_and_source.source"), "test_network")
+        d.wait_RadioSelect("type_and_source.type", "network")
+        d.wait_DropdownSelect("type_and_source.source", "default")
+        d.set_DropdownSelect("type_and_source.source", "test_network")
         # Save the network settings
         b.click(d.apply_button())
         b.wait_not_present("#vm-subVmTest1-network-2-edit-dialog-modal-window")
@@ -629,9 +629,9 @@ class TestMachinesNetworks(machineslib.VirtualMachinesCase):
         # Open the modal dialog
         b.click("#vm-subVmTest1-network-1-edit-dialog")
 
-        b.wait_val(d.field("type_and_source.type"), "bridge")
-        b.select_from_dropdown(d.field("type_and_source.type"), "direct")
-        source = b.val(d.field("type_and_source.source"))
+        d.wait_RadioSelect("type_and_source.type", "bridge")
+        d.set_RadioSelect("type_and_source.type", "direct")
+        source = d.get_DropdownSelect("type_and_source.source")
 
         # Save the network settings
         b.click(d.apply_button())
@@ -644,9 +644,9 @@ class TestMachinesNetworks(machineslib.VirtualMachinesCase):
         # Open the modal dialog
         b.click("#vm-subVmTest1-network-1-edit-dialog")
 
-        b.wait_val(d.field("type_and_source.type"), "direct")
-        b.select_from_dropdown(d.field("type_and_source.type"), "bridge")
-        b.select_from_dropdown(d.field("type_and_source.source"), "virbr0")
+        d.wait_RadioSelect("type_and_source.type", "direct")
+        d.set_RadioSelect("type_and_source.type", "bridge")
+        d.set_DropdownSelect("type_and_source.source", "virbr0")
 
         # Save the network settings
         b.click(d.apply_button())
@@ -656,7 +656,7 @@ class TestMachinesNetworks(machineslib.VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-network-1-source", "virbr0")
 
         b.click("#vm-subVmTest1-network-1-edit-dialog")
-        b.wait_in_text(d.field("type_and_source.source"), "virbr0")
+        d.wait_DropdownSelect("type_and_source.source", "virbr0")
         b.click(d.apply_button())
         b.wait_not_present("#vm-subVmTest1-network-1-edit-dialog-modal-window")
         b.wait_in_text("#vm-subVmTest1-network-1-source", "virbr0")
@@ -665,9 +665,9 @@ class TestMachinesNetworks(machineslib.VirtualMachinesCase):
         # Open the modal dialog
         b.click("#vm-subVmTest1-network-1-edit-dialog")
 
-        b.wait_val(d.field("type_and_source.type"), "bridge")
-        b.select_from_dropdown(d.field("type_and_source.type"), "network")
-        b.select_from_dropdown(d.field("type_and_source.source"), "test_network")
+        d.wait_RadioSelect("type_and_source.type", "bridge")
+        d.set_RadioSelect("type_and_source.type", "network")
+        d.set_DropdownSelect("type_and_source.source", "test_network")
 
         # Save the network settings
         b.click(d.apply_button())
@@ -679,8 +679,7 @@ class TestMachinesNetworks(machineslib.VirtualMachinesCase):
         # Remove test_network from the VM again
         self.deleteIface(1)
 
-        # Remove all Virtual Networks and confirm that trying to choose
-        # Virtual Networks type for a NIC disables the save button
+        # Remove all Virtual Networks
         m.execute("virsh net-dumpxml default > /tmp/net-default.xml")
         m.execute("virsh net-dumpxml test_network > /tmp/net-test-network.xml")
         m.execute("virsh net-destroy test_network; virsh net-destroy default")
@@ -709,15 +708,13 @@ class TestMachinesNetworks(machineslib.VirtualMachinesCase):
         # Open the modal dialog
         b.click("#vm-subVmTest1-network-1-edit-dialog")
 
-        # And ensure that the network sources dropdown is disabled
-        b.wait_val(d.field("type_and_source.type"), "bridge")
-        b.select_from_dropdown(d.field("type_and_source.type"), "network")
-        b.click(d.apply_button())
-        b.wait_in_text(d.helper_text("type_and_source.source"), "No sources available")
-        b.wait_visible(d.apply_button() + ":disabled")
+        # And ensure that the network type is disabled
+        d.wait_RadioSelect("type_and_source.type", "bridge")
+        b.wait_visible(d.id("type_and_source.type", "network") + ":disabled")
         b.click(d.cancel_button())
 
-        # Ensure that when the source of a NIC was removed we can still change it
+        # Ensure that when the source of a NIC was removed, it is
+        # still shown in the Edit dialog, and we can still change it
 
         # Redefine deleted networks and attach an interface with source a deleted network
         next_mac = self.get_next_mac(next_mac)
@@ -733,18 +730,15 @@ class TestMachinesNetworks(machineslib.VirtualMachinesCase):
         self.performAction("subVmTest1", "forceOff")
 
         # Try to edit the interface changing the source to a non deleted network
-        b.click("#vm-subVmTest1-network-1-edit-dialog")
-        b.wait_visible("#vm-subVmTest1-network-1-edit-dialog-modal-window")
-        b.select_from_dropdown(d.field("type_and_source.type"), "network")
-        b.select_from_dropdown(d.field("type_and_source.source"), "test_network")
+        b.click("#vm-subVmTest1-network-2-edit-dialog")
+        b.wait_visible("#vm-subVmTest1-network-2-edit-dialog-modal-window")
+        d.wait_RadioSelect("type_and_source.type", "network")
+        d.wait_DropdownSelect("type_and_source.source", "default")
+        d.set_DropdownSelect("type_and_source.source", "test_network")
         b.click(d.apply_button())
-        b.wait_not_present("#vm-subVmTest1-network-1-edit-dialog-modal-window")
-        self.expandNicRow(1)
-        b.wait_in_text("#vm-subVmTest1-network-1-source", "test_network")
-
-        # Test detaching of disk on non-persistent VM
-        m.execute("virsh undefine subVmTest1")
-        b.wait_not_present("#vm-subVmTest1-network-1-edit-dialog")
+        b.wait_not_present("#vm-subVmTest1-network-2-edit-dialog-modal-window")
+        self.expandNicRow(2)
+        b.wait_in_text("#vm-subVmTest1-network-2-source", "test_network")
 
     def testNetworkAutostart(self):
         b = self.browser

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -93,7 +93,7 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
         self.waitPageInit()
         b.click("#vm-subVmTest1-add-iface-button")  # open the Network Interfaces subtab
         b.wait_visible("#vm-subVmTest1-add-iface-dialog")
-        b.select_from_dropdown(d.field("type_and_source.type"), "bridge")
+        d.set_RadioSelect("type_and_source.type", "bridge")
         # dropdown options are not visible, but still part of DOM tree, so let's use _wait_present
         b._wait_present(d.field("type_and_source.source") + " option:nth-of-type(1):contains('0bridge')")
         b._wait_present(d.field("type_and_source.source") + " option:nth-of-type(2):contains('abridge')")
@@ -450,6 +450,25 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
             remove=False,
         ).execute()
 
+    def testNICAddNoDefault(self):
+        m = self.machine
+
+        self.createVm("subVmTest1", running=False)
+
+        # Delete the "default" virtual network and hide all real interfaces.
+        m.execute("virsh net-destroy default; virsh net-undefine default")
+        m.execute('mount -t tmpfs tmpfs /sys/class/net')
+        self.addCleanup(self.machine.execute, "umount /sys/class/net")
+
+        self.login_and_go("/machines")
+        self.waitPageInit()
+        self.goToVmPage("subVmTest1")
+
+        self.browser.click("#vm-subVmTest1-add-iface-button")
+        self.browser.wait_in_text(".pf-v6-c-modal-box .pf-v6-c-modal-box__header .pf-v6-c-modal-box__title",
+                                  "Add virtual network interface")
+        self.browser.wait_in_text(".pf-v6-c-modal-box", "There are no sources for virtual network interfaces")
+
     class NICEditDialog(DialogHelpers):
 
         def __init__(
@@ -496,29 +515,29 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
 
             # select widget options are never visible for the headless chrome,
             # call therefore directly the js function
-            self.source_type_current = b.attr(self.field("type_and_source.type"), "data-value")
+            self.source_type_current = self.get_RadioSelect("type_and_source.type")
             if self.source_type_current == "direct":
-                self.source_mode_current = b.attr(self.field("type_and_source.mode"), "data-value")
-            self.source_current = b.attr(self.field("type_and_source.source"), "data-value")
-            self.mac_current = b.val(self.field("mac"))
-            self.model_current = b.attr(self.field("model"), "data-value")
+                self.source_mode_current = self.get_RadioSelect("type_and_source.mode")
+            self.source_current = self.get_DropdownSelect("type_and_source.source")
+            self.mac_current = self.get_TextInput("mac")
+            self.model_current = self.get_DropdownSelect("model")
 
         def fill(self):
             b = self.browser
 
             if self.source_type:
-                b.select_from_dropdown(self.field("type_and_source.type"), self.source_type)
+                self.set_RadioSelect("type_and_source.type", self.source_type)
             if self.source_mode:
-                b.click(self.id("type_and_source.mode", self.source_mode))
+                self.set_RadioSelect("type_and_source.mode", self.source_mode)
             if self.source:
-                b.select_from_dropdown(self.field("type_and_source.source"), self.source)
+                self.set_DropdownSelect("type_and_source.source", self.source)
             if self.model:
-                b.select_from_dropdown(self.field("model"), self.model)
+                self.set_DropdownSelect("model", self.model)
 
             if self.vm_state == "running":
-                b.wait_attr(self.field("mac"), "readonly", "")
+                b.wait_attr(self.field("mac"), "disabled", "")
             else:
-                b.set_input_text(self.field("mac"), self.mac)
+                self.set_TextInput("mac", self.mac)
 
             if (self.vm_state == "running" and
                     ((self.source_type is not None and self.source_type != self.source_type_current) or
@@ -805,7 +824,7 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
                                       "Add virtual network interface")
 
         def fill(self):
-            self.browser.select_from_dropdown(self.field("type_and_source.type"), self.source_type)
+            self.set_RadioSelect("type_and_source.type", self.source_type)
 
             # Ensure that Bridge to LAN option offers only bridge devices for selection and vice versa
             for bridge in self.bridge_devices:
@@ -815,15 +834,15 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
                     self.browser._wait_present(self.field("type_and_source.source") + f" option[value={bridge}]")
 
             if self.source_mode:
-                self.browser.click(self.id("type_and_source.mode", self.source_mode))
+                self.set_RadioSelect("type_and_source.mode", self.source_mode)
             if self.source:
-                self.browser.select_from_dropdown(self.field("type_and_source.source"), self.source)
+                self.set_DropdownSelect("type_and_source.source", self.source)
             if self.model:
-                self.browser.select_from_dropdown(self.field("model"), self.model)
+                self.set_DropdownSelect("model", self.model)
 
             if self.mac:
                 self.browser.click(self.id("mac.set", "on"))
-                self.browser.set_input_text(self.field("mac.val"), self.mac)
+                self.set_TextInput("mac.val", self.mac)
 
             if self.permanent:
                 self.browser.click(self.field("permanent"))
@@ -859,7 +878,7 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
             if (self.source_type == "network"):
                 self.assertEqual("network", self.machine.execute(xmllint_element.format(prop='@type')).strip())
                 if self.source:
-                    self.assertEqual(self.source,
+                    self.assertEqual("default" if self.source == "$create" else self.source,
                                      self.machine.execute(xmllint_element.format(prop='source/@network')).strip())
             elif (self.source_type == "direct"):
                 self.assertEqual("direct", self.machine.execute(xmllint_element.format(prop='@type')).strip())
@@ -881,7 +900,8 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
             if self.model:
                 self.browser.wait_in_text(f"#vm-subVmTest1-network-{self.nic_num}-model", self.model)
             if self.source:
-                self.browser.wait_in_text(f"#vm-subVmTest1-network-{self.nic_num}-source", self.source)
+                self.browser.wait_in_text(f"#vm-subVmTest1-network-{self.nic_num}-source",
+                                          "default" if self.source == "$create" else self.source)
             if self.source_mode:
                 self.browser.wait_in_text(f"#vm-subVmTest1-network-{self.nic_num}-source-mode", self.source_mode)
             if self.mac:
@@ -928,22 +948,22 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
         b.click("#vm-subVmTest1-network-1-edit-dialog")
         b.wait_visible("#vm-subVmTest1-network-1-edit-dialog-modal-window")
         b.click(d.field("portForwards") + " button:contains(Add)")
-        b.set_input_text(d.field("portForwards.0.host"), "8080-8090")
-        b.set_input_text(d.field("portForwards.0.guest"), "80")
-        b.select_from_dropdown(d.field("portForwards.0.proto"), "udp")
+        d.set_TextInput("portForwards.0.host", "8080-8090")
+        d.set_TextInput("portForwards.0.guest", "80")
+        d.set_DropdownSelect("portForwards.0.proto", "udp")
         b.click(d.field("portForwards") + " button:contains(Add)")
-        b.set_input_text(d.field("portForwards.1.address"), "127.0.0.1")
-        b.set_input_text(d.field("portForwards.1.host"), "2222")
-        b.set_input_text(d.field("portForwards.1.guest"), "22")
+        d.set_TextInput("portForwards.1.address", "127.0.0.1")
+        d.set_TextInput("portForwards.1.host", "2222")
+        d.set_TextInput("portForwards.1.guest", "22")
         b.click(d.field("portForwards") + " button:contains(Add)")
-        b.set_input_text(d.field("portForwards.2.address"), "localhost")
-        b.set_input_text(d.field("portForwards.2.host"), "")
-        b.set_input_text(d.field("portForwards.2.guest"), "ssh")
+        d.set_TextInput("portForwards.2.address", "localhost")
+        d.set_TextInput("portForwards.2.host", "")
+        d.set_TextInput("portForwards.2.guest", "ssh")
         b.click(d.apply_button())
         b.wait_in_text(d.helper_text("portForwards.2.address"), "Invalid IP address")
         b.wait_in_text(d.helper_text("portForwards.2.host"), "Host port can not be empty")
         b.wait_in_text(d.helper_text("portForwards.2.guest"), "Port must be a number")
-        b.set_input_text(d.field("portForwards.2.host"), "xxx")
+        d.set_TextInput("portForwards.2.host", "xxx")
         b.wait_in_text(d.helper_text("portForwards.2.host"), "Port must be a number")
         b.click(d.id("portForwards.2", "remove"))
         b.click(d.apply_button())
@@ -994,8 +1014,8 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
 
         b.click("#vm-subVmTest1-add-iface-button")
         b.wait_visible("#vm-subVmTest1-add-iface-dialog")
-        self.browser.click(d.id("mac.set", "on"))
-        self.browser.set_input_text(d.field("mac.val"), "52:54:01:00:00:01")
+        b.click(d.id("mac.set", "on"))
+        d.set_TextInput("mac.val", "52:54:01:00:00:01")
         b.click(d.apply_button())
         b.wait_not_present("#vm-subVmTest1-add-iface-dialog")
 
@@ -1009,11 +1029,11 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
 
         b.click("#vm-subVmTest1-add-iface-button")
         b.wait_visible("#vm-subVmTest1-add-iface-dialog")
-        self.browser.click(d.id("mac.set", "on"))
-        self.browser.set_input_text(d.field("mac.val"), "52:54:01:00:00:02")
+        b.click(d.id("mac.set", "on"))
+        d.set_TextInput("mac.val", "52:54:01:00:00:02")
         b.click(d.field("portForwards") + " button:contains(Add)")
-        b.set_input_text(d.field("portForwards.0.host"), "8080")
-        b.set_input_text(d.field("portForwards.0.guest"), "80")
+        d.set_TextInput("portForwards.0.host", "8080")
+        d.set_TextInput("portForwards.0.guest", "80")
         b.click(d.apply_button())
         b.wait_not_present("#vm-subVmTest1-add-iface-dialog")
         self.expandNicRow(3)
@@ -1028,7 +1048,7 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
         # Change port forward of a NIC, check "pending".
         b.click("#vm-subVmTest1-network-3-edit-dialog")
         b.wait_visible("#vm-subVmTest1-network-3-edit-dialog-modal-window")
-        b.set_input_text(d.field("portForwards.0.guest"), "88")
+        d.set_TextInput("portForwards.0.guest", "88")
         b.click(d.apply_button())
         b.wait_not_present("#vm-subVmTest1-network-3-edit-dialog-modal-window")
         b.wait_visible("#vm-subVmTest1-network-3-port-forward-0-tooltip")

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -302,7 +302,7 @@ class VirtualMachinesCaseHelpers(testlib.MachineCase):
         b.wait_not_present(".pf-v6-c-modal-box")
         b.wait_not_present(f"#vm-{vm_name}-disks-{target}-device")
 
-    def deleteIface(self, iface: str, mac: str | None = None, vm_name: str | None = None) -> None:
+    def deleteIface(self, iface: int, mac: str | None = None, vm_name: str | None = None) -> None:
         b = self.browser
 
         self.dropdownAction(f"#vm-subVmTest1-iface-{iface}-action-kebab", f"#delete-vm-subVmTest1-iface-{iface}")


### PR DESCRIPTION
Demo:  https://youtu.be/VSb6anWw-tc

This uses the obvious porcelain components for checkboxes, dropdown selects and radio buttons. At the same time, the dialog experience is improved in a number of ways:

 - Instead of being read-only with a tooltip, the mac field is now disabled with a helper text.  The readonly state is rare and communicates less well than the disabled state. Tooltips (that open on hover) are not mobile friendly and generally awkward. There is enough space in the dialog for a inline explanation.

 - The "interface type" is selected with radio buttons instead of a dropdown. There are only three types and there is enough space to show them all. Instead of a info popover with questionably typography and content, the choices now have brief helper text to explain their purpose.

 - When a interface type has no sources, the type is disabled, instead of keeping it enabled and showing an empty list of sources, which would be a dead-end.

 - When editing a interface, the current source is always in the "Source" dropdown, even if it doesn't currently exist. Consequently, the current type is always enabled.

 - When adding a interface and there are no sources at all, the dialog explains that and only offers "Cancel".

<img width="845" height="606" alt="image" src="https://github.com/user-attachments/assets/3adf1890-caa8-487c-b75c-60d78a0b8c95" />

<img width="852" height="535" alt="image" src="https://github.com/user-attachments/assets/34fe3fa4-bae0-41d1-84c4-38b979639dae" />

<img width="1080" height="311" alt="image" src="https://github.com/user-attachments/assets/b07193cf-9e13-44d2-ab07-e12684562a8d" />

Fixes: [COCKPIT-1761](https://redhat.atlassian.net/browse/COCKPIT-1761)

[COCKPIT-1761]: https://redhat.atlassian.net/browse/COCKPIT-1761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ