### PR TITLE
consoles: Make console selector scrollable

### DIFF
--- a/src/components/vm/consoles/consoles.tsx
+++ b/src/components/vm/consoles/consoles.tsx
@@ -398,6 +398,7 @@ export const ConsoleCard = ({
                                     ? <ToggleGroup>{tabs}</ToggleGroup>
                                     : <SimpleSelect
                                           options={select_options}
+                                          isScrollable
                                           selected={type}
                                           onSelect={t => state.setType(t)}
                                     />


### PR DESCRIPTION
when it is a SimpleSelect instead of a set of toggle buttons. Otherwise the menu might not be useable when it is truly huge and starts overflowing the page.

Fixes RHEL-106754, again.