### PR TITLE
disks: Redo "Add disk" and "Insert media" dialog with new framework

### DIFF
--- a/src/components/common/dialog.tsx
+++ b/src/components/common/dialog.tsx
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * Copyright (C) 2026 Red Hat, Inc.
+ */
+
+/* Common dialog input elements that are compatible with
+   "cockpit/dialog".
+ */
+
+import cockpit from "cockpit";
+import React from 'react';
+
+import { InputGroup } from "@patternfly/react-core/dist/esm/components/InputGroup";
+
+import { FileAutoComplete as CockpitFileAutoComplete } from "cockpit-components-file-autocomplete.jsx";
+
+import {
+    DialogField,
+    DialogHelperText, OptionalFormGroup,
+    DialogTextInput,
+    DialogDropdownSelect,
+} from "cockpit/dialog";
+
+import { convertToUnit, units } from "../../helpers.js";
+
+const _ = cockpit.gettext;
+
+export const FileAutoComplete = ({
+    label,
+    field,
+    placeholder,
+} : {
+    label: React.ReactNode,
+    field: DialogField<string>,
+    placeholder: string,
+}) => {
+    return (
+        <OptionalFormGroup label={label}>
+            <CockpitFileAutoComplete
+                id={field.id()}
+                placeholder={placeholder}
+                onChange={(value: string) => field.set(value)}
+                value={field.get()}
+                superuser="try"
+            />
+            <DialogHelperText field={field} />
+        </OptionalFormGroup>
+    );
+};
+
+export interface SizeValue {
+    size: string,
+    unit: string,
+}
+
+export const SizeInput = ({
+    label,
+    field,
+    max,
+    warning,
+    explanation,
+} : {
+    label: React.ReactNode,
+    field: DialogField<SizeValue>,
+    max: number,
+    warning?: React.ReactNode;
+    explanation?: React.ReactNode;
+}) => {
+    const { unit } = field.get();
+    const maxSize = parseFloat(convertToUnit(max, units.B, unit).toFixed(2));
+
+    return (
+        <OptionalFormGroup
+            label={label}
+            fieldId={field.sub("size").id()}
+        >
+            <InputGroup>
+                {/* We don't do anything special while the user is
+                    typing, like rejecting certain key strokes, or
+                    converting the value to a integer and back to a
+                    string.  That would all be too surprising. If the
+                    entered text is not a number, then the value will
+                    be the empty string, which needs to be rejected
+                    during validation.
+                  */}
+                <DialogTextInput
+                    field={field.sub("size")}
+                    type="number"
+                    inputMode='numeric'
+                    step={1}
+                    min={0}
+                    max={maxSize}
+                />
+                <DialogDropdownSelect
+                    className="ct-machines-select-unit"
+                    field={field.sub("unit")}
+                    options={[
+                        { value: units.MiB.name, label: _("MiB") },
+                        { value: units.GiB.name, label: _("GiB") },
+                    ]}
+                />
+            </InputGroup>
+            <DialogHelperText field={field} warning={warning} explanation={explanation} />
+        </OptionalFormGroup>
+    );
+};

--- a/src/components/storagePools/storageVolumeCreate.tsx
+++ b/src/components/storagePools/storageVolumeCreate.tsx
@@ -7,8 +7,7 @@
 import React from 'react';
 
 import type { StoragePool } from '../../types';
-import type { DialogValues, ValidationFailed } from './storageVolumeCreateBody';
-import type { Dialogs } from 'dialogs';
+import { useDialogs } from 'dialogs';
 
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Form } from "@patternfly/react-core/dist/esm/components/Form";
@@ -18,165 +17,138 @@ import {
 import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip";
 import cockpit from 'cockpit';
 
-import { ModalError } from 'cockpit-components-inline-notification.jsx';
-import { DialogsContext } from 'dialogs.jsx';
-import { units, getDefaultVolumeFormat, convertToUnit, isEmpty } from '../../helpers.js';
+import { convertToUnit } from '../../helpers.js';
 import { storageVolumeCreate } from '../../libvirtApi/storageVolume.js';
-import { VolumeCreateBody } from './storageVolumeCreateBody.jsx';
+
+import {
+    type VolumeCreateValue, VolumeCreate, init_VolumeCreate, validate_VolumeCreate,
+} from './storageVolumeCreateBody.jsx';
+import {
+    useDialogState,
+    DialogError, DialogErrorMessage,
+    DialogActionButton, DialogCancelButton,
+} from 'cockpit/dialog';
 
 const _ = cockpit.gettext;
 
-interface CreateStorageVolumeModalProps {
+interface CreateStorageVolumeValues {
+    volume: VolumeCreateValue,
+}
+
+const CreateStorageVolumeModal = ({
+    idPrefix,
+    storagePool,
+} : {
     idPrefix: string;
     storagePool: StoragePool;
-}
+}) => {
+    const Dialogs = useDialogs();
 
-interface CreateStorageVolumeModalState extends DialogValues {
-    createInProgress: boolean,
-    validate?: boolean;
-    dialogError: string | undefined,
-    dialogErrorDetail?: string | undefined;
-}
-
-class CreateStorageVolumeModal extends React.Component<CreateStorageVolumeModalProps, CreateStorageVolumeModalState> {
-    static contextType = DialogsContext;
-    declare context: Dialogs;
-
-    constructor(props: CreateStorageVolumeModalProps) {
-        super(props);
-        this.state = {
-            createInProgress: false,
-            dialogError: undefined,
-            volumeName: '',
-            size: 1,
-            unit: units.GiB.name,
-            format: getDefaultVolumeFormat(props.storagePool),
+    function init() {
+        return {
+            volume: init_VolumeCreate(storagePool),
         };
-        this.dialogErrorSet = this.dialogErrorSet.bind(this);
-        this.onCreateClicked = this.onCreateClicked.bind(this);
-        this.onValueChanged = this.onValueChanged.bind(this);
-        this.validateParams = this.validateParams.bind(this);
     }
 
-    dialogErrorSet(text: string, detail: string) {
-        this.setState({ dialogError: text, dialogErrorDetail: detail });
+    function validate() {
+        validate_VolumeCreate(dlg.field("volume"));
     }
 
-    onValueChanged<K extends keyof DialogValues>(key: K, value: DialogValues[K]) {
-        this.setState({ [key]: value } as Pick<CreateStorageVolumeModalState, K>);
-    }
+    const dlg = useDialogState<CreateStorageVolumeValues>(init, validate);
 
-    validateParams() {
-        const validationFailed: ValidationFailed = {};
+    async function create(values: CreateStorageVolumeValues) {
+        const { name: volName, format, newSize } = values.volume;
+        const { name: poolName, connectionName } = storagePool;
+        const size = convertToUnit(newSize.size, newSize.unit, 'MiB');
 
-        if (isEmpty(this.state.volumeName.trim()))
-            validationFailed.volumeName = _("Name must not be empty");
-        const poolCapacity = convertToUnit(this.props.storagePool.capacity, units.B, this.state.unit);
-        if (this.state.size > poolCapacity)
-            validationFailed.size = cockpit.format(_("Storage volume size must not exceed the storage pool's capacity ($0 $1)"), poolCapacity.toFixed(2), this.state.unit);
-
-        return validationFailed;
-    }
-
-    onCreateClicked() {
-        const Dialogs = this.context;
-        const validation = this.validateParams();
-        if (Object.getOwnPropertyNames(validation).length > 0) {
-            this.setState({ createInProgress: false, validate: true });
-        } else {
-            this.setState({ createInProgress: true, validate: false });
-
-            const { volumeName, format } = this.state;
-            const { name, connectionName } = this.props.storagePool;
-            const size = convertToUnit(this.state.size, this.state.unit, 'MiB');
-
-            storageVolumeCreate({ connectionName, poolName: name, volName: volumeName, size, format })
-                    .then(() => Dialogs.close())
-                    .catch(exc => {
-                        this.setState({ createInProgress: false });
-                        this.dialogErrorSet(_("Volume failed to be created"), exc.message);
-                    });
+        try {
+            await storageVolumeCreate({
+                connectionName,
+                poolName,
+                volName,
+                size,
+                format
+            });
+        } catch (ex) {
+            throw DialogError.fromError(_("Volume failed to be created"), ex);
         }
     }
 
-    render() {
-        const Dialogs = this.context;
-        const idPrefix = `${this.props.idPrefix}-dialog`;
-        const validationFailed = this.state.validate ? this.validateParams() : {};
+    return (
+        <Modal
+            position="top"
+            variant="medium"
+            id={`${idPrefix}-dialog-modal`}
+            className='volume-create'
+            isOpen
+            onClose={Dialogs.close}
+        >
+            <ModalHeader title={_("Create storage volume")} />
+            <ModalBody>
+                <DialogErrorMessage dialog={dlg} />
+                <Form isHorizontal>
+                    <VolumeCreate field={dlg.field("volume")} />
+                </Form>
+            </ModalBody>
+            <ModalFooter>
+                <DialogActionButton dialog={dlg} onClose={Dialogs.close} action={create}>
+                    {_("Create")}
+                </DialogActionButton>
+                <DialogCancelButton dialog={dlg} onClose={Dialogs.close} />
+            </ModalFooter>
+        </Modal>
+    );
+};
 
-        return (
-            <Modal position="top" variant="medium" id={`${idPrefix}-modal`} className='volume-create' isOpen onClose={Dialogs.close}>
-                <ModalHeader title={_("Create storage volume")} />
-                <ModalBody>
-                    <Form isHorizontal>
-                        {this.state.dialogError &&
-                            <ModalError
-                                dialogError={this.state.dialogError}
-                                {...this.state.dialogErrorDetail && { dialogErrorDetail: this.state.dialogErrorDetail } }
-                            />
-                        }
-                        <VolumeCreateBody format={this.state.format}
-                                          idPrefix={idPrefix}
-                                          onValueChanged={this.onValueChanged}
-                                          size={this.state.size}
-                                          storagePool={this.props.storagePool}
-                                          unit={this.state.unit}
-                                          validationFailed={validationFailed}
-                                          volumeName={this.state.volumeName} />
-                    </Form>
-                </ModalBody>
-                <ModalFooter>
-                    <Button variant="primary" onClick={this.onCreateClicked} isLoading={this.state.createInProgress} isDisabled={this.state.createInProgress}>
-                        {_("Create")}
-                    </Button>
-                    <Button variant='link' onClick={Dialogs.close}>
-                        {_("Cancel")}
-                    </Button>
-                </ModalFooter>
-            </Modal>
-        );
-    }
-}
-
-interface StorageVolumeCreateProps {
+export const StorageVolumeCreate = ({
+    storagePool,
+} : {
     storagePool: StoragePool,
-}
+}) => {
+    const Dialogs = useDialogs();
+    const idPrefix = `${storagePool.name}-${storagePool.connectionName}-create-volume`;
+    const poolTypesNotSupportingVolumeCreation = ['iscsi', 'iscsi-direct', 'gluster', 'mpath'];
 
-export class StorageVolumeCreate extends React.Component<StorageVolumeCreateProps> {
-    static contextType = DialogsContext;
-    declare context: Dialogs;
-
-    render() {
-        const Dialogs = this.context;
-        const idPrefix = `${this.props.storagePool.name}-${this.props.storagePool.connectionName}-create-volume`;
-        const poolTypesNotSupportingVolumeCreation = ['iscsi', 'iscsi-direct', 'gluster', 'mpath'];
-
-        const createButton = () => {
-            if (!poolTypesNotSupportingVolumeCreation.includes(this.props.storagePool.type) && this.props.storagePool.active) {
-                return (
-                    <Button id={`${idPrefix}-button`}
+    const createButton = () => {
+        if (!poolTypesNotSupportingVolumeCreation.includes(storagePool.type) && storagePool.active) {
+            return (
+                <Button id={`${idPrefix}-button`}
+                    variant='secondary'
+                    onClick={
+                        () => Dialogs.show(
+                            <CreateStorageVolumeModal
+                                idPrefix="create-volume"
+                                storagePool={storagePool}
+                            />
+                        )
+                    }
+                >
+                    {_("Create volume")}
+                </Button>
+            );
+        } else {
+            return (
+                <Tooltip
+                    id='create-tooltip'
+                    content={
+                        storagePool.active
+                            ? _("Pool type doesn't support volume creation")
+                            : _("Pool needs to be active to create volume")
+                    }
+                >
+                    <span>
+                        <Button
+                            id={`${idPrefix}-button`}
                             variant='secondary'
-                            onClick={() => Dialogs.show(<CreateStorageVolumeModal idPrefix="create-volume"
-                                                                                  storagePool={this.props.storagePool} />)}>
-                        {_("Create volume")}
-                    </Button>
-                );
-            } else {
-                return (
-                    <Tooltip id='create-tooltip'
-                             content={this.props.storagePool.active ? _("Pool type doesn't support volume creation") : _("Pool needs to be active to create volume")}>
-                        <span>
-                            <Button id={`${idPrefix}-button`}
-                                    variant='secondary'
-                                    isDisabled>
-                                {_("Create volume")}
-                            </Button>
-                        </span>
-                    </Tooltip>
-                );
-            }
-        };
+                            isDisabled
+                        >
+                            {_("Create volume")}
+                        </Button>
+                    </span>
+                </Tooltip>
+            );
+        }
+    };
 
-        return createButton();
-    }
-}
+    return createButton();
+};

--- a/src/components/storagePools/storageVolumeCreateBody.tsx
+++ b/src/components/storagePools/storageVolumeCreateBody.tsx
@@ -6,179 +6,123 @@
 
 import React from 'react';
 
-import type { optString, StoragePool } from '../../types';
+import type { StoragePool } from '../../types';
 
-import { FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
-import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
 import { Grid } from "@patternfly/react-core/dist/esm/layouts/Grid";
-import { InputGroup } from "@patternfly/react-core/dist/esm/components/InputGroup";
-import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 
-import { FormHelper } from 'cockpit-components-form-helper.jsx';
-import { convertToUnit, units, digitFilter } from '../../helpers.js';
+import { convertToUnit, units, getDefaultVolumeFormat } from '../../helpers.js';
 import cockpit from 'cockpit';
+
+import {
+    DialogField,
+    DialogTextInput,
+    DialogDropdownSelectObject,
+} from 'cockpit/dialog';
+
+import { SizeInput, SizeValue } from '../common/dialog';
 
 const _ = cockpit.gettext;
 
-export interface DialogValues {
-    volumeName: string,
-    size: number,
-    unit: string;
-    format: optString;
+export interface VolumeCreateValue {
+    name: string,
+    newSize: SizeValue,
+    format: string,
+
+    _storagePool: StoragePool,
 }
 
-export interface ValidationFailed {
-    volumeName?: string;
-    size?: string;
+export function init_VolumeCreate(storagePool: StoragePool): VolumeCreateValue {
+    return {
+        name: "",
+        newSize: {
+            size: "1",
+            unit: units.GiB.name,
+        },
+        format: getDefaultVolumeFormat(storagePool) || "",
+
+        _storagePool: storagePool,
+    };
 }
 
-type OnValueChanged = <K extends keyof DialogValues>(key: K, value: DialogValues[K]) => void;
+export function update_VolumeCreate(field: DialogField<VolumeCreateValue>, storagePool: StoragePool) {
+    if (storagePool.type != field.get()._storagePool.type)
+        field.sub("format").set(getDefaultVolumeFormat(storagePool) || "");
+    field.sub("_storagePool").set(storagePool);
+}
 
-const VolumeName = ({
-    idPrefix,
-    volumeName,
-    validationFailed,
-    onValueChanged
-} : {
-    idPrefix: string,
-    volumeName: string,
-    validationFailed: ValidationFailed,
-    onValueChanged: OnValueChanged,
-}) => {
-    const validationStateName = validationFailed.volumeName ? 'error' : 'default';
-    return (
-        <FormGroup fieldId={`${idPrefix}-name`}
-                   label={_("Name")}>
-            <TextInput id={`${idPrefix}-name`}
-                        minLength={1}
-                        placeholder={_("New volume name")}
-                        value={volumeName || ""}
-                        validated={validationStateName}
-                        onChange={(_, value) => onValueChanged('volumeName', value)} />
-            <FormHelper fieldId={`${idPrefix}-name`} helperTextInvalid={validationStateName == "error" ? validationFailed.volumeName : null} />
-        </FormGroup>
-    );
-};
+export function validate_VolumeCreate(field: DialogField<VolumeCreateValue>) {
+    field.sub("name").validate(v => {
+        if (!v)
+            return _("Please enter new volume name");
+    });
+    field.sub("newSize").validate(v => {
+        const { _storagePool } = field.get();
+        const poolCapacity = convertToUnit(_storagePool.capacity, units.B, v.unit);
+        if (!v.size || isNaN(Number(v.size)))
+            return _("Size must be a number");
+        if (!isNaN(Number(poolCapacity)) && Number(v.size) > Number(poolCapacity)) {
+            return cockpit.format(
+                _("Storage volume size must not exceed the storage pool's capacity ($0 $1)"),
+                poolCapacity?.toFixed(2),
+                v.unit
+            );
+        }
+    });
+}
 
-const VolumeDetails = ({
-    idPrefix,
-    size,
-    unit,
-    format,
-    storagePoolCapacity,
-    storagePoolType,
-    validationFailed,
-    onValueChanged
+export const VolumeCreate = ({
+    field,
 } : {
-    idPrefix: string,
-    size: number,
-    unit: string,
-    format: optString,
-    storagePoolCapacity: optString,
-    storagePoolType: string,
-    validationFailed: ValidationFailed,
-    onValueChanged: OnValueChanged,
+    field: DialogField<VolumeCreateValue>
 }) => {
-    // TODO: Use slider
+    const { format, _storagePool } = field.get();
+
     let formatRow;
     let validVolumeFormats;
     const existingValidVolumeFormats = []; // valid for existing volumes, but not for creation
-    const volumeMaxSize = parseFloat(convertToUnit(storagePoolCapacity, units.B, unit).toFixed(2));
-    const validationStateSize = validationFailed.size ? 'error' : 'default';
 
     // For the valid volume format types for different pool types see https://libvirt.org/storage.html
-    if (['disk'].indexOf(storagePoolType) > -1) {
+    if (['disk'].indexOf(_storagePool.type) > -1) {
         validVolumeFormats = [
             'none', 'linux', 'fat16', 'fat32', 'linux-swap', 'linux-lvm',
             'linux-raid', 'extended'
         ];
-    } else if (['dir', 'fs', 'netfs', 'gluster', 'vstorage'].indexOf(storagePoolType) > -1) {
+    } else if (['dir', 'fs', 'netfs', 'gluster', 'vstorage'].indexOf(_storagePool.type) > -1) {
         validVolumeFormats = ['qcow2', 'raw'];
         existingValidVolumeFormats.push('iso');
     }
 
     if (validVolumeFormats) {
         if (!format)
-            console.error("VolumeDetails internal error: format is not set for storage pool type", storagePoolType); // not-covered: assertion
+            console.error("VolumeDetails internal error: format is not set for storage pool type", _storagePool.type); // not-covered: assertion
         else if (!validVolumeFormats.includes(format) && !existingValidVolumeFormats.includes(format))
-            console.error("VolumeDetails internal error: format", format, "is not valid for storage pool type", storagePoolType); // not-covered: assertion
+            console.error("VolumeDetails internal error: format", format, "is not valid for storage pool type", _storagePool.type); // not-covered: assertion
         else
             formatRow = (
-                <FormGroup fieldId={`${idPrefix}-fileformat`} label={_("Format")}>
-                    <FormSelect id={`${idPrefix}-format`}
-                        onChange={(_event, value) => onValueChanged('format', value)}
-                        value={format}>
-                        { validVolumeFormats.map(format => <FormSelectOption value={format} key={format} label={format} />) }
-                    </FormSelect>
-                </FormGroup>
+                <DialogDropdownSelectObject
+                    label={_("Format")}
+                    field={field.sub("format")}
+                    options={validVolumeFormats}
+                />
             );
     }
 
     return (
-        <Grid hasGutter md={6}>
-            <FormGroup fieldId={`${idPrefix}-size`}
-                       id={`${idPrefix}-size-group`}
-                       label={_("Size")}>
-                <InputGroup>
-                    <TextInput id={`${idPrefix}-size`}
-                               type="number" inputMode='numeric' pattern="[0-9]*"
-                               value={size.toFixed(0)}
-                               onKeyUp={digitFilter}
-                               step={1}
-                               min={0}
-                               max={volumeMaxSize}
-                               validated={validationStateSize}
-                               onChange={(_, value) => onValueChanged('size', parseInt(value))} />
-                    <FormSelect id={`${idPrefix}-unit`}
-                                className="ct-machines-select-unit"
-                                value={unit}
-                                onChange={(_event, value) => onValueChanged('unit', value)}>
-                        <FormSelectOption value={units.MiB.name} key={units.MiB.name}
-                                          label={_("MiB")} />
-                        <FormSelectOption value={units.GiB.name} key={units.GiB.name}
-                                          label={_("GiB")} />
-                    </FormSelect>
-                </InputGroup>
-                <FormHelper fieldId={`${idPrefix}-size`} helperTextInvalid={validationStateSize == "error" ? validationFailed.size : null} />
-            </FormGroup>
-            {formatRow}
-        </Grid>
-    );
-};
-
-export const VolumeCreateBody = ({
-    format,
-    idPrefix,
-    onValueChanged,
-    size,
-    storagePool,
-    unit,
-    validationFailed,
-    volumeName,
-} : {
-    format: optString,
-    idPrefix: string,
-    onValueChanged: OnValueChanged,
-    size: number,
-    storagePool: StoragePool,
-    unit: string,
-    validationFailed: ValidationFailed,
-    volumeName: string,
-}) => {
-    return (
         <>
-            <VolumeName idPrefix={idPrefix}
-                        volumeName={volumeName}
-                        validationFailed={validationFailed}
-                        onValueChanged={onValueChanged} />
-            <VolumeDetails format={format}
-                           idPrefix={idPrefix}
-                           onValueChanged={onValueChanged}
-                           size={size}
-                           storagePoolCapacity={storagePool.capacity}
-                           storagePoolType={storagePool.type}
-                           unit={unit}
-                           validationFailed={validationFailed} />
+            <DialogTextInput
+                label={_("Name")}
+                field={field.sub("name")}
+                minLength={1}
+                placeholder={_("New volume name")}
+            />
+            <Grid hasGutter md={6}>
+                <SizeInput
+                    label={_("Size")}
+                    field={field.sub("newSize")}
+                    max={Number(_storagePool.capacity)}
+                />
+                {formatRow}
+            </Grid>
         </>
     );
 };

--- a/src/components/vm/disks/diskAdd.tsx
+++ b/src/components/vm/disks/diskAdd.tsx
@@ -4,39 +4,42 @@
  * Copyright (C) 2018 Red Hat, Inc.
  */
 
-import type { optString, VM, VMDisk, VMDiskDevice, StoragePool, StorageVolume } from '../../../types';
-import type {
-    DialogValues as VolumeCreateBodyDialogValues,
-    ValidationFailed as VolumeCreateBodyValidationFailed,
-} from '../../storagePools/storageVolumeCreateBody';
+import type { VM, VMDisk, VMDiskDevice, StoragePool, StorageVolume } from '../../../types';
 
-import React, { useMemo, useState, useEffect } from 'react';
+import React from 'react';
 import { Bullseye } from "@patternfly/react-core/dist/esm/layouts/Bullseye";
-import { Button } from "@patternfly/react-core/dist/esm/components/Button";
-import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
 import { ExpandableSection } from "@patternfly/react-core/dist/esm/components/ExpandableSection";
-import { Form, FormGroup, FormHelperText } from "@patternfly/react-core/dist/esm/components/Form";
-import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
+import { Form } from "@patternfly/react-core/dist/esm/components/Form";
 import { Grid } from "@patternfly/react-core/dist/esm/layouts/Grid";
-import { HelperText, HelperTextItem } from "@patternfly/react-core/dist/esm/components/HelperText";
 import {
     Modal, ModalBody, ModalFooter, ModalHeader
 } from '@patternfly/react-core/dist/esm/components/Modal';
-import { Radio } from "@patternfly/react-core/dist/esm/components/Radio";
 import { Spinner } from "@patternfly/react-core/dist/esm/components/Spinner";
-import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import cockpit from 'cockpit';
 import { useDialogs } from 'dialogs.jsx';
-import { FormHelper } from 'cockpit-components-form-helper.jsx';
 
-import { FileAutoComplete } from 'cockpit-components-file-autocomplete.jsx';
-import { ModalError } from 'cockpit-components-inline-notification.jsx';
-import { diskBusTypes, diskCacheModes, units, convertToUnit, getDefaultVolumeFormat, getNextAvailableTarget, getStorageVolumesUsage, getVmStoragePools } from '../../../helpers.js';
-import { VolumeCreateBody } from '../../storagePools/storageVolumeCreateBody.jsx';
+import { diskBusTypes, diskCacheModes, convertToUnit, getDefaultVolumeFormat, getNextAvailableTarget, getStorageVolumesUsage, getVmStoragePools } from '../../../helpers.js';
+import {
+    VolumeCreate, init_VolumeCreate, update_VolumeCreate, validate_VolumeCreate,
+    type VolumeCreateValue,
+} from '../../storagePools/storageVolumeCreateBody.jsx';
 import { domainAttachDisk, domainGet, virtXmlHotEdit, domainIsRunning } from '../../../libvirtApi/domain.js';
 import { storagePoolGetAll } from '../../../libvirtApi/storagePool.js';
 import { storageVolumeCreateAndAttach } from '../../../libvirtApi/storageVolume.js';
 import { appState } from '../../../state';
+
+import {
+    useDialogState_async, DialogState,
+    DialogField,
+    DialogError, DialogErrorMessage,
+    DialogRadioSelect, DialogRadioSelectOption,
+    DialogDropdownSelect, DialogDropdownSelectObject,
+    DialogTextInput,
+    DialogCheckbox,
+    DialogActionButton, DialogCancelButton,
+} from 'cockpit/dialog';
+
+import { FileAutoComplete } from '../../common/dialog';
 
 const _ = cockpit.gettext;
 
@@ -74,907 +77,661 @@ function getDiskUsageMessage(vms: VM[], storagePool: StoragePool, volumeName: st
     return cockpit.format(_("This volume is already used by $0."), vmsUsing);
 }
 
-function getDefaultVolumeName(vmStoragePool: StoragePool, vm: VM) {
-    const filteredVolumes = getFilteredVolumes(vmStoragePool, vm.disks);
-    return filteredVolumes[0] && filteredVolumes[0].name;
-}
-
-interface DialogValues extends VolumeCreateBodyDialogValues {
-    existingVolumeName?: string | undefined;
-    permanent: boolean;
-    storagePoolName?: string;
+interface AdditionalOptionsValue {
+    expanded: boolean;
+    cache_mode: string;
+    bus_type: string;
     serial: string;
-    cacheMode: string;
-    busType?: string | undefined;
-    file: string;
-    device: VMDiskDevice;
-    storagePool?: StoragePool | undefined;
-    target?: string | undefined;
+
+    _bus_types: string[];
 }
 
-interface ValidationFailed extends VolumeCreateBodyValidationFailed {
-    storagePool?: string;
-    serial?: string;
-    customPath?: string | null;
-    existingVolumeName?: string;
+function getBusType(vm: VM, device: VMDiskDevice) {
+    // According to https://libvirt.org/formatdomain.html#hard-drives-floppy-disks-cdroms (section about 'target'),
+    // scsi is the default option for libvirt for cdrom devices
+
+    let bus_type: string = "";
+    if (device == "cdrom")
+        bus_type = "scsi";
+    else {
+        // If disk with the same device exists, use the same bus too
+        bus_type = "virtio";
+        for (const disk of Object.values(vm.disks)) {
+            if (disk.device === device && disk.bus) {
+                bus_type = disk.bus;
+                break;
+            }
+        }
+    }
+
+    return bus_type;
 }
 
-type OnValueChanged = <K extends keyof DialogValues>(key: K, value: DialogValues[K]) => void;
+function init_AdditionalOptions(vm: VM, device: VMDiskDevice): AdditionalOptionsValue {
+    const bus_types: string[] = diskBusTypes[device].filter(bus => vm.capabilities.supportedDiskBusTypes.includes(bus));
+    const bus_type = getBusType(vm, device);
 
-const SelectExistingVolume = ({
-    idPrefix,
-    storagePoolName,
-    existingVolumeName,
-    onValueChanged,
-    vmStoragePools,
-    vmDisks,
-    vms
-} : {
-    idPrefix: string,
-    storagePoolName: string | undefined,
-    existingVolumeName: string | undefined,
-    onValueChanged: OnValueChanged,
-    vmStoragePools: StoragePool[],
-    vmDisks: Record<string, VMDisk>,
-    vms: VM[],
-}) => {
-    const vmStoragePool = vmStoragePools.find(pool => pool.name == storagePoolName);
-    if (!vmStoragePool)
-        return null;
+    if (!bus_types.includes(bus_type))
+        bus_types.push(bus_type);
 
-    const filteredVolumes = getFilteredVolumes(vmStoragePool, vmDisks);
+    return {
+        expanded: false,
+        cache_mode: "default",
+        bus_type,
+        serial: "",
 
-    let initiallySelected;
-    let content;
-    if (filteredVolumes.length > 0) {
-        content = filteredVolumes.map(volume => {
-            return (
-                <FormSelectOption value={volume.name} key={volume.name}
-                                  label={volume.name} />
-            );
-        });
-        initiallySelected = existingVolumeName;
-    } else {
-        content = (
-            <FormSelectOption value="empty" key="empty-list"
-                              label={_("The pool is empty")} />
-        );
-        initiallySelected = "empty";
-    }
+        _bus_types: bus_types,
+    };
+}
 
-    const diskUsageMessage = existingVolumeName && getDiskUsageMessage(vms, vmStoragePool, existingVolumeName);
-    return (
-        <FormGroup fieldId={`${idPrefix}-select-volume`}
-                   label={_("Volume")}>
-            <FormSelect id={`${idPrefix}-select-volume`}
-                        onChange={(_event, value) => onValueChanged('existingVolumeName', value)}
-                        value={initiallySelected}
-                        validated={diskUsageMessage ? "warning" : undefined}
-                        isDisabled={!filteredVolumes.length}>
-                {content}
-            </FormSelect>
-            <FormHelper fieldId={`${idPrefix}-select-volume`} variant="warning" helperText={diskUsageMessage} />
-        </FormGroup>
-    );
-};
+function update_AdditionalOptions(field: DialogField<AdditionalOptionsValue>, vm: VM, device: VMDiskDevice) {
+    const { _bus_types } = field.get();
+    const bus_type = getBusType(vm, device);
 
-const PermanentChange = ({
-    idPrefix,
-    onValueChanged,
-    permanent,
-    vm
-} : {
-    idPrefix: string,
-    onValueChanged: OnValueChanged,
-    permanent: boolean,
-    vm: VM,
-}) => {
-    // By default for a running VM, the disk is attached until shut down only. Enable permanent change of the domain.xml
-    if (!domainIsRunning(vm.state)) {
-        return null;
-    }
+    if (!_bus_types.includes(bus_type))
+        _bus_types.push(bus_type);
 
-    return (
-        <FormGroup fieldId={`${idPrefix}-permanent`} label={_("Persistence")} hasNoPaddingTop>
-            <Checkbox id={`${idPrefix}-permanent`}
-                      isChecked={permanent}
-                      label={_("Always attach")}
-                      onChange={(_event, checked) => onValueChanged('permanent', checked)} />
-        </FormGroup>
-    );
-};
+    field.sub("_bus_types").set(_bus_types);
+    field.sub("bus_type").set(bus_type);
+}
 
-const PoolRow = ({
-    idPrefix,
-    onValueChanged,
-    storagePoolName,
-    validationFailed,
-    vmStoragePools
-} : {
-    idPrefix: string,
-    onValueChanged: OnValueChanged,
-    storagePoolName: string | undefined,
-    validationFailed: ValidationFailed,
-    vmStoragePools: (StoragePool & { disabled?: boolean })[],
-}) => {
-    const validationStatePool = validationFailed.storagePool ? 'error' : 'default';
-
-    return (
-        <FormGroup fieldId={`${idPrefix}-select-pool`}
-                   label={_("Pool")}>
-            <FormSelect id={`${idPrefix}-select-pool`}
-                           isDisabled={!vmStoragePools.length}
-                           onChange={(_event, value) => onValueChanged('storagePoolName', value)}
-                           validated={validationStatePool}
-                           value={storagePoolName || 'no-resource'}>
-                {vmStoragePools.length > 0
-                    ? vmStoragePools
-                            .sort((a, b) => a.name.localeCompare(b.name))
-                            .map(pool => {
-                                return (
-                                    <FormSelectOption isDisabled={!!pool.disabled} value={pool.name} key={pool.name}
-                                                  label={pool.name} />
-                                );
-                            })
-                    : [<FormSelectOption value='no-resource' key='no-resource'
-                                         label={_("No storage pools available")} />]}
-            </FormSelect>
-            <FormHelper fieldId={`${idPrefix}-select-pool`} helperTextInvalid={validationFailed.storagePool} />
-        </FormGroup>
-    );
-};
+function validate_AdditionalOptions(field: DialogField<AdditionalOptionsValue>) {
+    field.sub("serial").validate(v => {
+        if (v != clearSerial(v))
+            return _("Allowed characters: basic Latin alphabet, numbers, and limited punctuation (-, _, +, .)");
+    });
+}
 
 const AdditionalOptions = ({
-    cacheMode,
-    device,
-    idPrefix,
-    onValueChanged,
-    busType,
-    serial,
-    validationFailed,
-    supportedDiskBusTypes
+    field,
 } : {
-    cacheMode: string,
-    device: VMDiskDevice,
-    idPrefix: string,
-    onValueChanged: OnValueChanged,
-    busType: string | undefined,
-    serial: string,
-    validationFailed: ValidationFailed,
-    supportedDiskBusTypes: string[],
+    field: DialogField<AdditionalOptionsValue>,
 }) => {
-    const [expanded, setExpanded] = useState(false);
-    const [showAllowedCharactersMessage, setShowAllowedCharactersMessage] = useState(false);
-    const [showMaxLengthMessage, setShowMaxLengthMessage] = useState(false);
-    const [truncatedSerial, setTruncatedSerial] = useState("");
+    const { expanded, bus_type, serial, _bus_types } = field.get();
 
     // Many disk types have serial length limitations.
-    // libvirt docs: "IDE/SATA devices are commonly limited to 20 characters. SCSI devices depending on hypervisor version are limited to 20, 36 or 247 characters."
+    //
+    // libvirt docs: "IDE/SATA devices are commonly limited to 20
+    // characters. SCSI devices depending on hypervisor version are
+    // limited to 20, 36 or 247 characters."
+    //
     // https://libvirt.org/formatdomain.html#hard-drives-floppy-disks-cdroms
-    const serialLength = busType === "scsi" ? 36 : 20;
 
-    useEffect(() => {
-        const clearedSerial = clearSerial(serial);
-
-        if (serial !== clearedSerial) {
-            // Show the message once triggered and leave it around as reminder
-            setShowAllowedCharactersMessage(true);
-            onValueChanged('serial', clearedSerial);
-        }
-        if (clearedSerial.length > serialLength) {
-            setShowMaxLengthMessage(true);
-            setTruncatedSerial(clearedSerial.substring(0, serialLength));
-        } else {
-            setShowMaxLengthMessage(false);
-        }
-    }, [onValueChanged, serial, serialLength, busType]);
-
-    const displayBusTypes: { value: string, disabled?: boolean }[] = diskBusTypes[device]
-            .filter(bus => supportedDiskBusTypes.includes(bus))
-            .map(type => ({ value: type }));
-    if (!displayBusTypes.find(displayBusType => busType === displayBusType.value))
-        displayBusTypes.push({ value: busType || "", disabled: true });
+    const maxSerialLength = bus_type === "scsi" ? 36 : 20;
 
     return (
-        <ExpandableSection toggleText={ expanded ? _("Hide additional options") : _("Show additional options")}
-                           onToggle={() => setExpanded(!expanded)} isExpanded={expanded} className="pf-v6-u-pt-lg">
+        <ExpandableSection
+            toggleText={ expanded ? _("Hide additional options") : _("Show additional options")}
+            onToggle={() => field.sub("expanded").set(!expanded)}
+            isExpanded={expanded}
+            className="pf-v6-u-pt-lg"
+        >
             <Form onSubmit={e => e.preventDefault()} isHorizontal>
                 <Grid hasGutter md={6}>
-                    <FormGroup fieldId='cache-mode' label={_("Cache")}>
-                        <FormSelect id='cache-mode'
-                            onChange={(_event, value) => onValueChanged('cacheMode', value)}
-                            value={cacheMode}>
-                            {diskCacheModes.map(cacheMode =>
-                                (<FormSelectOption value={cacheMode} key={cacheMode}
-                                                  label={cacheMode} />)
-                            )}
-                        </FormSelect>
-                    </FormGroup>
-
-                    <FormGroup fieldId={idPrefix + '-bus-type'} label={_("Bus")}>
-                        <FormSelect id={idPrefix + '-bus-type'}
-                            data-value={busType}
-                            onChange={(_event, value) => onValueChanged('busType', value)}
-                            value={busType}>
-                            {displayBusTypes.map(busType =>
-                                (<FormSelectOption value={busType.value}
-                                                  key={busType.value}
-                                                  isDisabled={!!busType.disabled}
-                                                  label={busType.value} />)
-                            )}
-                        </FormSelect>
-                    </FormGroup>
+                    <DialogDropdownSelectObject
+                        label={_("Cache")}
+                        field={field.sub("cache_mode")}
+                        options={diskCacheModes}
+                    />
+                    <DialogDropdownSelectObject
+                        label={_("Bus")}
+                        field={field.sub("bus_type")}
+                        options={_bus_types}
+                    />
                 </Grid>
-                <FormGroup fieldId={idPrefix + "-serial"}
-                    label={_("Disk identifier")}>
-                    <TextInput id={idPrefix + "-serial"}
-                        aria-label={_("serial number")}
-                        className="ct-monospace"
-                        value={serial}
-                        onChange={(_, value) => onValueChanged("serial", value)} />
-                    <FormHelperText>
-                        {validationFailed.serial
-                            ? <HelperText>
-                                <HelperTextItem variant="error">
-                                    {validationFailed.serial}
-                                </HelperTextItem>
-                            </HelperText>
-                            : <HelperText component="ul">
-                                { showAllowedCharactersMessage &&
-                                <HelperTextItem id="serial-characters-message" key="regex" variant="indeterminate">
-                                    {_("Allowed characters: basic Latin alphabet, numbers, and limited punctuation (-, _, +, .)")}
-                                </HelperTextItem>
-                                }
-                                { showMaxLengthMessage &&
-                                <HelperTextItem id="serial-length-message" key="length" variant="warning">
-                                    {cockpit.format(_("Identifier may be silently truncated to $0 characters "), serialLength)}
-                                    <span className="ct-monospace">{`(${truncatedSerial})`}</span>
-                                </HelperTextItem>
-                                }
-                            </HelperText>
-                        }
-                    </FormHelperText>
-                </FormGroup>
+                <DialogTextInput
+                    label={_("Disk identifier")}
+                    field={field.sub("serial")}
+                    className="ct-monospace"
+                    warning={
+                        serial.length > maxSerialLength
+                            ? cockpit.format(
+                                _("Identifier may be silently truncated to $0 characters "),
+                                maxSerialLength)
+                            : null
+                    }
+                />
             </Form>
         </ExpandableSection>
     );
 };
 
-const CreateNewDisk = ({
-    format,
-    idPrefix,
-    onValueChanged,
-    size,
-    storagePoolName,
-    unit,
-    validationFailed,
-    vmStoragePools,
-    volumeName,
+interface CreateNewValue {
+    pool: StoragePool;
+    volume: VolumeCreateValue;
+
+    _pools: StoragePool[];
+}
+
+function init_CreateNew(pools: StoragePool[]): CreateNewValue | string {
+    const filtered_pools = pools.filter(p => !poolTypesNotSupportingVolumeCreation.includes(p.type));
+
+    if (filtered_pools.length == 0)
+        return _("No pools that allow volume creation");
+
+    return {
+        pool: filtered_pools[0],
+        volume: init_VolumeCreate(filtered_pools[0]),
+
+        _pools: filtered_pools,
+    };
+}
+
+function validate_CreateNew(field: DialogField<CreateNewValue | string>) {
+    const val = field.get();
+    if (typeof val == "string")
+        return;
+
+    const vc_field = field.at(val);
+    validate_VolumeCreate(vc_field.sub("volume"));
+}
+
+const CreateNew = ({
+    field,
 } : {
-    format: optString,
-    idPrefix: string,
-    onValueChanged: OnValueChanged,
-    size: number,
-    storagePoolName: string | undefined,
-    unit: string,
-    validationFailed: ValidationFailed,
-    vmStoragePools: StoragePool[],
-    volumeName: string,
+    field: DialogField<CreateNewValue | string>,
 }) => {
-    const storagePool = vmStoragePools.find(pool => pool.name == storagePoolName);
+    const val = field.get();
+    if (typeof val == "string")
+        return null;
+
+    const vc_field = field.at(val);
+    const { _pools } = val;
+
+    function update_pool(p: StoragePool) {
+        update_VolumeCreate(vc_field.sub("volume"), p);
+    }
 
     return (
         <>
-            <PoolRow idPrefix={idPrefix}
-                     storagePoolName={storagePoolName}
-                     validationFailed={validationFailed}
-                     onValueChanged={onValueChanged}
-                     vmStoragePools={vmStoragePools.map(pool => ({ ...pool, disabled: poolTypesNotSupportingVolumeCreation.includes(pool.type) }))} />
-            {storagePool &&
-            <VolumeCreateBody format={format}
-                              size={size}
-                              storagePool={storagePool}
-                              unit={unit}
-                              validationFailed={validationFailed}
-                              volumeName={volumeName}
-                              idPrefix={idPrefix}
-                              onValueChanged={(key: keyof VolumeCreateBodyDialogValues, value) => onValueChanged(key, value)} />}
+            <DialogDropdownSelectObject
+                label={_("Pool")}
+                field={vc_field.sub("pool", update_pool)}
+                options={_pools}
+                option_label={p => p.name}
+            />
+            <VolumeCreate field={vc_field.sub("volume")} />
         </>
     );
 };
 
-const UseExistingDisk = ({
-    existingVolumeName,
-    idPrefix,
-    onValueChanged,
-    storagePoolName,
-    validationFailed,
-    vm,
-    vmStoragePools,
-    vms,
+interface ExistingPool {
+    name: string,
+    volumes: string[],
+
+    _storagePool: StoragePool,
+}
+
+interface UseExistingValue {
+    pool: ExistingPool,
+    volume: string,
+
+    _pools: ExistingPool[];
+    _vms: VM[];
+}
+
+function init_UseExisting(vm: VM, vms: VM[], pools: StoragePool[]): UseExistingValue | string {
+    const filtered_pools: ExistingPool[] = [];
+    for (const p of pools) {
+        const volumes = getFilteredVolumes(p, vm.disks);
+        if (volumes.length > 0) {
+            filtered_pools.push(
+                {
+                    name: p.name,
+                    volumes: volumes.map(v => v.name),
+                    _storagePool: p,
+                }
+            );
+        }
+    }
+
+    if (filtered_pools.length == 0)
+        return _("No usable storage volumes");
+
+    return {
+        pool: filtered_pools[0],
+        volume: filtered_pools[0].volumes[0],
+
+        _pools: filtered_pools,
+        _vms: vms,
+    };
+}
+
+const UseExisting = ({
+    field,
 } : {
-    existingVolumeName: string | undefined,
-    idPrefix: string,
-    onValueChanged: OnValueChanged,
-    storagePoolName: string | undefined,
-    validationFailed: ValidationFailed,
-    vm: VM,
-    vmStoragePools: StoragePool[],
-    vms: VM[],
+    field: DialogField<UseExistingValue | string>,
 }) => {
+    const val = field.get();
+    if (typeof val == "string")
+        return null;
+
+    const ue_field = field.at(val);
+    const { pool, volume, _pools, _vms } = val;
+
+    function update_pool(p: ExistingPool) {
+        ue_field.sub("volume").set(p.volumes[0]);
+    }
+
+    const diskUsageMessage = pool._storagePool && getDiskUsageMessage(_vms, pool._storagePool, volume);
+
     return (
         <>
-            <PoolRow idPrefix={idPrefix}
-                     storagePoolName={storagePoolName}
-                     validationFailed={validationFailed}
-                     onValueChanged={onValueChanged}
-                     vmStoragePools={vmStoragePools} />
-            {vmStoragePools.length > 0 &&
-                <SelectExistingVolume idPrefix={idPrefix}
-                                      vms={vms}
-                                      storagePoolName={storagePoolName}
-                                      existingVolumeName={existingVolumeName}
-                                      onValueChanged={onValueChanged}
-                                      vmStoragePools={vmStoragePools}
-                                      vmDisks={vm.disks} />}
+            <DialogDropdownSelectObject
+                label={_("Pool")}
+                field={ue_field.sub("pool", update_pool)}
+                options={_pools}
+                option_label={p => p.name}
+            />
+            <DialogDropdownSelectObject
+                label={_("Volume")}
+                field={ue_field.sub("volume")}
+                options={pool.volumes}
+                warning={diskUsageMessage}
+            />
         </>
     );
 };
+
+interface FileInfo {
+    format: string;
+    usesBackingFile: boolean;
+}
+
+type FileInfoCache = Record<string, FileInfo>;
+
+async function getFileInfo(file: string, cache: FileInfoCache): Promise<FileInfo> {
+    if (file in cache)
+        return cache[file];
+
+    const file_header = await cockpit.spawn(
+        ["head", "--bytes=16", file],
+        { binary: true, err: "message", superuser: "try" }
+    );
+
+    // https://git.qemu.org/?p=qemu.git;a=blob;f=docs/interop/qcow2.txt
+    let result;
+    if (file_header[0] == 81 && file_header[1] == 70 &&
+        file_header[2] == 73 && file_header[3] == 251) {
+        result = {
+            format: "qcow2",
+            // All zeros, no backing file offset
+            usesBackingFile: !file_header.slice(8).every(bytes => bytes === 0),
+        };
+    } else {
+        result = {
+            format: "raw",
+            usesBackingFile: false,
+        };
+    }
+
+    cache[file] = result;
+    return result;
+}
+
+interface CustomPathValue {
+    file: string,
+    device: "disk" | "cdrom",
+    _fileInfoCache: FileInfoCache,
+}
+
+function init_CustomPath(): CustomPathValue {
+    return {
+        file: "",
+        device: "disk",
+        _fileInfoCache: {},
+    };
+}
+
+function validate_CustomPath(field: DialogField<CustomPathValue>) {
+    const { _fileInfoCache } = field.get();
+    field.sub("file").validate_async(0, async file => {
+        if (!file)
+            return _("Path can not be empty");
+
+        const { usesBackingFile } = await getFileInfo(file, _fileInfoCache);
+        if (usesBackingFile)
+            return _("Importing an image with a backing file is unsupported");
+    });
+}
 
 const CustomPath = ({
-    idPrefix,
-    onValueChanged,
-    device,
-    validationFailed,
+    field,
     hideDeviceRow
 } : {
-    idPrefix: string,
-    onValueChanged: OnValueChanged,
-    device?: string,
-    validationFailed: ValidationFailed,
+    field: DialogField<CustomPathValue>,
     hideDeviceRow?: boolean,
 }) => {
+    function update_file(val: string) {
+        if (val.endsWith(".iso"))
+            field.sub("device").set("cdrom");
+    }
+
     return (
         <>
-            <FormGroup
-                id={`${idPrefix}-file`}
-                fieldId={`${idPrefix}-file-autocomplete`}
-                label={_("Custom path")}>
-                <FileAutoComplete
-                    id={`${idPrefix}-file-autocomplete`}
-                    placeholder={_("Path to file on host's file system")}
-                    onChange={(value: string) => onValueChanged("file", value)}
-                    superuser="try" />
-                <FormHelper fieldId={`${idPrefix}-file-autocomplete`} helperTextInvalid={validationFailed.customPath} />
-            </FormGroup>
-            {!hideDeviceRow && <FormGroup label={_("Device")}>
-                <FormSelect id={`${idPrefix}-select-device`}
-                        onChange={(_event, value) => {
-                            cockpit.assert(value == "disk" || value == "cdrom");
-                            onValueChanged('device', value);
-                        }}
-                        value={device}>
-                    <FormSelectOption value="disk" key="disk"
-                                  label={_("Disk image file")} />
-                    <FormSelectOption value="cdrom" key="cdrom"
-                                  label={_("CD/DVD disc")} />
-                </FormSelect>
-            </FormGroup>}
+            <FileAutoComplete
+                label={_("Custom path")}
+                field={field.sub("file", update_file)}
+                placeholder={_("Path to file on host's file system")}
+            />
+            {
+                !hideDeviceRow &&
+                    <DialogDropdownSelect
+                        label={_("Device")}
+                        field={field.sub("device")}
+                        options={
+                            [
+                                { value: "disk", label: _("Disk image file") },
+                                { value: "cdrom", label: _("CD/DVD disc") },
+                            ]
+                        }
+                    />
+            }
         </>
     );
 };
+
+function getPoolFormatAndDevice(pool: StoragePool | undefined, volName: string | false) {
+    const params: { format: string, device: VMDiskDevice } = {
+        format: pool ? getDefaultVolumeFormat(pool) || "" : "",
+        device: "disk"
+    };
+    if (pool && volName && ['dir', 'fs', 'netfs', 'gluster', 'vstorage'].indexOf(pool.type) > -1) {
+        const volume = (pool.volumes || []).find(vol => vol.name === volName);
+        if (volume?.format) {
+            params.format = volume.format;
+            if (volume.format === "iso")
+                params.device = "cdrom";
+        }
+    }
+    return params;
+}
 
 const sortFunction = (poolA: StoragePool, poolB: StoragePool) => poolA.name.localeCompare(poolB.name);
 
-export const AddDiskModalBody = ({
+type Mode = typeof USE_EXISTING | typeof CUSTOM_PATH | typeof CREATE_NEW;
+
+interface AddDiskValues {
+    mode: Mode,
+    custom_path: CustomPathValue,
+    use_existing: UseExistingValue | string,
+    create_new: CreateNewValue | string,
+    permanent: boolean,
+    additional_options: AdditionalOptionsValue,
+}
+
+export const AddDisk = ({
     disk,
     idPrefix,
-    isMediaInsertion,
+    isMediaInsertion = false,
     vm,
-    supportedDiskBusTypes
 } : {
     disk?: VMDisk,
     idPrefix: string,
     isMediaInsertion?: boolean,
     vm: VM,
-    supportedDiskBusTypes: string[],
 }) => {
-    const [customDiskVerificationFailed, setCustomDiskVerificationFailed] = useState(false);
-    const [customDiskVerificationMessage, setCustomDiskVerificationMessage] = useState<string | null>(null);
-    const [dialogError, setDialogError] = useState<string | null>(null);
-    const [dialogErrorDetail, setDialogErrorDetail] = useState<string | null>(null);
-    const [diskParams, setDiskParams] = useState<DialogValues>({
-        cacheMode: 'default',
-        device: "disk",
-        file: "",
-        format: undefined,
-        serial: "",
-        size: 1,
-        unit: units.GiB.name,
-        volumeName: "",
-        permanent: vm.persistent,
-    });
-    const [mode, setMode] = useState(isMediaInsertion ? CUSTOM_PATH : CREATE_NEW);
-    const [validate, setValidate] = useState(false);
-    const [verificationInProgress, setVerificationInProgress] = useState(false);
-    const [storagePools, setStoragePools] = useState<StoragePool[] | undefined>();
-    const [vms, setVms] = useState<VM[] | undefined>();
-
     const Dialogs = useDialogs();
 
-    const defaultPool = useMemo(() => storagePools?.[0], [storagePools]);
+    async function init(): Promise<AddDiskValues> {
+        const vms = await appState.getVms();
 
-    // VM params that should be refreshed when VM, storage Pools or mode changes
-    const initialDiskParams = useMemo(() => ({
-        connectionName: vm.connectionName,
-        existingVolumeName: defaultPool && getDefaultVolumeName(defaultPool, vm),
-        storagePool: defaultPool,
-        type: mode === CUSTOM_PATH ? "file" : "volume",
-    }), [defaultPool, mode, vm]);
-    const storagePoolName = diskParams.storagePool?.name;
-
-    const getPoolFormatAndDevice = (pool: StoragePool, volName: optString | false) => {
-        const params: Pick<DialogValues, "format" | "device"> = {
-            format: getDefaultVolumeFormat(pool),
-            device: "disk"
-        };
-        if (volName && ['dir', 'fs', 'netfs', 'gluster', 'vstorage'].indexOf(pool.type) > -1) {
-            const volume = (pool.volumes || []).find(vol => vol.name === volName);
-            if (volume?.format) {
-                params.format = volume.format;
-                if (volume.format === "iso")
-                    params.device = "cdrom";
-            }
-        }
-        return params;
-    };
-
-    useEffect(() => {
-        // Get the list of VMs.
-        appState.getVms().then(setVms);
-    }, []);
-
-    useEffect(() => {
         // Refresh storage volume list before displaying the dialog.
         // There are recently no Libvirt events for storage volumes and polling is ugly.
         // https://bugzilla.redhat.com/show_bug.cgi?id=1578836
-        storagePoolGetAll({ connectionName: vm.connectionName })
-                .finally(() => setStoragePools(getVmStoragePools(vm.connectionName).sort(sortFunction)))
-                .catch(exc => dialogErrorSet(_("Storage pools could not be fetched"), exc.message));
-    }, [vm.connectionName]);
+        await storagePoolGetAll({ connectionName: vm.connectionName });
+        const pools = getVmStoragePools(vm.connectionName).sort(sortFunction);
 
-    useEffect(() => {
-        // Reset dialog form when changing mode or if storage pools list changed
-        setDiskParams(diskParams => ({
-            ...diskParams,
-            ...initialDiskParams,
-        }));
-    }, [initialDiskParams]);
+        const custom_path = init_CustomPath();
+        const use_existing = init_UseExisting(vm, vms, pools);
+        const create_new = init_CreateNew(pools);
 
-    useEffect(() => {
-        // Follow up state updates after 'existingVolumeName' is changed
-        if (!diskParams.storagePool) {
-            // if storage pool detection finished, and there are no pools, mark format detection as initialized
-            if (storagePools !== undefined && storagePools.length === 0)
-                setDiskParams(diskParams => ({ ...diskParams, format: null }));
-            return;
-        }
+        let mode: AddDiskValues["mode"] = CUSTOM_PATH;
+        if (!isMediaInsertion && typeof create_new != "string")
+            mode = CREATE_NEW;
+        else if (!isMediaInsertion && typeof use_existing != "string")
+            mode = USE_EXISTING;
 
-        setDiskParams(diskParams => ({
-            ...diskParams,
-            ...getPoolFormatAndDevice(diskParams.storagePool!, mode == USE_EXISTING && diskParams.existingVolumeName),
-        }));
-    }, [storagePools, diskParams.storagePool, diskParams.existingVolumeName, mode]);
-
-    useEffect(() => {
-        // Initial state settings and follow up state updates after 'device' is changed
-
-        // According to https://libvirt.org/formatdomain.html#hard-drives-floppy-disks-cdroms (section about 'target'),
-        // scsi is the default option for libvirt for cdrom devices
-        let newBus: optString = diskParams.device === "cdrom" ? "scsi" : null;
-
-        if (!newBus) {
-            // If disk with the same device exists, use the same bus too
-            for (const disk of Object.values(vm.disks)) {
-                if (disk.device === diskParams.device) {
-                    newBus = disk.bus;
-                    break;
-                }
-            }
-            newBus = newBus || "virtio";
-        }
-
-        setDiskParams(diskParams => ({ ...diskParams, busType: newBus }));
-    }, [diskParams.device, vm.disks]);
-
-    useEffect(() => {
-        // Initial state settings and follow up state updates after 'busType' is changed
-        const existingTargets = Object.getOwnPropertyNames(vm.disks);
-        const availableTarget = isMediaInsertion ? disk?.target : getNextAvailableTarget(existingTargets, diskParams.busType || "");
-        setDiskParams(diskParams => ({ ...diskParams, target: availableTarget }));
-    }, [vm.disks, disk?.target, diskParams.busType, isMediaInsertion]);
-
-    useEffect(() => {
-        const file = diskParams.file;
-
-        if (file?.endsWith(".iso")) {
-            setDiskParams(diskParams => ({ ...diskParams, device: "cdrom" }));
-        }
-
-        if (file) {
-            setVerificationInProgress(true);
-            cockpit.spawn(["head", "--bytes=16", file], { binary: true, err: "message", superuser: "try" })
-                    .then(file_header => {
-                        let format;
-
-                        // https://git.qemu.org/?p=qemu.git;a=blob;f=docs/interop/qcow2.txt
-                        if (file_header[0] == 81 && file_header[1] == 70 &&
-                            file_header[2] == 73 && file_header[3] == 251) {
-                            format = "qcow2";
-                            // All zeros, no backing file offset
-                            if (file_header.slice(8).every(bytes => bytes === 0)) {
-                                setCustomDiskVerificationFailed(false);
-                            } else {
-                                setCustomDiskVerificationFailed(true);
-                                setCustomDiskVerificationMessage(_("Importing an image with a backing file is unsupported"));
-                            }
-                        } else {
-                            format = "raw";
-                            setCustomDiskVerificationFailed(false);
-                        }
-                        setDiskParams(diskParams => ({ ...diskParams, format }));
-                        setVerificationInProgress(false);
-                    })
-                    .catch(e => {
-                        setVerificationInProgress(false);
-                        setDiskParams(diskParams => ({ ...diskParams, format: "raw" }));
-                        console.warn("could not execute head --bytes=16", e.toString());
-                    });
-        } else {
-            setCustomDiskVerificationFailed(false);
-        }
-    }, [diskParams.file]);
-
-    const onValueChanged = <K extends keyof DialogValues>(key: K, value: DialogValues[K]): void => {
-        switch (key) {
-        case 'storagePoolName': {
-            const currentPool = (storagePools || []).find(pool => pool.name === value && pool.connectionName === vm.connectionName);
-            if (!currentPool)
-                break;
-
-            const existingVolumeName = getDefaultVolumeName(currentPool, vm);
-
-            setDiskParams(diskParams => ({
-                ...diskParams,
-                storagePool: currentPool,
-                existingVolumeName,
-                ...getPoolFormatAndDevice(currentPool, mode == USE_EXISTING && existingVolumeName),
-            }));
-            break;
-        }
-        default:
-            setDiskParams(diskParams => ({ ...diskParams, [key]: value }));
-        }
-    };
-
-    const dialogErrorSet = (text: string, detail: string) => {
-        setDialogError(text);
-        setDialogErrorDetail(detail);
-    };
-
-    const _validationFailed = useMemo(() => {
-        const validateParams = () => {
-            const validationFailed: ValidationFailed = {};
-            const storagePoolType = diskParams.storagePool?.type;
-
-            if (mode !== CUSTOM_PATH && !storagePoolName)
-                validationFailed.storagePool = _("Please choose a storage pool");
-
-            if (mode === CUSTOM_PATH && customDiskVerificationFailed)
-                validationFailed.customPath = customDiskVerificationMessage;
-
-            if (mode === CREATE_NEW) {
-                if (!diskParams.volumeName) {
-                    validationFailed.volumeName = _("Please enter new volume name");
-                }
-                if (poolTypesNotSupportingVolumeCreation.includes(storagePoolType || "")) {
-                    validationFailed.storagePool = cockpit.format(_("Pool type $0 does not support volume creation"), storagePoolType);
-                }
-                const poolCapacity = diskParams.storagePool && convertToUnit(diskParams.storagePool.capacity, units.B, diskParams.unit);
-                if (!isNaN(Number(poolCapacity)) && diskParams.size > Number(poolCapacity)) {
-                    validationFailed.size = cockpit.format(_("Storage volume size must not exceed the storage pool's capacity ($0 $1)"), poolCapacity?.toFixed(2), diskParams.unit);
-                }
-            } else if (mode === USE_EXISTING) {
-                if (!diskParams.existingVolumeName)
-                    validationFailed.existingVolumeName = _("Please choose a volume");
-            }
-
-            return validationFailed;
+        return {
+            mode,
+            custom_path,
+            use_existing,
+            create_new,
+            permanent: vm.persistent,
+            additional_options: init_AdditionalOptions(vm, "disk"),
         };
-        return validateParams();
-    }, [diskParams, mode, customDiskVerificationFailed, customDiskVerificationMessage, storagePoolName]);
-    const validationFailed = validate ? _validationFailed : {};
+    }
+
+    function validate(dlg: DialogState<AddDiskValues>) {
+        if (dlg.values.mode == CREATE_NEW)
+            validate_CreateNew(dlg.field("create_new"));
+        if (dlg.values.mode == CUSTOM_PATH)
+            validate_CustomPath(dlg.field("custom_path"));
+        if (!isMediaInsertion)
+            validate_AdditionalOptions(dlg.field("additional_options"));
+    }
+
+    function get_device(values: AddDiskValues): VMDiskDevice {
+        const { mode } = values;
+        if (mode == USE_EXISTING && typeof values.use_existing != "string") {
+            const { pool, volume } = values.use_existing;
+            return getPoolFormatAndDevice(pool._storagePool, volume).device;
+        } else if (mode == CREATE_NEW) {
+            return "disk";
+        } else if (mode == CUSTOM_PATH) {
+            return values.custom_path.device;
+        } else
+            return "disk";
+    }
+
+    function update_bus() {
+        cockpit.assert(dlg instanceof DialogState);
+        const device = get_device(dlg.values);
+        if (device)
+            update_AdditionalOptions(dlg.field("additional_options"), vm, device);
+    }
+
+    const dlg = useDialogState_async<AddDiskValues>(init, validate);
 
     let defaultBody;
-    const dialogLoading = storagePools === undefined || diskParams.format === undefined || vms === undefined;
-    if (dialogLoading) {
+
+    if (!dlg) {
         defaultBody = (
             <Bullseye>
                 <Spinner />
             </Bullseye>
         );
-    } else if (isMediaInsertion) {
-        defaultBody = (
-            <Form onSubmit={e => e.preventDefault()} isHorizontal>
-                <FormGroup fieldId={`${idPrefix}-source`}
-                           id={`${idPrefix}-source-group`}
-                           label={_("Source")} isInline hasNoPaddingTop>
-                    <Radio id={`${idPrefix}-custompath`}
-                           name="source"
-                           label={_("Custom path")}
-                           isChecked={mode === CUSTOM_PATH}
-                           onChange={() => setMode(CUSTOM_PATH)} />
-                    <Radio id={`${idPrefix}-useexisting`}
-                           name="source"
-                           label={_("Use existing")}
-                           isChecked={mode === USE_EXISTING}
-                           onChange={() => setMode(USE_EXISTING)} />
-                </FormGroup>
-                {mode === USE_EXISTING && (
-                    <UseExistingDisk idPrefix={`${idPrefix}-existing`}
-                                     onValueChanged={onValueChanged}
-                                     storagePoolName={storagePoolName}
-                                     existingVolumeName={diskParams.existingVolumeName}
-                                     validationFailed={validationFailed}
-                                     vmStoragePools={storagePools}
-                                     vms={vms}
-                                     vm={vm} />
-                )}
-                {mode === CUSTOM_PATH && (
-                    <CustomPath idPrefix={idPrefix}
-                                onValueChanged={onValueChanged}
-                                hideDeviceRow
-                                validationFailed={validationFailed} />
-                )}
-            </Form>
-        );
+    } else if (dlg instanceof DialogError) {
+        defaultBody = null;
     } else {
+        const { mode, use_existing, create_new } = dlg.values;
+
+        let mode_options: DialogRadioSelectOption<Mode>[] = [
+            {
+                value: CREATE_NEW,
+                label: _("Create new"),
+                excuse: typeof create_new == "string" ? create_new : undefined,
+            },
+            {
+                value: USE_EXISTING,
+                label: _("Use existing"),
+                excuse: typeof use_existing == "string" ? use_existing : undefined,
+            },
+            {
+                value: CUSTOM_PATH,
+                label: _("Custom path")
+            },
+        ];
+
+        if (isMediaInsertion)
+            mode_options = [mode_options[2], mode_options[1]];
+
         defaultBody = (
             <>
                 <Form onSubmit={e => e.preventDefault()} isHorizontal>
-                    <FormGroup fieldId={`${idPrefix}-source`}
-                               id={`${idPrefix}-source-group`}
-                               label={_("Source")} isInline hasNoPaddingTop>
-                        <Radio id={`${idPrefix}-createnew`}
-                               name="source"
-                               label={_("Create new")}
-                               isChecked={mode === CREATE_NEW}
-                               onChange={() => setMode(CREATE_NEW)} />
-                        <Radio id={`${idPrefix}-useexisting`}
-                               name="source"
-                               label={_("Use existing")}
-                               isChecked={mode === USE_EXISTING}
-                               onChange={() => setMode(USE_EXISTING)} />
-                        <Radio id={`${idPrefix}-custompath`}
-                               name="source"
-                               label={_("Custom path")}
-                               isChecked={mode === CUSTOM_PATH}
-                               onChange={() => setMode(CUSTOM_PATH)} />
-                    </FormGroup>
-                    {mode === CREATE_NEW && (
-                        <CreateNewDisk idPrefix={`${idPrefix}-new`}
-                                       onValueChanged={onValueChanged}
-                                       storagePoolName={storagePoolName}
-                                       volumeName={diskParams.volumeName}
-                                       size={diskParams.size}
-                                       unit={diskParams.unit}
-                                       format={diskParams.format}
-                                       validationFailed={validationFailed}
-                                       vmStoragePools={storagePools} />
-                    )}
-                    {mode === USE_EXISTING && (
-                        <UseExistingDisk idPrefix={`${idPrefix}-existing`}
-                                         onValueChanged={onValueChanged}
-                                         storagePoolName={storagePoolName}
-                                         existingVolumeName={diskParams.existingVolumeName}
-                                         validationFailed={validationFailed}
-                                         vmStoragePools={storagePools}
-                                         vms={vms}
-                                         vm={vm} />
-                    )}
-                    {mode === CUSTOM_PATH && (
-                        <CustomPath idPrefix={idPrefix}
-                                    onValueChanged={onValueChanged}
-                                    device={diskParams.device}
-                                    validationFailed={validationFailed} />
-                    )}
-                    {vm.persistent &&
-                    <PermanentChange idPrefix={idPrefix}
-                                     permanent={diskParams.permanent}
-                                     onValueChanged={onValueChanged}
-                                     vm={vm} />}
+                    <DialogRadioSelect
+                        isInline
+                        label={_("Source")}
+                        field={dlg.field("mode", update_bus)}
+                        options={mode_options}
+                    />
+                    {
+                        mode === CREATE_NEW &&
+                            <CreateNew field={dlg.field("create_new", update_bus)} />
+                    }
+                    {
+                        mode === USE_EXISTING &&
+                            <UseExisting field={dlg.field("use_existing", update_bus)} />
+                    }
+                    {
+                        mode === CUSTOM_PATH &&
+                            <CustomPath field={dlg.field("custom_path", update_bus)} hideDeviceRow={isMediaInsertion} />
+                    }
+                    {
+                        !isMediaInsertion && vm.persistent && domainIsRunning(vm.state) &&
+                            <DialogCheckbox
+                                field_label={_("Persistence")}
+                                checkbox_label={_("Always attach")}
+                                field={dlg.field("permanent")}
+                            />
+                    }
                 </Form>
-                <AdditionalOptions cacheMode={diskParams.cacheMode}
-                                   device={diskParams.device}
-                                   idPrefix={idPrefix}
-                                   onValueChanged={onValueChanged}
-                                   busType={diskParams.busType}
-                                   serial={diskParams.serial}
-                                   validationFailed={validationFailed}
-                                   supportedDiskBusTypes={supportedDiskBusTypes} />
+                { !isMediaInsertion &&
+                    <AdditionalOptions field={dlg.field("additional_options")} />
+                }
             </>
         );
     }
 
+    async function insert_media(values: AddDiskValues) {
+        try {
+            let xml;
+            if (values.mode === CUSTOM_PATH) {
+                xml = {
+                    type: "file",
+                    source: {
+                        file: values.custom_path.file
+                    }
+                };
+            } else if (values.mode === USE_EXISTING && typeof values.use_existing != "string") {
+                xml = {
+                    type: "volume",
+                    source: {
+                        pool: values.use_existing.pool.name,
+                        volume: values.use_existing.volume,
+                    }
+                };
+            } else
+                return;
+
+            cockpit.assert(disk);
+
+            await virtXmlHotEdit(
+                vm,
+                "disk",
+                { target: { dev: disk.target } },
+                xml
+            );
+
+            // force reload of VM data, events are not reliable (i.e. for a down VM)
+            domainGet({ connectionName: vm.connectionName, id: vm.id });
+        } catch (ex) {
+            throw DialogError.fromError(_("Media failed to be inserted"), ex);
+        }
+    }
+
+    async function add_disk(values: AddDiskValues) {
+        try {
+            const existingTargets = Object.getOwnPropertyNames(vm.disks);
+            const target = getNextAvailableTarget(existingTargets, values.additional_options.bus_type);
+
+            if (!target)
+                throw new DialogError(_("Failed to add disk"), _("Can not determine guest device name"));
+
+            const hotplug = domainIsRunning(vm.state);
+
+            const common = {
+                permanent: values.permanent,
+                hotplug,
+                vmId: vm.id,
+                cacheMode: values.additional_options.cache_mode,
+                busType: values.additional_options.bus_type,
+                serial: values.additional_options.serial,
+            };
+
+            if (values.mode === CREATE_NEW && typeof values.create_new != "string") {
+                const params = values.create_new;
+                const size = convertToUnit(params.volume.newSize.size, params.volume.newSize.unit, 'MiB');
+                await storageVolumeCreateAndAttach({
+                    connectionName: vm.connectionName,
+                    target,
+                    poolName: params.pool.name,
+                    volumeName: params.volume.name,
+                    format: params.volume.format,
+                    size,
+                    ...common
+                });
+            } else if (values.mode == CUSTOM_PATH) {
+                const params = values.custom_path;
+                const file_info = await getFileInfo(params.file, params._fileInfoCache);
+                await domainAttachDisk({
+                    connectionName: vm.connectionName,
+                    target,
+                    type: "file",
+                    file: params.file,
+                    device: params.device,
+                    format: file_info.format,
+                    shareable: false,
+                    ...common
+                });
+            } else if (values.mode == USE_EXISTING && typeof values.use_existing != "string") {
+                const params = values.use_existing;
+                const { device, format } = getPoolFormatAndDevice(params.pool._storagePool, params.volume);
+                await domainAttachDisk({
+                    connectionName: vm.connectionName,
+                    target,
+                    type: "volume",
+                    device,
+                    format,
+                    poolName: params.pool.name,
+                    volumeName: params.volume,
+                    shareable: false,
+                    ...common
+                });
+            }
+
+            // force reload of VM data, events are not reliable (i.e. for a down VM)
+            domainGet({ connectionName: vm.connectionName, id: vm.id });
+        } catch (ex) {
+            throw DialogError.fromError(_("Disk failed to be added"), ex);
+        }
+    }
+
     return (
-        <Modal position="top" variant="medium" id={`${idPrefix}-dialog-modal-window`} isOpen onClose={Dialogs.close}>
+        <Modal
+            position="top"
+            variant="medium"
+            id={`${idPrefix}-dialog-modal-window`}
+            isOpen
+            onClose={Dialogs.close}
+        >
             <ModalHeader title={isMediaInsertion ? _("Insert disc media") : _("Add disk")} />
             <ModalBody>
-                {dialogError && <ModalError dialogError={dialogError} {...dialogErrorDetail && { dialogErrorDetail } } />}
+                <DialogErrorMessage dialog={dlg} />
                 {defaultBody}
             </ModalBody>
             <ModalFooter>
-                <AddDiskModalFooter
-                  dialogLoading={dialogLoading}
-                  dialogErrorSet={dialogErrorSet}
-                  diskParams={diskParams}
-                  idPrefix={idPrefix}
-                  isMediaInsertion={!!isMediaInsertion}
-                  mode={mode}
-                  setValidate={setValidate}
-                  storagePoolName={storagePoolName}
-                  storagePools={storagePools}
-                  validate={validate}
-                  validationFailed={_validationFailed}
-                  verificationInProgress={verificationInProgress}
-                  vm={vm}
-                />
+                {
+                    isMediaInsertion
+                        ? <DialogActionButton dialog={dlg} action={insert_media} onClose={Dialogs.close}>
+                            {_("Insert")}
+                        </DialogActionButton>
+                        : <DialogActionButton dialog={dlg} action={add_disk} onClose={Dialogs.close}>
+                            {_("Add")}
+                        </DialogActionButton>
+                }
+                <DialogCancelButton dialog={dlg} onClose={Dialogs.close} />
             </ModalFooter>
         </Modal>
-    );
-};
-
-const AddDiskModalFooter = ({
-    dialogErrorSet,
-    dialogLoading,
-    diskParams,
-    idPrefix,
-    isMediaInsertion,
-    mode,
-    setValidate,
-    storagePoolName,
-    storagePools,
-    validate,
-    validationFailed,
-    verificationInProgress,
-    vm,
-} : {
-    dialogErrorSet: (text: string, detail: string) => void,
-    dialogLoading: boolean,
-    diskParams: DialogValues,
-    idPrefix: string,
-    isMediaInsertion: boolean,
-    mode: string,
-    setValidate: (flag: boolean) => void,
-    storagePoolName: string | undefined,
-    storagePools: StoragePool[] | undefined,
-    validate: boolean,
-    validationFailed: ValidationFailed,
-    verificationInProgress: boolean,
-    vm: VM,
-}) => {
-    const [addDiskInProgress, setAddDiskInProgress] = useState(false);
-    const Dialogs = useDialogs();
-
-    const onInsertClicked = async () => {
-        let values;
-        if (mode === CUSTOM_PATH) {
-            values = {
-                type: "file",
-                source: {
-                    file: diskParams.file
-                }
-            };
-        } else {
-            values = {
-                type: "volume",
-                source: {
-                    pool: storagePoolName,
-                    volume: diskParams.existingVolumeName,
-                }
-            };
-        }
-
-        await virtXmlHotEdit(
-            vm,
-            "disk",
-            { target: { dev: diskParams.target } },
-            values
-        );
-    };
-
-    const onAddClicked = () => {
-        cockpit.assert(diskParams.target);
-
-        const hotplug = domainIsRunning(vm.state);
-
-        if (mode === CREATE_NEW) {
-            // create new disk
-            const size = convertToUnit(diskParams.size, diskParams.unit, 'MiB');
-            return storageVolumeCreateAndAttach({
-                connectionName: vm.connectionName,
-                poolName: storagePoolName || "",
-                volumeName: diskParams.volumeName,
-                size,
-                format: diskParams.format || "",
-                target: diskParams.target,
-                permanent: diskParams.permanent,
-                hotplug,
-                vmId: vm.id,
-                cacheMode: diskParams.cacheMode,
-                busType: diskParams.busType || "",
-                serial: diskParams.serial
-            });
-        }
-
-        return domainAttachDisk({
-            connectionName: vm.connectionName,
-            type: mode === CUSTOM_PATH ? "file" : "volume",
-            file: diskParams.file,
-            device: diskParams.device,
-            poolName: storagePoolName,
-            volumeName: diskParams.existingVolumeName,
-            format: diskParams.format || "",
-            target: diskParams.target,
-            permanent: diskParams.permanent,
-            hotplug,
-            vmId: vm.id,
-            cacheMode: diskParams.cacheMode,
-            shareable: false,
-            busType: diskParams.busType || "",
-            serial: diskParams.serial
-        });
-    };
-
-    const onClick = () => {
-        setValidate(true);
-        if (Object.getOwnPropertyNames(validationFailed).length > 0) {
-            setAddDiskInProgress(false);
-            return;
-        }
-
-        setAddDiskInProgress(true);
-
-        return (
-            isMediaInsertion
-                ? onInsertClicked()
-                : onAddClicked()
-        )
-                .then(() => { // force reload of VM data, events are not reliable (i.e. for a down VM)
-                    Dialogs.close();
-                    return domainGet({ connectionName: vm.connectionName, id: vm.id });
-                })
-                .catch(exc => {
-                    setAddDiskInProgress(false);
-                    dialogErrorSet(_("Disk failed to be added"), exc.message);
-                });
-    };
-
-    return (
-        <>
-            <Button id={`${idPrefix}-dialog-add`}
-                    variant='primary'
-                    isLoading={addDiskInProgress || verificationInProgress}
-                    isDisabled={addDiskInProgress || verificationInProgress || dialogLoading ||
-                                ((storagePools || []).length == 0 && mode != CUSTOM_PATH) ||
-                                (validate && Object.keys(validationFailed).length > 0) ||
-                                !diskParams.target}
-                    onClick={onClick}>
-                {isMediaInsertion ? _("Insert") : _("Add")}
-            </Button>
-            <Button id={`${idPrefix}-dialog-cancel`} variant='link' onClick={Dialogs.close}>
-                {_("Cancel")}
-            </Button>
-        </>
     );
 };

--- a/src/components/vm/disks/vmDiskColumns.tsx
+++ b/src/components/vm/disks/vmDiskColumns.tsx
@@ -21,7 +21,7 @@ import { useDialogs } from 'dialogs.jsx';
 import { domainDeleteStorage, domainDetachDisk, domainGet } from '../../../libvirtApi/domain.js';
 import { MediaEjectModal } from './mediaEject.jsx';
 import { EditDiskAction } from './diskEdit.jsx';
-import { AddDiskModalBody } from './diskAdd.jsx';
+import { AddDisk } from './diskAdd.jsx';
 import { DeleteResourceModal } from '../../common/deleteResource.jsx';
 import { canDeleteDiskFile } from '../../../helpers.js';
 import { appState } from '../../../state';
@@ -209,11 +209,13 @@ export const DiskActions = ({
     const Dialogs = useDialogs();
 
     function openMediaInsertionDialog() {
-        Dialogs.show(<AddDiskModalBody idPrefix={idPrefixRow + "-insert-dialog-adddisk"}
-                                       vm={vm}
-                                       disk={disk}
-                                       supportedDiskBusTypes={supportedDiskBusTypes}
-                                       isMediaInsertion />);
+        Dialogs.show(
+            <AddDisk
+                idPrefix={idPrefixRow + "-insert-dialog-adddisk"}
+                vm={vm}
+                isMediaInsertion disk={disk}
+            />
+        );
     }
 
     let cdromAction;

--- a/src/components/vm/disks/vmDisksCard.tsx
+++ b/src/components/vm/disks/vmDisksCard.tsx
@@ -14,7 +14,7 @@ import { DescriptionList, DescriptionListDescription, DescriptionListGroup, Desc
 import { useDialogs } from 'dialogs.jsx';
 
 import { convertToUnit, toReadableNumber, units, vmId } from "../../../helpers.js";
-import { AddDiskModalBody } from './diskAdd.jsx';
+import { AddDisk } from './diskAdd.jsx';
 import { needsShutdownDiskAccess, needsShutdownDiskCache, WithPending } from '../../common/needsShutdown.jsx';
 import { ListingTable } from "cockpit-components-table.jsx";
 import { DiskSourceDescriptions, DiskSourceAbbrev, DiskExtraDescriptions, DiskActions } from './vmDiskColumns.jsx';
@@ -60,9 +60,7 @@ export const VmDisksActions = ({
     const idPrefix = `${vmId(vm.name)}-disks`;
 
     function open() {
-        Dialogs.show(<AddDiskModalBody idPrefix={idPrefix + "-adddisk"}
-                                       vm={vm}
-                                       supportedDiskBusTypes={supportedDiskBusTypes} />);
+        Dialogs.show(<AddDisk idPrefix={idPrefix + "-adddisk"} vm={vm} />);
     }
 
     return (

--- a/src/libvirt-xml-create.ts
+++ b/src/libvirt-xml-create.ts
@@ -186,7 +186,7 @@ export function getVolumeXML(
 
     const allocationElem = doc.createElement('capacity');
     allocationElem.setAttribute('unit', 'MiB');
-    allocationElem.appendChild(doc.createTextNode(String(size)));
+    allocationElem.appendChild(doc.createTextNode(String(Math.round(size))));
     volElem.appendChild(allocationElem);
 
     const targetElem = doc.createElement('target');

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1977,8 +1977,8 @@ class TestMachinesCreate(machineslib.VirtualMachinesCase):
                 b.wait_in_text(f"#vm-{name}-disks .pf-v6-c-empty-state", "No disks")
                 b.click(f"#vm-{name}-disks-adddisk")
                 # wait for the dialog to initialize and have a stable layout
-                b.wait_visible(f"#vm-{name}-disks-adddisk-source-group")
-                b.click(f"#vm-{name}-disks-adddisk-dialog-cancel")
+                b.wait_visible("#dialog-field-mode")
+                b.click("#dialog-cancel")
                 b.wait_not_present(".pf-v6-c-modal-box")
 
             if dialog.sourceType == 'pxe' and "network" not in dialog.location:

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -8,7 +8,6 @@ import xml.etree.ElementTree as ET
 
 import machineslib
 import testlib
-from dialoglib import DialogHelpers
 
 SYSTEM_LOCAL_CONF = '''<!DOCTYPE busconfig PUBLIC
 "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
@@ -59,7 +58,7 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
 
     def testDiskEdit(self):
         b = self.browser
-        d = DialogHelpers(b)
+        d = machineslib.MachinesDialogHelpers(b)
         m = self.machine
 
         def openDialog(target, name="subVmTest1"):
@@ -252,6 +251,7 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
 
     def testDisks(self):
         b = self.browser
+        d = machineslib.MachinesDialogHelpers(b)
         m = self.machine
         prefix = "#vm-subVmTest1-disks-adddisk"
 
@@ -301,11 +301,11 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
 
         # Check a warning message about a volume being used by another VM
         b.click(f"{prefix}")
-        b.click(f"{prefix}-useexisting")
-        b.select_from_dropdown("#vm-subVmTest1-disks-adddisk-existing-select-pool", "images")
-        b.select_from_dropdown("#vm-subVmTest1-disks-adddisk-existing-select-volume", "subVmTest2-2.img")
-        b.wait_in_text("#vm-subVmTest1-disks-adddisk-existing-select-volume-helper", "used by subVmTest2")
-        b.click(".pf-v6-c-modal-box__footer button:contains(Cancel)")
+        d.set_RadioSelect("mode", "use-existing")
+        d.set_DropdownSelect("use_existing.pool", "images")
+        d.set_DropdownSelect("use_existing.volume", "subVmTest2-2.img")
+        b.wait_in_text(d.helper_text("use_existing.volume"), "used by subVmTest2")
+        b.click(d.cancel_button())
 
         # Test remove disk - by external action
         m.execute("virsh detach-disk subVmTest1 vdc")
@@ -320,14 +320,11 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         m.execute("virsh pool-destroy images; virsh pool-undefine images")
         # Open "add disk" dialog
         b.click(f"{prefix}")
-        b.click(f"{prefix}-useexisting")
         # Check
         b.wait_not_present("#navbar-oops")
-        b.wait_visible(f"{prefix}-existing-select-pool:disabled")
-        b.wait_in_text(f"{prefix}-existing-select-pool:disabled", "No storage pools available")
-        b.wait_visible(f"{prefix}-dialog-add:disabled")
+        b.wait_visible(d.id("mode", "use-existing") + ":disabled")
 
-    class VMInsertMediaDialog:
+    class VMInsertMediaDialog(machineslib.MachinesDialogHelpers):
         def __init__(
             self, test_obj,
             vm_name='subVmTest1',
@@ -337,6 +334,8 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             force=False,
             pixel_tag=None,
         ):
+            super().__init__(test_obj.browser)
+
             self.test_obj = test_obj
             self.mode = mode
             self.vm_name = vm_name
@@ -382,33 +381,27 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             b.click(prefix)  # button
             b.wait_in_text(".pf-v6-c-modal-box__title", "Insert disc media")
 
-            b.wait_visible(f"{prefix}-dialog-adddisk-custompath:checked")
+            self.wait_RadioSelect("mode", "custom-path")
             if self.mode == "use-existing":
-                b.click(f"{prefix}-dialog-adddisk-useexisting")
+                self.set_RadioSelect("mode", "use-existing")
 
             return self
 
         def fill(self):
-            b = self.test_obj.browser
             if self.mode == "custom-path":
-                b.wait_visible(f"#vm-{self.vm_name}-disks-{self.target}-insert-dialog-adddisk-file")
                 # Type in file path
-                b.set_file_autocomplete_val(f"#vm-{self.vm_name}-disks-{self.target}-insert-dialog-adddisk-file",
-                                            self.file_path)
+                self.set_FileAutoComplete("custom_path.file", self.file_path)
             elif self.mode == "use-existing":
-                b.wait_visible(f"#vm-{self.vm_name}-disks-{self.target}-insert-dialog-adddisk-existing-select-pool:enabled")
                 # Choose storage pool
-                b.select_from_dropdown(f"#vm-{self.vm_name}-disks-{self.target}-insert-dialog-adddisk-existing-select-pool",
-                                       self.pool_name)
+                self.set_DropdownSelect("use_existing.pool", self.pool_name)
                 # Select from the available volumes
-                b.select_from_dropdown(f"#vm-{self.vm_name}-disks-{self.target}-insert-dialog-adddisk-existing-select-volume",
-                                       self.volume_name)
+                self.set_DropdownSelect("use_existing.volume", self.volume_name)
 
             return self
 
         def insert(self):
             b = self.test_obj.browser
-            b.click(".pf-v6-c-modal-box__footer button:contains(Insert)")
+            b.click(self.apply_button())
 
             return self
 
@@ -515,7 +508,7 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             # Empty cdrom should have no source
             self.test_obj.assertEqual(disks[self.target]['source'], '-')
 
-    class VMAddDiskDialog:
+    class VMAddDiskDialog(machineslib.MachinesDialogHelpers):
         def __init__(
             self, test_obj, pool_name=None, volume_name=None,
             vm_name='subVmTest1',
@@ -524,7 +517,7 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             mode="create-new",
             expected_target='vda', permanent=True, cache_mode=None,
             expected_format='raw',
-            serial=None, expected_serial=None,
+            serial=None,
             bus_type=None, pool_type=None,
             volume_format=None, expected_volume_format=None,
             persistent_vm=True,
@@ -535,6 +528,8 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             xwarning_object=None, xwarning_message=None,
             pixel_test_ignore=None,
         ):
+            super().__init__(test_obj.browser)
+
             self.test_obj = test_obj
             self.vm_name = vm_name
             self.file_path = file_path
@@ -550,7 +545,6 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             self.cache_mode = cache_mode
             self.bus_type = bus_type
             self.serial = serial
-            self.expected_serial = expected_serial or serial
             self.pool_type = pool_type
             self.volume_format = volume_format
             self.expected_volume_format = expected_volume_format
@@ -585,7 +579,7 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             prefix = f"#vm-{self.vm_name}-disks-adddisk"
 
             if self.pixel_test_tag:
-                self.test_obj.browser.wait_visible(f"{prefix}-dialog-add:not([aria-disabled=true])")
+                self.test_obj.browser.wait_visible(self.apply_button() + ":not([aria-disabled=true])")
                 self.test_obj.browser.assert_pixels(f"{prefix}-dialog-modal-window", self.pixel_test_tag,
                                                     ignore=[self.pixel_test_ignore] if self.pixel_test_ignore else [],
                                                     skip_layouts=["rtl"])
@@ -595,12 +589,10 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
                 self.verify_disk_added()
             else:
                 if self.xfail_object:
-                    self.test_obj.browser.wait_in_text(f"{prefix}-{self.xfail_object}-helper.pf-m-error",
-                                                       self.xfail_error_message)
+                    self.test_obj.browser.wait_in_text(self.helper_text(self.xfail_object), self.xfail_error_message)
                 else:
-                    self.test_obj.browser.wait_in_text(".pf-v6-c-modal-box__body .pf-v6-c-alert__title",
-                                                       self.xfail_error_title)
-                self.test_obj.browser.click(f"{prefix}-dialog-cancel")
+                    self.test_obj.browser.wait_in_text(self.error(), self.xfail_error_title)
+                self.test_obj.browser.click(self.cancel_button())
                 self.test_obj.browser.wait_not_present(".pf-v6-c-modal-box")
 
         def openDialog(self):
@@ -609,11 +601,7 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             b.click(prefix)  # button
             b.wait_in_text(".pf-v6-c-modal-box__title", "Add disk")
 
-            b.wait_visible(f"{prefix}-createnew:checked")
-            if self.mode == "use-existing":
-                b.click(f"{prefix}-useexisting")
-            elif self.mode == "custom-path":
-                b.click(f"{prefix}-custompath")
+            self.set_RadioSelect("mode", self.mode)
 
             return self
 
@@ -621,53 +609,41 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             b = self.test_obj.browser
             if self.mode == "create-new":
                 # Choose storage pool
-                if not self.pool_type or self.pool_type not in ['iscsi', 'iscsi-direct']:
-                    b.wait_visible(f"#vm-{self.vm_name}-disks-adddisk-new-select-pool:enabled")
-                    b.select_from_dropdown(f"#vm-{self.vm_name}-disks-adddisk-new-select-pool", self.pool_name)
-                else:
-                    b.click(f"#vm-{self.vm_name}-disks-adddisk-new-select-pool")
-                    # Our custom select does not respond on the click function
-                    b._wait_present(f".pf-v6-c-modal-box option[value={self.pool_name}]:disabled")
-                    return self
+                self.set_DropdownSelect("create_new.pool", self.pool_name)
 
                 # Insert name for the new volume
-                b.set_input_text(f"#vm-{self.vm_name}-disks-adddisk-new-name", self.volume_name)
+                self.set_TextInput("create_new.volume.name", self.volume_name)
                 # Insert size for the new volume
-                b.set_input_text(f"#vm-{self.vm_name}-disks-adddisk-new-size", str(self.volume_size))
-                b.select_from_dropdown(f"#vm-{self.vm_name}-disks-adddisk-new-unit", self.volume_size_unit)
+                self.set_TextInput("create_new.volume.newSize.size", str(self.volume_size))
+                self.set_DropdownSelect("create_new.volume.newSize.unit", self.volume_size_unit)
 
                 if self.volume_format:
-                    b.select_from_dropdown(f"#vm-{self.vm_name}-disks-adddisk-new-format", self.volume_format)
+                    self.set_DropdownSelect("create_new.volume.format", self.volume_format)
                 else:
-                    b.wait_val(f"#vm-{self.vm_name}-disks-adddisk-new-format",
-                               self.getExpectedFormat(self.pool_type, self.expected_volume_format))
+                    self.wait_DropdownSelect("create_new.volume.format",
+                                         self.getExpectedFormat(self.pool_type, self.expected_volume_format))
             elif self.mode == "custom-path":
-                b.wait_visible(f"#vm-{self.vm_name}-disks-adddisk-file")
+                b.wait_visible(self.field("custom_path.file"))
                 # Type in file path
-                b.set_file_autocomplete_val(f"#vm-{self.vm_name}-disks-adddisk-file", self.file_path)
+                self.set_FileAutoComplete("custom_path.file", self.file_path)
                 if self.device:
                     if self.file_path.endswith(".iso"):
                         # wait for auto-detection to finish
-                        b.wait_val(f"#vm-{self.vm_name}-disks-adddisk-select-device", "cdrom")
-                    b.select_from_dropdown(f"#vm-{self.vm_name}-disks-adddisk-select-device", self.device)
+                        self.wait_DropdownSelect("custom_path.device", "cdrom")
+                    self.set_DropdownSelect("custom_path.device", self.device)
             elif self.mode == "use-existing":
-                b.wait_visible(f"#vm-{self.vm_name}-disks-adddisk-existing-select-pool:enabled")
                 # Choose storage pool
-                b.select_from_dropdown(f"#vm-{self.vm_name}-disks-adddisk-existing-select-pool", self.pool_name)
+                self.set_DropdownSelect("use_existing.pool", self.pool_name)
                 # Select from the available volumes
-                b.select_from_dropdown(f"#vm-{self.vm_name}-disks-adddisk-existing-select-volume", self.volume_name)
+                self.set_DropdownSelect("use_existing.volume", self.volume_name)
 
             # Configure persistency - by default the check box is checked
             if self.persistent_vm:
                 if not self.permanent:
-                    b.set_checked(f"#vm-{self.vm_name}-disks-adddisk-permanent", False)
+                    b.set_checked(self.field("permanent"), False)
             else:
                 # checkbox not shown at all for transient VM
-                b.wait_not_present(f"#vm-{self.vm_name}-disks-adddisk-permanent")
-
-            # Check non-persistent VM cannot have permanent disk attached
-            if not self.persistent_vm:
-                b.wait_not_present(f"#vm-{self.vm_name}-disks-adddisk-new-permanent")
+                b.wait_not_present(self.field("permanent"))
 
             # Expand additional options
             if self.cache_mode or self.bus_type or self.serial:
@@ -676,35 +652,23 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
 
                 # Configure performance options
                 if self.cache_mode:
-                    b.select_from_dropdown("#cache-mode", self.cache_mode)
+                    self.set_DropdownSelect("additional_options.cache_mode", self.cache_mode)
 
                 # Configure bus type
                 if self.bus_type:
-                    b.select_from_dropdown(f"div.pf-v6-c-modal-box #vm-{self.vm_name}-disks-adddisk-bus-type",
-                                           self.bus_type)
+                    self.set_DropdownSelect("additional_options.bus_type", self.bus_type)
 
                 # Configure serial number
                 if self.serial:
-                    if self.xwarning_object != "serial-characters":
-                        b.set_input_text(f"#vm-{self.vm_name}-disks-adddisk-serial", self.serial)
-                    else:
-                        b.set_input_text(f"#vm-{self.vm_name}-disks-adddisk-serial", self.serial, value_check=False)
-                        # unfit characters gets dynamically filtered from serial number
-                        b.wait_val(f"#vm-{self.vm_name}-disks-adddisk-serial", self.expected_serial)
-
-                    if self.xwarning_object == 'serial-characters':
-                        b.wait_in_text("#serial-characters-message .pf-v6-c-helper-text__item-text",
-                                       self.xwarning_message)
-                    elif self.xwarning_object == 'serial-length':
-                        b.wait_in_text("#serial-length-message .pf-v6-c-helper-text__item-text",
-                                       self.xwarning_message)
-                    else:
-                        b.wait_not_present("#serial-length-message")
-                        b.wait_not_present("#serial-characters-message")
+                    self.set_TextInput("additional_options.serial", self.serial)
             else:
-                b.wait_not_visible("#cache-mode")
-                b.wait_not_visible(f"div.pf-v6-c-modal-box #vm-{self.vm_name}-disks-adddisk-bus-type")
-                b.wait_not_visible(f"#vm-{self.vm_name}-disks-adddisk-serial")
+                b.wait_not_visible(self.field("additional_options.cache_mode"))
+                b.wait_not_visible(self.field("additional_options.bus_type"))
+                b.wait_not_visible(self.field("additional_options.serial"))
+
+            if self.xwarning_object:
+                b.wait_in_text(self.helper_text(self.xwarning_object),
+                               self.xwarning_message)
 
             return self
 
@@ -789,8 +753,8 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             if self.cache_mode:
                 b.wait_in_text(f"#vm-{self.vm_name}-disks-{self.expected_target}-cache", self.cache_mode)
 
-            if self.expected_serial:
-                b.wait_in_text(f"#vm-{self.vm_name}-disks-{self.expected_target}-serial", self.expected_serial)
+            if self.serial:
+                b.wait_in_text(f"#vm-{self.vm_name}-disks-{self.expected_target}-serial", self.serial)
 
             # Check we set unmap by default
             self.test_obj.assertEqual(
@@ -804,6 +768,7 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
     @testlib.skipImage("Debian images' -cloud kernel don't have target-cli-mod kmod", "debian*")
     def testAddDiskSCSI(self):
         b = self.browser
+        d = machineslib.MachinesDialogHelpers(b)
         m = self.machine
 
         used_targets = ['vda']
@@ -842,12 +807,13 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         # ISCSI driver does not support virStorageVolCreate API
         self.VMAddDiskDialog(
             self,
+            mode='use-existing',
             pool_name='iscsi-pool',
             pool_type='iscsi',
-            xfail=True,
-            xfail_object='new-select-pool',
-            xfail_error_message='Pool type iscsi does not support volume creation',
-        ).execute()
+        ).openDialog()
+        b.wait_visible(d.id("mode", "create-new") + ":disabled")
+        b.click(d.cancel_button())
+        b.wait_not_present(".pf-v6-c-modal-box")
 
         self.VMAddDiskDialog(
             self,
@@ -926,6 +892,7 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
 
     def testAddDiskPool(self):
         b = self.browser
+        d = machineslib.MachinesDialogHelpers(b)
         m = self.machine
 
         dev = self.add_ram_disk(2)
@@ -1003,20 +970,20 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             device="disk",
         )
         dialog.openDialog()
-        b.wait_visible("#vm-subVmTest1-disks-adddisk-existing-select-pool:enabled")
         # First select some iso file, where disk type is set to "cdrom"
-        b.select_from_dropdown("#vm-subVmTest1-disks-adddisk-existing-select-pool", "images")
-        b.select_from_dropdown("#vm-subVmTest1-disks-adddisk-existing-select-volume", "defaultVol.iso")
+        d.set_DropdownSelect("use_existing.pool", "images")
+        d.set_DropdownSelect("use_existing.volume", "defaultVol.iso")
         # Then choose a different storage pool without selecting the volume
         # (let UI automatically select the first volume from loop-disk storage pool)
         # This tests that type of disk automatically resets back to default "disk"
-        b.select_from_dropdown("#vm-subVmTest1-disks-adddisk-existing-select-pool", "loop-disk")
+        d.set_DropdownSelect("use_existing.pool", "loop-disk")
         # Check that newly attached disk is indeed of type "disk"
         dialog.add_disk().verify_disk_added()
 
     @testlib.timeout(900)
     def testAddDiskDirPool(self):
         b = self.browser
+        d = machineslib.MachinesDialogHelpers(b)
         m = self.machine
         prefix = "#vm-subVmTest1-disks-adddisk"
 
@@ -1065,11 +1032,10 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             pool_name='myPoolOne',
             mode='use-existing',
         ).openDialog()
-        b.select_from_dropdown(f"{prefix}-existing-select-pool", "myPoolOne")
+        b._wait_present(d.field("use_existing.pool") + " option[value=myPoolTwo]")
         # since both disks are already attached
-        b.wait_attr(f"{prefix}-existing-select-volume", "disabled", "")
-        b.wait_in_text(f"{prefix}-existing-select-volume", "The pool is empty")
-        b.click(f"{prefix}-dialog-cancel")
+        b.wait_not_present(d.field("use_existing.pool") + " option[value=myPoolOne]")
+        b.click(d.cancel_button())
         b.wait_not_present(f"{prefix}-dialog-modal-window")
 
         pool_disk = get_next_free_target(used_targets)[-1]
@@ -1157,7 +1123,9 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
                 expected_target=get_next_free_target(used_targets)[-1],
             ).execute()
 
-        # Undefine all Storage pools and  confirm that the Add Disk dialog is disabled
+        # Undefine all Storage pools and confirm that the "Create new"
+        # and "Use existing" choices in the Add Disk dialog are
+        # disabled
         active_pools = filter(lambda pool: pool != '', m.execute("virsh pool-list --name").split('\n'))
         for pool in active_pools:
             m.execute(f"virsh pool-destroy {pool}")
@@ -1166,11 +1134,11 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             m.execute(f"virsh pool-undefine {pool}")
         b.wait_visible("#vm-details[data-pools-count='0']")
 
-        b.click(prefix)  # radio button label in modal dialog
-        b.wait_visible(f"{prefix}-dialog-add:disabled")
-        b.click(f"{prefix}-useexisting")
-        b.wait_visible(f"{prefix}-dialog-add:disabled")
-        b.click(f"{prefix}-dialog-cancel")
+        b.click(prefix)
+        b.wait_visible(d.id("mode", "create-new") + ":disabled")
+        b.wait_visible(d.id("mode", "use-existing") + ":disabled")
+        b.wait_visible(d.id("mode", "custom-path") + ":not(:disabled)")
+        b.click(d.cancel_button())
 
         # Make sure that trying to inspect the Disks tab will just show the
         # fields that are available when a pool is inactive
@@ -1183,6 +1151,8 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
     def testAddDiskCustomPath(self):
         b = self.browser
         m = self.machine
+        d = machineslib.MachinesDialogHelpers(b)
+
         prefix = "#vm-subVmTest1-disks-adddisk"
 
         # We want a "pc-i440fx" machine that supports IDE etc, and
@@ -1242,7 +1212,8 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             device='disk',
             file_path='/tmp/base.qcow2',
             mode='custom-path',
-            xfail=True, xfail_object='file-autocomplete',
+            xfail=True,
+            xfail_object='custom_path.file',
             xfail_error_message='Importing an image with a backing file is unsupported',
         ).execute()
 
@@ -1285,7 +1256,7 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             self,
             mode='custom-path'
         ).openDialog()
-        b.click(f"{prefix}-file-autocomplete .pf-v6-c-menu-toggle__button")
+        b.click(d.field("custom_path.file") + " .pf-v6-c-menu-toggle__button")
         b.wait_visible(".pf-v6-c-menu__content")
         b.key("ArrowDown")
         b.focus(".pf-v6-c-menu__content li:first-child")
@@ -1302,15 +1273,12 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         m.execute("for pool in $(virsh pool-list --all --name); do virsh pool-undefine $pool; done")
         b.wait_visible("#vm-details[data-pools-count='0']")
         b.click(prefix)
-        b.click(f"{prefix}-custompath")
-        b.set_file_autocomplete_val("#vm-subVmTest1-disks-adddisk-file", "/var/lib/libvirt/novell.iso")
-        b.wait_visible(f"{prefix}-custompath:checked")
-        b.wait_visible(f"{prefix}-dialog-add:not([disabled])")
-        b.click(f"{prefix}-createnew")
-        b.wait_visible(f"{prefix}-dialog-add[disabled]")
-        b.click(f"{prefix}-useexisting")
-        b.wait_visible(f"{prefix}-dialog-add[disabled]")
-        b.click(f"{prefix}-dialog-cancel")
+        d.set_RadioSelect("mode", "custom-path")
+        d.set_FileAutoComplete("custom_path.file", "/var/lib/libvirt/novell.iso")
+        b.wait_visible(d.apply_button() + ":not([disabled])")
+        b.wait_visible(d.id("mode", "create-new") + ":disabled")
+        b.wait_visible(d.id("mode", "use-existing") + ":disabled")
+        b.click(d.cancel_button())
         b.wait_not_present(".pf-v6-c-modal-box")
 
         self.VMAddDiskDialog(
@@ -1326,11 +1294,11 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         self.expandDiskRow("vda")
         b.wait_text("#vm-subVmTest1-disks-vda-bus", "ide")
         b.click(prefix)
-        b.click(f"{prefix}-custompath")
-        b.select_from_dropdown(f"{prefix}-select-device", "disk")
+        d.set_RadioSelect("mode", "custom-path")
+        d.set_DropdownSelect("custom_path.device", "disk")
         b.click("div.pf-v6-c-modal-box button:contains(Show additional options)")
-        b.wait_visible(f"{prefix}-bus-type[data-value=ide]")
-        b.click(".pf-v6-c-modal-box__footer button:contains(Cancel)")
+        d.wait_DropdownSelect("additional_options.bus_type", "ide")
+        b.click(d.cancel_button())
         b.wait_not_present(".pf-v6-c-modal-box")
 
         # check CD/DVD discs correctly assumes raw format for raw file
@@ -1445,10 +1413,10 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             volume_name='disk_with_serial_warning1',
             mode='create-new',
             serial='íňválíď;šéříáľ123',
-            expected_serial='vl123',
             expected_target='vdd',
-            xwarning_object="serial-characters",
-            xwarning_message="Allowed characters"
+            xfail=True,
+            xfail_object="additional_options.serial",
+            xfail_error_message="Allowed characters"
         ).execute()
 
         # Disk with serial number
@@ -1458,10 +1426,9 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             volume_name='disk_with_serial_warning2',
             mode='create-new',
             serial='serial_so_long_its_longer_than_20_characters',
-            expected_serial='serial_so_long_its_l',
-            expected_target='vde',
-            xwarning_object="serial-length",
-            xwarning_message="Identifier may be silently truncated to 20 characters (serial_so_long_its_l)"
+            expected_target='vdd',
+            xwarning_object="additional_options.serial",
+            xwarning_message="Identifier may be silently truncated to 20 characters"
         ).execute()
 
         m.execute("touch /var/lib/libvirt/novell.iso")
@@ -1476,7 +1443,6 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             expected_access='Read-only',
             mode='custom-path',
             serial="customPath",
-            expected_serial="customPath",
         ).execute()
 
         # Raw disk should be Writeable
@@ -1486,11 +1452,10 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             pool_name='myPoolOne',
             volume_name='rawVol',
             mode='use-existing',
-            expected_target='vdf',
+            expected_target='vde',
             expected_access="Writeable",
             volume_format='raw',
             serial="useexisting",
-            expected_serial="useexisting"
         ).execute()
 
         self.createVm("subVmTest2")

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -6,6 +6,7 @@ import time
 
 import machineslib
 import testlib
+from dialoglib import DialogHelpers
 
 
 @testlib.nondestructive
@@ -381,6 +382,7 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
 
     def testDelete(self):
         b = self.browser
+        d = DialogHelpers(b)
         m = self.machine
 
         name = "subVmTest1"
@@ -403,13 +405,13 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
             b.wait_visible(f"#vm-{vmName}-disks-adddisk-dialog-modal-window")
             b.wait_visible("label:contains(Create new)")  # radio button label in the modal dialog
 
-            b.select_from_dropdown(f"#vm-{vmName}-disks-adddisk-new-select-pool", poolName)
-            b.set_input_text(f"#vm-{vmName}-disks-adddisk-new-name", volName)
-            b.set_input_text(f"#vm-{vmName}-disks-adddisk-new-size", "10")
-            b.select_from_dropdown(f"#vm-{vmName}-disks-adddisk-new-unit", "MiB")
-            b.click(f"#vm-{vmName}-disks-adddisk-permanent")
+            d.set_DropdownSelect("create_new.pool", poolName)
+            d.set_TextInput("create_new.volume.name", volName)
+            d.set_TextInput("create_new.volume.newSize.size", "10")
+            d.set_DropdownSelect("create_new.volume.newSize.unit", "MiB")
+            b.click(d.field("permanent"))
 
-            b.click(f"#vm-{vmName}-disks-adddisk-dialog-add")
+            b.click(d.apply_button())
             with b.wait_timeout(30):
                 b.wait_not_present(f"#vm-{vmName}-disks-adddisk-dialog-modal-window")
 

--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -6,6 +6,7 @@ import os
 
 import machineslib
 import testlib
+from dialoglib import DialogHelpers
 
 
 @testlib.skipImage("NFS kernel oops https://bugzilla.redhat.com/show_bug.cgi?id=2344326",
@@ -533,11 +534,13 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
         b.wait_in_text("#card-pf-storage-pools .pf-v6-c-card__header button", "Storage pools")
         b.click(".pf-v6-c-card .pf-v6-c-card__header button:contains(Storage pools)")
 
-        class StorageVolumeCreateDialog:
+        class StorageVolumeCreateDialog(DialogHelpers):
             def __init__(
                 self, test_obj, pool_name, vol_name, size="128", unit="MiB", fmt='qcow2',
                 pool_type="dir", xfail=False, xfail_objects=None, xfail_error=None, remove=True,
             ):
+                super().__init__(test_obj.browser)
+
                 self.test_obj = test_obj
                 self.pool_name = pool_name
                 self.pool_type = pool_type
@@ -572,34 +575,33 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
                                "Create storage volume")
 
             def fill(self):
-                b.set_input_text("#create-volume-dialog-name", self.vol_name)
+                self.set_TextInput("volume.name", self.vol_name)
 
                 if self.size:
-                    b.set_input_text("#create-volume-dialog-size", self.size)
+                    self.set_TextInput("volume.newSize.size", self.size)
 
                 if self.unit:
-                    b.select_from_dropdown("#create-volume-dialog-unit", self.unit)
+                    self.set_TextInput("volume.newSize.unit", self.unit)
 
                 if self.fmt:
-                    b.select_from_dropdown("#create-volume-dialog-format", self.fmt)
+                    self.set_DropdownSelect("volume.format", self.fmt)
 
             def cancel(self):
-                b.click(".pf-v6-c-modal-box__footer button:contains(Cancel)")
+                b.click(self.cancel_button())
                 b.wait_not_present("#create-storage-pool-dialog")
 
             def create(self):
-                b.click(".pf-v6-c-modal-box__footer button:contains(Create)")
+                b.click(self.apply_button())
 
                 if not self.xfail:
                     # Creation of volumes might take longer for some pool types
                     if self.pool_type in ["disk", "netfs"]:
-                        b.wait_visible(".pf-v6-c-modal-box__footer button.pf-m-in-progress")
-                        b.wait_visible(".pf-v6-c-modal-box__footer button:contains(Create):disabled")
+                        b.wait_visible(self.apply_button() + ".pf-m-in-progress")
+                        b.wait_visible(self.apply_button() + ":disabled")
                     b.wait_not_present("#create-volume-dialog-modal")
                 else:
                     for xfo in self.xfail_objects:
-                        b.wait_in_text(f"#create-volume-dialog-{xfo}-group .pf-v6-c-form__helper-text .pf-m-error",
-                                       self.xfail_error)
+                        b.wait_in_text(self.helper_text(xfo), self.xfail_error)
 
             def verify(self):
                 # Check that the defined volume is now visible
@@ -640,7 +642,7 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
             fmt="qcow2",
             remove=True,
             xfail=True,
-            xfail_objects=['size'],
+            xfail_objects=['volume.newSize'],
             xfail_error="exceed the storage pool",
         ).execute()
 

--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -10,6 +10,7 @@ from collections.abc import Mapping, Sequence
 import netlib
 import storagelib
 import testlib
+from dialoglib import DialogHelpers
 from machine import testvm
 
 
@@ -611,3 +612,18 @@ class VirtualMachinesCase(VirtualMachinesCaseHelpers, storagelib.StorageHelpers,
                 traceback.print_exc(file=sys.stderr)
 
         super().tearDown()
+
+
+class MachinesDialogHelpers(DialogHelpers):
+
+    # FileAutoComplete
+
+    def set_FileAutoComplete(self, path: str, val: str) -> None:
+        b = self.browser
+        sel = self.field(path)
+        b.set_input_text(f"{sel}.pf-v6-c-menu-toggle input", val)
+        # select the file
+        b.wait_text(".pf-v6-c-menu ul li:nth-child(1) button", val)
+        b.click(".pf-v6-c-menu ul li:nth-child(1) button")
+        b.wait_not_present(".pf-v6-c-menu")
+        b.wait_val(f"{sel}.pf-v6-c-menu-toggle input", val)


### PR DESCRIPTION
This untangles the complex logic in the "Add disk" dialog. It keeps the three modes cleanly separate and avoids overlapping their states and logic. For example, the "format" handling for the "Custom path" mode is different from that of "Use existing", but it was hard to see which code is for which.
