### PR TITLE
xml: Redo all the parsing with new helper functions

### DIFF
--- a/src/components/vm/overview/firmware.tsx
+++ b/src/components/vm/overview/firmware.tsx
@@ -128,25 +128,12 @@ class FirmwareModal extends React.Component<FirmwareModalProps, FirmwareModalSta
 
 export const FirmwareLink = ({
     vm,
-    loaderElems,
     idPrefix
 } : {
     vm: VM,
-    loaderElems: HTMLCollection,
     idPrefix: string,
 }) => {
     const Dialogs = useDialogs();
-
-    function getOVMFBinariesOnHost(loaderElems: HTMLCollection): string[] {
-        const res = [];
-        for (let i = 0; i < loaderElems.length; i++) {
-            const loader = loaderElems[i];
-            const valueElem = loader.getElementsByTagName('value');
-            if (valueElem && valueElem[0].parentNode == loader && valueElem[0].textContent)
-                res.push(valueElem[0].textContent);
-        }
-        return res;
-    }
 
     let firmwareLinkWrapper;
     const hasInstallPhase = vm.metadata && vm.metadata.hasInstallPhase;
@@ -167,7 +154,6 @@ export const FirmwareLink = ({
     if (!domainCanInstall(vm.state, hasInstallPhase) && sourceType !== "disk_image") {
         firmwareLinkWrapper = <div id={`${idPrefix}-firmware`}>{currentFirmware}</div>;
     } else {
-        const uefiPaths = getOVMFBinariesOnHost(loaderElems).filter(elem => elem !== undefined);
         const firmwareLink = (disabled: boolean) => {
             return (
                 <span id={`${idPrefix}-firmware-tooltip`}>
@@ -193,13 +179,13 @@ export const FirmwareLink = ({
                     </Tooltip>
                 );
             }
-        } else if (!supportsUefiXml(loaderElems[0])) {
+        } else if (!supportsUefiXml(vm.capabilities.loader)) {
             firmwareLinkWrapper = (
                 <Tooltip id='missing-uefi-support' content={_("Libvirt or hypervisor does not support UEFI")}>
                     {firmwareLink(true)}
                 </Tooltip>
             );
-        } else if (uefiPaths.length == 0) {
+        } else if (vm.capabilities.loader.firmware_values.length == 0) {
             firmwareLinkWrapper = (
                 <Tooltip id='missing-uefi-images' content={_("Libvirt did not detect any UEFI/OVMF firmware image installed on the host")}>
                     {firmwareLink(true)}

--- a/src/components/vm/overview/helpers.tsx
+++ b/src/components/vm/overview/helpers.tsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import cockpit from 'cockpit';
 
-import type { optString } from '../../../types';
+import type { optString, DomainLoaderCapabilities } from '../../../types';
 
 import { CodeBlock, CodeBlockCode } from "@patternfly/react-core/dist/esm/components/CodeBlock";
 import { FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
@@ -86,10 +86,7 @@ export function labelForFirmwarePath(path: optString, guest_arch: optString) {
     }
 }
 
-export function supportsUefiXml(loaderElem: Element) {
+export function supportsUefiXml(loaderCaps: DomainLoaderCapabilities) {
     /* Return True if libvirt advertises support for proper UEFI setup  */
-    const enums = loaderElem.getElementsByTagName("enum");
-    const readonly = Array.prototype.filter.call(enums, enm => enm.getAttribute("name") == "readonly");
-
-    return Array.prototype.filter.call(readonly[0].getElementsByTagName("value"), value => value.textContent == "yes").length > 0;
+    return loaderCaps.readonly_values.includes("yes");
 }

--- a/src/components/vm/overview/vmOverviewCard.tsx
+++ b/src/components/vm/overview/vmOverviewCard.tsx
@@ -63,7 +63,6 @@ interface VmOverviewCardProps {
     maxVcpu: optString;
     cpuModels: string[];
     config: Config;
-    loaderElems: HTMLCollection | undefined;
     libvirtVersion: number;
 }
 
@@ -261,11 +260,10 @@ export class VmOverviewCard extends React.Component<VmOverviewCardProps, VmOverv
                             <DescriptionListDescription id={`${idPrefix}-emulated-machine`}>{vm.emulatedMachine}</DescriptionListDescription>
                         </DescriptionListGroup>
 
-                        { this.props.loaderElems && libvirtVersion >= 5002000 && // <os firmware=[bios/efi]' settings is available only for libvirt version >= 5.2. Before that version it silently ignores this attribute in the XML
+                        { vm.capabilities.loader.supported && libvirtVersion >= 5002000 && // <os firmware=[bios/efi]' settings is available only for libvirt version >= 5.2. Before that version it silently ignores this attribute in the XML
                             <DescriptionListGroup>
                                 <DescriptionListTerm>{_("Firmware")}</DescriptionListTerm>
                                 <FirmwareLink vm={vm}
-                                              loaderElems={this.props.loaderElems}
                                               idPrefix={idPrefix} />
                             </DescriptionListGroup>}
                     </DescriptionList>

--- a/src/components/vm/vmDetailsPage.tsx
+++ b/src/components/vm/vmDetailsPage.tsx
@@ -155,7 +155,6 @@ export const VmDetailsPage = ({
             title: _("Overview"),
             body: <VmOverviewCard vm={vm}
                                   config={config}
-                                  loaderElems={vm.capabilities.loaderElems}
                                   maxVcpu={vm.capabilities.maxVcpu}
                                   cpuModels={vm.capabilities.cpuModels}
                                   libvirtVersion={libvirtVersion} />,

--- a/src/libvirt-xml-parse.ts
+++ b/src/libvirt-xml-parse.ts
@@ -17,17 +17,19 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
+import cockpit from "cockpit";
+
 import type {
     optString,
 
     ConnectionName,
 
-    HypervisorCapabilities, GuestCapabilities,
+    HypervisorCapabilities, GuestCapabilities, DomainLoaderCapabilities,
 
     VMXML,
-    VMOsBoot, VMCpu, VMVcpus, VMMetadata,
+    VMOsBoot, VMCpu, VMVcpus,
     VMConsole, VMGraphics, VMWatchdog, VMVsock,
-    VMDisk, VMDiskDevice, VMInterface, VMInterfacePortForward, VMInterfacePortForwardRange,
+    VMDisk, VMDiskDevice, VMInterface, VMInterfacePortForward,
     VMFilesystem, VMRedirectedDevice,
     VMHostDevice, VMHostDeviceUsb, VMHostDevicePci, VMHostDeviceScsi, VMHostDeviceScsiHost,
     VMHostDeviceMdev, VMHostDeviceStorage, VMHostDeviceMisc, VMHostDeviceNet,
@@ -163,9 +165,134 @@ export function getElem(xml: string): Element {
     return elem;
 }
 
+/* Ad-hoc parsing utilities, not used a lot yet.
+
+   We don't use getElementsByTagName etc since those search
+   recursively and we don't want that. There is an argument, however,
+   that we should just use querySelector instead of the functions here
+   to do the parsing.
+
+   These functions are forgiving: You can pass "undefined" as the
+   element to parse and they treat that as an empty element.
+
+   - get_child(element, match1, match2, ...)
+
+     Follow the given matches and return the child that they lead to.
+
+     A match can be a string, in which case it is compared against the
+     tagName property. It can be an object, in which case the fields
+     of the object are compared to the values of attribute of the same
+     name. (And "tag" is compared to the tagName property.) It can be
+     a function, in which case a element matches when the function
+     returns true for it.
+
+   - get_children(element, match1, match2, ...)
+
+     Similar to get_child, but for the last match, all matching
+     children are collected into an array.
+
+   - get_text(element, match1, match2, ...)
+
+     Similar to get_child, but return the text content of the element
+     found by following the matches.
+
+   - get_attr(element, match1, match2, ..., attr)
+
+     Similar to get_child, but return the value of attribute "attr" of
+     the element found by following the matches.
+
+   - get_texts(element, match1, match2, ...)
+
+     Similar to get_children, but instead of the elements themselves,
+     their textContent is collected into an array.
+
+   Specialized functions for common libvirt patterns:
+
+   - get_enum_values(element, match1, match2, ..., name)
+
+     Same as get_texts(element, match1, match3, ..., { tag: "enum", name: name }, "value")
+
+ */
+
+type Match = string | Record<string, string> | ((elt: Element) => boolean);
+
+function element_matches(element: Element, match: Match): boolean {
+    if (typeof match == "string") {
+        return element.tagName == match;
+    } else if (typeof match == "object") {
+        return Object.entries(match).every(([key, value]) => {
+            if (key == "tag")
+                return element.tagName == value;
+            else
+                return element.getAttribute(key) == value;
+        });
+    } else {
+        return match(element);
+    }
+}
+
+function get_child(parent: Element | undefined, ...matches: Match[]): Element | undefined {
+    for (const match of matches) {
+        if (!parent)
+            return undefined;
+        const children = parent.children;
+        parent = undefined;
+        for (let i = 0; i < children.length; i++) {
+            const c = children[i];
+            if (element_matches(c, match)) {
+                parent = c;
+                break;
+            }
+        }
+    }
+    return parent;
+}
+
+function get_children(parent: Element | undefined, ...matches: Match[]): Element[] {
+    if (matches.length == 0)
+        return [];
+
+    parent = get_child(parent, ...matches.slice(0, -1));
+    if (!parent)
+        return [];
+
+    const res = [];
+    const children = parent.children;
+    for (let i = 0; i < children.length; i++) {
+        const c = children[i];
+        if (element_matches(c, matches[matches.length - 1]))
+            res.push(c);
+    }
+    return res;
+}
+
+function get_text(parent: Element | undefined, ...matches: Match[]): string | undefined {
+    return get_child(parent, ...matches)?.textContent;
+}
+
+function get_attr(parent: Element | undefined, ...matches: Match[]): string | undefined {
+    if (matches.length == 0)
+        return undefined;
+    const attr = matches[matches.length - 1];
+    cockpit.assert(typeof attr == "string");
+    return get_child(parent, ...matches.slice(0, -1))?.getAttribute(attr) || undefined;
+}
+
+function get_texts(parent: Element | undefined, ...matches: Match[]): string[] {
+    return get_children(parent, ...matches).map(e => e.textContent);
+}
+
+function get_enum_values(parent: Element | undefined, ...matches: Match[]): string[] {
+    if (matches.length == 0)
+        return [];
+    const name = matches[matches.length - 1];
+    cockpit.assert(typeof name == "string");
+    return get_texts(parent, ...matches.slice(0, -1), { tag: "enum", name }, "value");
+}
+
 export function parsePoolCapabilities(capsXML: string): StoragePoolCapabilites {
     const poolCapsElem = getElem(capsXML);
-    const poolElements = Array.from(poolCapsElem.getElementsByTagName("pool"));
+    const poolElements = get_children(poolCapsElem, "pool");
 
     return poolElements.reduce(function(result: StoragePoolCapabilites, item) {
         const type = item.getAttribute('type');
@@ -176,85 +303,45 @@ export function parsePoolCapabilities(capsXML: string): StoragePoolCapabilites {
     }, {});
 }
 
-export function getDomainCapMaxVCPU(domainCapsElem: Element): optString {
-    const vcpuElem = domainCapsElem.getElementsByTagName("vcpu")?.[0];
-    return vcpuElem && vcpuElem.getAttribute('max');
+export function getDomainCapMaxVCPU(caps: Element): optString {
+    return get_attr(caps, "vcpu", "max");
 }
 
-export function getDomainCapLoader(domainCapsElem: Element): HTMLCollection | undefined {
-    const osElem = domainCapsElem.getElementsByTagName("os")?.[0];
-    const loaderElems = osElem && osElem.getElementsByTagName("loader");
-    // The rest of the code assumes that if this function returns a
-    // HTMLCollection, then it contains at least one loader.
-    if (loaderElems && loaderElems.length == 0)
-        return undefined;
-    return loaderElems;
+export function getDomainCapLoader(caps: Element): DomainLoaderCapabilities {
+    const loaderElem = get_child(caps, "os", "loader");
+    return {
+        supported: !!loaderElem,
+        firmware_values: get_texts(loaderElem, "value"),
+        type_values: get_enum_values(loaderElem, "type"),
+        readonly_values: get_enum_values(loaderElem, "readonly"),
+        secure_values: get_enum_values(loaderElem, "secure"),
+    };
 }
 
-export function getDomainCapCPUCustomModels(domainCapsElem: Element): string[] {
-    const cpuElem = domainCapsElem.getElementsByTagName("cpu")?.[0];
-    const modeElems = cpuElem && cpuElem.getElementsByTagName("mode");
-    const customModeElem = modeElems && Array.prototype.find.call(modeElems, modeElem => modeElem.getAttribute("name") == "custom");
-
-    const res: string[] = [];
-    if (customModeElem) {
-        for (const modelElem of customModeElem.getElementsByTagName("model"))
-            if (modelElem.textContent)
-                res.push(modelElem.textContent);
-    }
-    return res;
+export function getDomainCapCPUCustomModels(caps: Element): string[] {
+    return get_texts(caps, "cpu", { tag: "mode", name: "custom" }, "model");
 }
 
-export function getDomainCapCPUHostModel(domainCapsElem: Element): optString {
-    const cpuElem = domainCapsElem.getElementsByTagName("cpu")?.[0];
-    const modeElems = cpuElem && cpuElem.getElementsByTagName("mode");
-    const hostModelModeElem = modeElems && Array.prototype.find.call(modeElems, modeElem => modeElem.getAttribute("name") == "host-model");
-    return hostModelModeElem && Array.prototype.map.call(hostModelModeElem.getElementsByTagName("model"), modelElem => modelElem.textContent)[0];
+export function getDomainCapCPUHostModel(caps: Element): optString {
+    return get_text(caps, "cpu", { tag: "mode", name: "host-model" }, "model");
 }
 
-export function getDomainCapDiskBusTypes(domainCapsElem: Element): string[] {
-    const devicesCapsElem = domainCapsElem.getElementsByTagName("devices")?.[0];
-    const diskCapsElem = devicesCapsElem?.getElementsByTagName("disk")?.[0];
-    const enumElems = diskCapsElem?.getElementsByTagName("enum");
-    const busElem = enumElems && Array.prototype.find.call(enumElems, enumElem => enumElem.getAttribute("name") == "bus");
-
-    const res: string[] = [];
-    if (busElem) {
-        const vals = busElem.getElementsByTagName("value");
-        for (let i = 0; i < vals.length; i++)
-            if (vals[i].textContent)
-                res.push(vals[i].textContent);
-    }
-    return res;
+export function getDomainCapDiskBusTypes(caps: Element): string[] {
+    return get_enum_values(caps, "devices", "disk", "bus");
 }
 
-export function getDomainCapSupportsSpice(domainCapsElem: Element): boolean {
-    const graphicsCapsElems = domainCapsElem.getElementsByTagName("graphics")?.[0]
-            ?.getElementsByTagName("enum")?.[0]
-            ?.getElementsByTagName("value");
-    const hasSpiceGraphics = graphicsCapsElems && Array.prototype.find.call(
-        graphicsCapsElems, valueElem => valueElem.textContent == "spice");
-    const channelCapsElems = domainCapsElem.getElementsByTagName("channel")?.[0]
-            ?.getElementsByTagName("enum")?.[0]
-            ?.getElementsByTagName("value");
-    const hasSpiceChannel = channelCapsElems && Array.prototype.find.call(
-        channelCapsElems, valueElem => valueElem.textContent == "spicevmc");
-    return !!hasSpiceGraphics || !!hasSpiceChannel;
+export function getDomainCapSupportsSpice(caps: Element): boolean {
+    const hasSpiceGraphics = get_enum_values(caps, "devices", "graphics", "type").includes("spice");
+    const hasSpiceChannel = get_enum_values(caps, "devices", "channel", "type").includes("spicevmc");
+    return hasSpiceGraphics || hasSpiceChannel;
 }
 
-export function getDomainCapSupportsTPM(domainCapsElem: Element): boolean {
-    const tpmCapsElems = domainCapsElem.getElementsByTagName("tpm")?.[0]
-            ?.getElementsByTagName("enum")?.[0]
-            ?.getElementsByTagName("value");
-    return tpmCapsElems?.length > 0;
+export function getDomainCapSupportsTPM(caps: Element): boolean {
+    return get_enum_values(caps, "devices", "tpm", "model").length > 0;
 }
 
-export function getDomainCapInterfaceBackends(domainCapsElem: Element): string[] {
-    const values = domainCapsElem.querySelectorAll("devices interface[supported='yes'] enum[name='backendType'] value");
-    if (values)
-        return Array.from(values).map(n => n.textContent || "");
-    else
-        return ["default"];
+export function getDomainCapInterfaceBackends(caps: Element): string[] {
+    return get_enum_values(caps, "devices", "interface", "backendType");
 }
 
 export function getSingleOptionalElem(parent: Element, name: string): Element | undefined {
@@ -264,119 +351,84 @@ export function getSingleOptionalElem(parent: Element, name: string): Element | 
 
 export function parseDomainSnapshotDumpxml(snapshot: string): VMSnapshot {
     const snapElem = getElem(snapshot);
-
-    const nameElem = getSingleOptionalElem(snapElem, 'name');
-    const descElem = getSingleOptionalElem(snapElem, 'description');
-    const parentElem = getSingleOptionalElem(snapElem, 'parent');
-    const memElem = getSingleOptionalElem(snapElem, 'memory');
-
-    const name = nameElem?.childNodes[0].nodeValue || "";
-    const description = descElem?.childNodes[0].nodeValue;
-    const parentName = parentElem?.getElementsByTagName("name")[0].childNodes[0].nodeValue;
-    const state = snapElem.getElementsByTagName("state")[0].childNodes[0].nodeValue || "";
-    const creationTime = snapElem.getElementsByTagName("creationTime")[0].childNodes[0].nodeValue;
-    const memoryPath = memElem?.getAttribute("file");
-
-    return { name, description, state, creationTime, parentName, memoryPath };
+    return {
+        name: get_text(snapElem, "name") || "",
+        description: get_text(snapElem, "description"),
+        parentName: get_text(snapElem, "parent", "name"),
+        state: get_text(snapElem, "state") || "",
+        creationTime: get_text(snapElem, "creationTime"),
+        memoryPath: get_attr(snapElem, "memory", "file"),
+    };
 }
 
 export function parseDomainDumpxml(connectionName: ConnectionName, domXml: string, objPath: string): VMXML {
     const domainElem = getElem(domXml);
 
-    const osElem = domainElem.getElementsByTagNameNS("", "os")[0];
-    const currentMemoryElem = domainElem.getElementsByTagName("currentMemory")[0];
-    const memoryElem = domainElem.getElementsByTagName("memory")[0];
-    const memoryBackingElem = domainElem.getElementsByTagName("memoryBacking")[0];
-    const vcpuElem = domainElem.getElementsByTagName("vcpu")[0];
-    const cpuElem = domainElem.getElementsByTagName("cpu")[0];
-    const vcpuCurrentAttr = vcpuElem.attributes.getNamedItem('current');
-    const devicesElem = domainElem.getElementsByTagName("devices")[0];
-    const osTypeElem = osElem.getElementsByTagName("type")[0];
-    const osBootElems = osElem.getElementsByTagName("boot");
-    const metadataElem = getSingleOptionalElem(domainElem, "metadata");
-
-    const name = domainElem.getElementsByTagName("name")[0].childNodes[0].nodeValue || "";
-    const uuid = domainElem.getElementsByTagName("uuid")[0].childNodes[0].nodeValue || "";
-    const description = domainElem.getElementsByTagName("description")[0]?.childNodes[0]?.nodeValue;
-    const id = objPath;
-    const osType = osTypeElem.childNodes[0].nodeValue;
-    const osBoot = parseDumpxmlForOsBoot(osBootElems);
-    const arch = osTypeElem.getAttribute("arch");
-    const emulatedMachine = osTypeElem.getAttribute("machine");
-    const firmware = osElem.getAttribute("firmware");
-    const loaderElem = getSingleOptionalElem(osElem, "loader");
-
-    const currentMemoryUnit = currentMemoryElem.getAttribute("unit") || "B";
-    const currentMemory = convertToUnit(currentMemoryElem.childNodes[0].nodeValue, currentMemoryUnit, units.KiB);
-    const memoryUnit = memoryElem.getAttribute("unit") || "B";
-    const memory = convertToUnit(memoryElem.childNodes[0].nodeValue, memoryUnit, units.KiB);
-
-    const vcpus = parseDumpxmlForVCPU(vcpuElem, vcpuCurrentAttr);
-
-    const disks = parseDumpxmlForDisks(devicesElem);
-    const cpu = parseDumpxmlForCpu(cpuElem);
-    const displays = parseDumpxmlForConsoles(devicesElem);
-    const interfaces = parseDumpxmlForInterfaces(devicesElem);
-    const redirectedDevices = parseDumpxmlForRedirectedDevices(devicesElem);
-    const hostDevices = parseDumpxmlForHostDevices(devicesElem);
-    const filesystems = parseDumpxmlForFilesystems(devicesElem);
-    const watchdog = parseDumpxmlForWatchdog(devicesElem);
-    const vsock = parseDumpxmlForVsock(devicesElem);
-    const hasSpice = parseDumpxmlForSpice(devicesElem);
-    const hasTPM = parseDumpxmlForTPM(devicesElem);
-    const hasPollingMemBalloon = parseDumpxmlForMemBalloon(devicesElem);
-
-    const hasInstallPhase = parseDumpxmlMachinesMetadataElement(metadataElem, 'has_install_phase') === 'true';
-    const installSourceType = parseDumpxmlMachinesMetadataElement(metadataElem, 'install_source_type');
-    const installSource = parseDumpxmlMachinesMetadataElement(metadataElem, 'install_source');
-    const osVariant = parseDumpxmlMachinesMetadataElement(metadataElem, 'os_variant');
-    const rootPassword = parseDumpxmlMachinesMetadataElement(metadataElem, 'root_password');
-    const userLogin = parseDumpxmlMachinesMetadataElement(metadataElem, 'user_login');
-    const userPassword = parseDumpxmlMachinesMetadataElement(metadataElem, 'user_password');
-
-    const metadata: VMMetadata = {
-        hasInstallPhase,
-        installSourceType,
-        installSource,
-        osVariant,
-        rootPassword,
-        userLogin,
-        userPassword,
-    };
+    // Shortcuts to elements that are used more than once.
+    const osElem = get_child(domainElem, "os");
+    const metadataElem = get_child(domainElem, "metadata");
+    const currentMemoryElem = get_child(domainElem, "currentMemory");
+    const memoryElem = get_child(domainElem, "memory");
+    const devicesElem = get_child(domainElem, "devices");
 
     return {
+        // General
         connectionName,
-        uuid,
-        name,
-        description,
-        id,
-        osType,
-        osBoot,
-        firmware,
-        loader: loaderElem?.textContent,
-        arch,
-        currentMemory,
-        memory,
-        memoryBacking: !!memoryBackingElem,
-        vcpus,
-        disks,
-        emulatedMachine,
-        cpu,
-        displays,
-        interfaces,
-        redirectedDevices,
-        hostDevices,
-        filesystems,
-        watchdog,
-        vsock,
-        metadata,
-        hasSpice,
-        hasTPM,
-        hasPollingMemBalloon,
+        name: get_text(domainElem, "name") || "",
+        uuid: get_text(domainElem, "uuid") || "",
+        description: get_text(domainElem, "description"),
+        id: objPath,
+        metadata: {
+            hasInstallPhase: parseDumpxmlMachinesMetadataElement(metadataElem, 'has_install_phase') === 'true',
+            installSourceType: parseDumpxmlMachinesMetadataElement(metadataElem, 'install_source_type'),
+            installSource: parseDumpxmlMachinesMetadataElement(metadataElem, 'install_source'),
+            osVariant: parseDumpxmlMachinesMetadataElement(metadataElem, 'os_variant'),
+            rootPassword: parseDumpxmlMachinesMetadataElement(metadataElem, 'root_password'),
+            userLogin: parseDumpxmlMachinesMetadataElement(metadataElem, 'user_login'),
+            userPassword: parseDumpxmlMachinesMetadataElement(metadataElem, 'user_password'),
+        },
+
+        // OS
+        osType: get_text(osElem, "type"),
+        arch: get_attr(osElem, "type", "arch"),
+        emulatedMachine: get_attr(osElem, "type", "machine"),
+        firmware: get_attr(osElem, "firmware"),
+        loader: get_text(osElem, "loader"),
+        osBoot: parseDumpxmlForOsBoot(get_children(osElem, "boot")),
+
+        // CPUs
+        vcpus: parseDumpxmlForVCPU(get_child(domainElem, "vcpu")),
+        cpu: parseDumpxmlForCpu(get_child(domainElem, "cpu")),
+
+        // Memory
+        currentMemory: convertToUnit(
+            get_text(currentMemoryElem),
+            get_attr(currentMemoryElem, "unit") || "B",
+            units.KiB
+        ),
+        memory: convertToUnit(
+            get_text(memoryElem),
+            get_attr(memoryElem, "unit") || "B",
+            units.KiB,
+        ),
+        memoryBacking: !!get_child(domainElem, "memoryBacking"),
+
+        // Devices
+        disks: parseDumpxmlForDisks(devicesElem),
+        displays: parseDumpxmlForConsoles(devicesElem),
+        interfaces: parseDumpxmlForInterfaces(devicesElem),
+        redirectedDevices: parseDumpxmlForRedirectedDevices(devicesElem),
+        hostDevices: parseDumpxmlForHostDevices(devicesElem),
+        filesystems: parseDumpxmlForFilesystems(devicesElem),
+        watchdog: parseDumpxmlForWatchdog(devicesElem),
+        vsock: parseDumpxmlForVsock(devicesElem),
+        hasSpice: parseDumpxmlForSpice(devicesElem),
+        hasTPM: !!get_child(devicesElem, 'tpm'),
+        hasPollingMemBalloon: !!get_attr(devicesElem, 'memballoon', 'stats', 'period'),
     };
 }
 
-export function parseDumpxmlForOsBoot(osBootElems: HTMLCollection): VMOsBoot[] {
+export function parseDumpxmlForOsBoot(osBootElems: Element[]): VMOsBoot[] {
     const osBoot: VMOsBoot[] = [];
 
     for (let bootNum = 0; bootNum < osBootElems.length; bootNum++) {
@@ -393,75 +445,64 @@ export function parseDumpxmlForOsBoot(osBootElems: HTMLCollection): VMOsBoot[] {
     return osBoot; // already sorted
 }
 
-export function parseDumpxmlForVCPU(vcpuElem: Element, vcpuCurrentAttr: Attr | null): VMVcpus {
+export function parseDumpxmlForVCPU(vcpuElem: Element | undefined): VMVcpus {
+    const current = get_attr(vcpuElem, "current");
+    const max = get_text(vcpuElem);
     return {
-        count: (vcpuCurrentAttr && vcpuCurrentAttr.value) ? vcpuCurrentAttr.value : vcpuElem.childNodes[0].nodeValue,
-        placement: vcpuElem.getAttribute("placement"),
-        max: vcpuElem.childNodes[0].nodeValue,
+        count: current || max,
+        placement: get_attr(vcpuElem, "placement"),
+        max,
     };
 }
 
-export function parseDumpxmlForCpu(cpuElem: Element): VMCpu {
+export function parseDumpxmlForCpu(cpuElem: Element | undefined): VMCpu {
     const cpu: VMCpu = { mode: "", topology: {} };
 
     if (!cpuElem) {
         return cpu;
     }
 
-    cpu.mode = cpuElem.getAttribute('mode') || "custom";
+    cpu.mode = get_attr(cpuElem, 'mode') || "custom";
     if (cpu.mode === 'custom') {
-        const modelElem = getSingleOptionalElem(cpuElem, 'model');
-        if (modelElem) {
-            cpu.model = modelElem.childNodes[0].nodeValue; // content of the domain/cpu/model element
-        }
+        cpu.model = get_text(cpuElem, 'model');
     }
 
-    const topologyElem = getSingleOptionalElem(cpuElem, 'topology');
-
+    const topologyElem = get_child(cpuElem, 'topology');
     if (topologyElem) {
-        cpu.topology.sockets = topologyElem.getAttribute('sockets');
-        cpu.topology.threads = topologyElem.getAttribute('threads');
-        cpu.topology.cores = topologyElem.getAttribute('cores');
+        cpu.topology.sockets = get_attr(topologyElem, 'sockets');
+        cpu.topology.threads = get_attr(topologyElem, 'threads');
+        cpu.topology.cores = get_attr(topologyElem, 'cores');
     }
 
     return cpu;
 }
 
-export function parseDumpxmlForConsoles(devicesElem: Element): VMConsole[] {
+export function parseDumpxmlForConsoles(devicesElem: Element | undefined): VMConsole[] {
     const displays: VMConsole[] = [];
-    const graphicsElems = devicesElem.getElementsByTagName("graphics");
-    if (graphicsElems) {
-        for (let i = 0; i < graphicsElems.length; i++) {
-            const graphicsElem = graphicsElems[i];
-            const display: VMGraphics = {
-                type: graphicsElem.getAttribute('type'),
-                port: graphicsElem.getAttribute('port'),
-                tlsPort: graphicsElem.getAttribute('tlsPort'),
-                address: graphicsElem.getAttribute('listen'),
-                password: graphicsElem.getAttribute('passwd'),
-                autoport: graphicsElem.getAttribute('autoport'),
-            };
-            if (display.type &&
-                (display.autoport ||
+    const graphicsElems = get_children(devicesElem, "graphics");
+    for (const graphicsElem of graphicsElems) {
+        const display: VMGraphics = {
+            type: get_attr(graphicsElem, 'type'),
+            port: get_attr(graphicsElem, 'port'),
+            tlsPort: get_attr(graphicsElem, 'tlsPort'),
+            address: get_attr(graphicsElem, 'listen'),
+            password: get_attr(graphicsElem, 'passwd'),
+            autoport: get_attr(graphicsElem, 'autoport'),
+        };
+        if (display.type &&
+            (display.autoport ||
                 (display.address && (display.port || display.tlsPort)))) {
-                displays.push(display);
-                logDebug(`parseDumpxmlForConsoles(): graphics device found: ${JSON.stringify(display)}`);
-            } else {
-                console.warn(`parseDumpxmlForConsoles(): mandatory properties are missing in dumpxml, found: ${JSON.stringify(display)}`);
-            }
+            displays.push(display);
+            logDebug(`parseDumpxmlForConsoles(): graphics device found: ${JSON.stringify(display)}`);
+        } else {
+            console.warn(`parseDumpxmlForConsoles(): mandatory properties are missing in dumpxml, found: ${JSON.stringify(display)}`);
         }
     }
 
     // console type='pty'
-    const consoleElems = devicesElem.getElementsByTagName("console");
-    if (consoleElems) {
-        for (let i = 0; i < consoleElems.length; i++) {
-            const consoleElem = consoleElems[i];
-            if (consoleElem.getAttribute('type') === 'pty') {
-                const aliasElem = getSingleOptionalElem(consoleElem, 'alias');
-                displays.push({ type: 'pty', alias: aliasElem?.getAttribute('name') });
-            }
-        }
+    const consoleElems = get_children(devicesElem, { tag: "console", type: "pty" });
+    for (const consoleElem of consoleElems) {
+        displays.push({ type: 'pty', alias: get_attr(consoleElem, 'alias', 'name') });
     }
 
     return displays;
@@ -472,26 +513,17 @@ export function parseDumpxmlForCapabilities(capabilitiesXML: string): Hypervisor
     const capabilities: HypervisorCapabilities = { guests: [] };
 
     if (capabilitiesElem) {
-        const guestElems = capabilitiesElem.getElementsByTagName('guest');
-        for (let i = 0; i < guestElems.length; i++) {
-            const guestElem = guestElems[i];
-
-            const osTypeElem = getSingleOptionalElem(guestElem, 'os_type');
-            const archElem = getSingleOptionalElem(guestElem, 'arch');
-
+        for (const guestElem of get_children(capabilitiesElem, 'guest')) {
             const guestCapabilities: GuestCapabilities = { // see https://libvirt.org/formatcaps.html#guest-capabilities
-                osType: osTypeElem?.childNodes[0].nodeValue,
-                arch: archElem?.getAttribute('name'),
+                osType: get_text(guestElem, 'os_type'),
+                arch: get_attr(guestElem, 'arch', 'name'),
             };
 
-            const featuresElem = getSingleOptionalElem(guestElem, 'features');
+            const featuresElem = get_child(guestElem, 'features');
             if (featuresElem) {
-                const diskSnapshotElem = getSingleOptionalElem(featuresElem, 'disksnapshot');
-                const externalSnapshotElem = getSingleOptionalElem(featuresElem, 'externalSnapshot');
-
                 guestCapabilities.features = {
-                    diskSnapshot: diskSnapshotElem?.getAttribute('default') === "yes",
-                    externalSnapshot: !!externalSnapshotElem,
+                    diskSnapshot: get_attr(featuresElem, 'disksnapshot', 'default') === "yes",
+                    externalSnapshot: !!get_child(featuresElem, 'externalSnapshot'),
                 };
             }
 
@@ -502,478 +534,375 @@ export function parseDumpxmlForCapabilities(capabilitiesXML: string): Hypervisor
     return capabilities;
 }
 
-export function parseDumpxmlForDisks(devicesElem: Element): Record<string, VMDisk> {
+export function parseDumpxmlForDisks(devicesElem: Element | undefined): Record<string, VMDisk> {
     const disks: Record<string, VMDisk> = {};
-    const diskElems = devicesElem.getElementsByTagName('disk');
-    if (diskElems) {
-        for (let i = 0; i < diskElems.length; i++) {
-            const diskElem = diskElems[i];
+    const diskElems = get_children(devicesElem, "disk");
+    for (let i = 0; i < diskElems.length; i++) {
+        const diskElem = diskElems[i];
 
-            const targetElem = diskElem.getElementsByTagName('target')[0];
+        const targetElem = get_child(diskElem, "target");
+        const driverElem = get_child(diskElem, 'driver');
+        const sourceElem = get_child(diskElem, 'source');
 
-            const driverElem = getSingleOptionalElem(diskElem, 'driver');
-            const sourceElem = getSingleOptionalElem(diskElem, 'source');
-            const serialElem = getSingleOptionalElem(diskElem, 'serial');
-            const aliasElem = getSingleOptionalElem(diskElem, 'alias');
-            const readonlyElem = getSingleOptionalElem(diskElem, 'readonly');
-            const shareableElem = getSingleOptionalElem(diskElem, 'shareable');
-            const bootElem = getSingleOptionalElem(diskElem, 'boot');
-
-            const sourceHostElem = sourceElem ? getSingleOptionalElem(sourceElem, 'host') : undefined;
-
-            const target = targetElem.getAttribute('dev');
-            if (target) {
-                const disk: VMDisk = { // see https://libvirt.org/formatdomain.html#elementsDisks
-                    target, // identifier of the disk, i.e. sda, hdc
-                    driver: {
-                        name: driverElem?.getAttribute('name'), // optional
-                        type: driverElem?.getAttribute('type'),
-                        cache: driverElem?.getAttribute('cache'), // optional
-                        discard: driverElem?.getAttribute('discard'), // optional
-                        io: driverElem?.getAttribute('io'), // optional
-                        errorPolicy: driverElem?.getAttribute('error_policy'), // optional
+        const target = get_attr(targetElem, 'dev');
+        if (target) {
+            const disk: VMDisk = { // see https://libvirt.org/formatdomain.html#elementsDisks
+                target, // identifier of the disk, i.e. sda, hdc
+                driver: {
+                    name: get_attr(driverElem, 'name'), // optional
+                    type: get_attr(driverElem, 'type'),
+                    cache: get_attr(driverElem, 'cache'), // optional
+                    discard: get_attr(driverElem, 'discard'), // optional
+                    io: get_attr(driverElem, 'io'), // optional
+                    errorPolicy: get_attr(driverElem, 'error_policy'), // optional
+                },
+                bootOrder: get_attr(diskElem, 'boot', 'order'),
+                type: get_attr(diskElem, 'type'), // i.e.: file
+                snapshot: get_attr(diskElem, 'snapshot'), // i.e.: internal, external
+                device: (get_attr(diskElem, 'device') || "disk") as VMDiskDevice, // i.e. cdrom, disk
+                source: {
+                    file: get_attr(sourceElem, 'file'), // optional file name of the disk
+                    dir: get_attr(sourceElem, 'dir'),
+                    dev: get_attr(sourceElem, 'dev'),
+                    pool: get_attr(sourceElem, 'pool'),
+                    volume: get_attr(sourceElem, 'volume'),
+                    protocol: get_attr(sourceElem, 'protocol'),
+                    name: get_attr(sourceElem, 'name'),
+                    host: {
+                        name: get_attr(sourceElem, 'host', 'name'),
+                        port: get_attr(sourceElem, 'host', 'port'),
                     },
-                    bootOrder: bootElem?.getAttribute('order'),
-                    type: diskElem.getAttribute('type'), // i.e.: file
-                    snapshot: diskElem.getAttribute('snapshot'), // i.e.: internal, external
-                    device: (diskElem.getAttribute('device') || "disk") as VMDiskDevice, // i.e. cdrom, disk
-                    source: {
-                        file: sourceElem?.getAttribute('file'), // optional file name of the disk
-                        dir: sourceElem?.getAttribute('dir'),
-                        dev: sourceElem?.getAttribute('dev'),
-                        pool: sourceElem?.getAttribute('pool'),
-                        volume: sourceElem?.getAttribute('volume'),
-                        protocol: sourceElem?.getAttribute('protocol'),
-                        name: sourceElem?.getAttribute('name'),
-                        host: {
-                            name: sourceHostElem?.getAttribute('name'),
-                            port: sourceHostElem?.getAttribute('port'),
-                        },
-                        startupPolicy: sourceElem?.getAttribute('startupPolicy'), // optional startupPolicy of the disk
+                    startupPolicy: get_attr(sourceElem, 'startupPolicy'), // optional startupPolicy of the disk
 
-                    },
-                    bus: targetElem.getAttribute('bus'), // i.e. scsi, ide
-                    serial: serialElem?.childNodes[0].nodeValue, // optional serial number
-                    aliasName: aliasElem?.getAttribute('name'), // i.e. scsi0-0-0-0, ide0-1-0
-                    readonly: !!readonlyElem,
-                    shareable: !!shareableElem,
-                    removable: targetElem.getAttribute('removable'),
-                };
+                },
+                bus: get_attr(targetElem, 'bus'), // i.e. scsi, ide
+                serial: get_text(diskElem, 'serial'), // optional serial number
+                aliasName: get_attr(diskElem, 'alias', 'name'), // i.e. scsi0-0-0-0, ide0-1-0
+                readonly: !!get_child(diskElem, 'readonly'),
+                shareable: !!get_child(diskElem, 'shareable'),
+                removable: get_attr(targetElem, 'removable'),
+            };
 
-                disks[disk.target] = disk;
-                logDebug(`parseDumpxmlForDisks(): disk device found: ${JSON.stringify(disk)}`);
-            } else {
-                console.warn(`parseDumpxmlForDisks(): mandatory target property missing in dumpxml for ${new XMLSerializer().serializeToString(diskElem)}`);
-            }
+            disks[disk.target] = disk;
+            logDebug(`parseDumpxmlForDisks(): disk device found: ${JSON.stringify(disk)}`);
+        } else {
+            console.warn(`parseDumpxmlForDisks(): mandatory target property missing in dumpxml for ${new XMLSerializer().serializeToString(diskElem)}`);
         }
     }
 
     return disks;
 }
 
-export function parseDumpxmlForWatchdog(devicesElem: Element): VMWatchdog {
-    const watchdogElem = getSingleOptionalElem(devicesElem, 'watchdog');
+export function parseDumpxmlForWatchdog(devicesElem: Element | undefined): VMWatchdog {
+    const watchdogElem = get_child(devicesElem, 'watchdog');
 
     if (watchdogElem) {
         return { // https://libvirt.org/formatdomain.html#watchdog-device
-            model: watchdogElem.getAttribute('model'),
-            action: watchdogElem.getAttribute('action'),
+            model: get_attr(watchdogElem, 'model'),
+            action: get_attr(watchdogElem, 'action'),
         };
     } else {
         return {};
     }
 }
 
-export function parseDumpxmlForVsock(devicesElem: Element): VMVsock {
-    const vsockElem = getSingleOptionalElem(devicesElem, 'vsock');
+export function parseDumpxmlForVsock(devicesElem: Element | undefined): VMVsock {
+    const vsockElem = get_child(devicesElem, 'vsock');
     const cid: VMVsock["cid"] = {};
 
     if (vsockElem) {
-        const cidElem = getSingleOptionalElem(devicesElem, 'cid');
-
+        const cidElem = get_child(vsockElem, 'cid');
         if (cidElem) {
             // https://libvirt.org/formatdomain.html#vsock
-            cid.auto = cidElem.getAttribute('auto');
-            cid.address = cidElem.getAttribute('address');
+            cid.auto = get_attr(cidElem, 'auto');
+            cid.address = get_attr(cidElem, 'address');
         }
     }
 
     return { cid };
 }
 
-function parseDumpxmlForSpice(devicesElem: Element): boolean {
-    for (let i = 0; i < devicesElem.children.length; ++i) {
-        const device = devicesElem.children.item(i);
-        if (!device)
-            continue;
+function parseDumpxmlForSpice(devicesElem: Element | undefined): boolean {
+    const spiceElem = get_child(devicesElem, device => {
         // also catch spicevmc
-        if (device.getAttribute("type")?.startsWith("spice"))
+        if (get_attr(device, "type")?.startsWith("spice"))
             return true;
         // qxl video is also related to SPICE
-        if (device.tagName === "video" && getSingleOptionalElem(device, "model")?.getAttribute("type") === "qxl")
+        if (device.tagName === "video" && get_attr(device, "model", "type") === "qxl")
             return true;
-    }
+        return false;
+    });
 
-    logDebug("parseDumpxmlForSpice: no SPICE elements found in", devicesElem.children);
-    return false;
+    return !!spiceElem;
 }
 
-function parseDumpxmlForTPM(devicesElem: Element): boolean {
-    return devicesElem.getElementsByTagName('tpm').length > 0;
-}
-
-function parseDumpxmlForMemBalloon(devicesElem: Element): boolean {
-    return devicesElem.querySelectorAll('memballoon stats[period]').length > 0;
-}
-
-export function parseDumpxmlForFilesystems(devicesElem: Element): VMFilesystem[] {
+export function parseDumpxmlForFilesystems(devicesElem: Element | undefined): VMFilesystem[] {
     const filesystems: VMFilesystem[] = [];
-    const filesystemElems = devicesElem.getElementsByTagName('filesystem');
-
-    if (filesystemElems) {
-        for (let i = 0; i < filesystemElems.length; i++) {
-            const filesystemElem = filesystemElems[i];
-
-            const sourceElem = getSingleOptionalElem(filesystemElem, 'source');
-            const targetElem = getSingleOptionalElem(filesystemElem, 'target');
-            const accessElem = getSingleOptionalElem(filesystemElem, 'readonly');
-
-            const target = targetElem?.getAttribute('dir');
-            if (target) {
-                const filesystem: VMFilesystem = { // https://libvirt.org/formatdomain.html#filesystems
-                    accessmode: filesystemElem.getAttribute('accessmode'),
-                    readonly: !!accessElem,
-                    source: {
-                        dir: sourceElem?.getAttribute('dir'),
-                        name: sourceElem?.getAttribute('name'),
-                        socket: sourceElem?.getAttribute('socket'),
-                        file: sourceElem?.getAttribute('file'),
-                    },
-                    target: {
-                        dir: target,
-                    },
-                };
-                filesystems.push(filesystem);
-            }
+    for (const filesystemElem of get_children(devicesElem, 'filesystem')) {
+        const sourceElem = get_child(filesystemElem, 'source');
+        const target = get_attr(filesystemElem, 'target', 'dir');
+        if (target) {
+            const filesystem: VMFilesystem = { // https://libvirt.org/formatdomain.html#filesystems
+                accessmode: get_attr(filesystemElem, 'accessmode'),
+                readonly: !!get_child(filesystemElem, 'readonly'),
+                source: {
+                    dir: get_attr(sourceElem, 'dir'),
+                    name: get_attr(sourceElem, 'name'),
+                    socket: get_attr(sourceElem, 'socket'),
+                    file: get_attr(sourceElem, 'file'),
+                },
+                target: {
+                    dir: target,
+                },
+            };
+            filesystems.push(filesystem);
         }
     }
+
     return filesystems;
 }
 
-export function parseDumpxmlForRedirectedDevices(devicesElem: Element): VMRedirectedDevice[] {
+export function parseDumpxmlForRedirectedDevices(devicesElem: Element | undefined): VMRedirectedDevice[] {
     const redirdevs: VMRedirectedDevice[] = [];
-    const redirdevElems = devicesElem.getElementsByTagName('redirdev');
-
-    if (redirdevElems) {
-        for (let i = 0; i < redirdevElems.length; i++) {
-            const redirdevElem = redirdevElems[i];
-
-            const addressElem = redirdevElem.getElementsByTagName('address')[0];
-            const sourceElem = getSingleOptionalElem(redirdevElem, 'source');
-            const bootElem = getSingleOptionalElem(redirdevElem, 'boot');
-
-            const dev: VMRedirectedDevice = { // see https://libvirt.org/formatdomain.html#elementsRedir
-                bus: redirdevElem.getAttribute('bus'),
-                type: redirdevElem.getAttribute('type'),
-                bootOrder: bootElem?.getAttribute('order'),
-                address: {
-                    type: addressElem?.getAttribute('type'),
-                    bus: addressElem?.getAttribute('bus'),
-                    port: addressElem?.getAttribute('port'),
-                },
-                source: {
-                    mode: sourceElem?.getAttribute('mode'),
-                    host: sourceElem?.getAttribute('host'),
-                    service: sourceElem?.getAttribute('service'),
-                },
-            };
-            redirdevs.push(dev);
-        }
+    for (const redirdevElem of get_children(devicesElem, 'redirdev')) {
+        const addressElem = get_child(redirdevElem, 'address');
+        const sourceElem = get_child(redirdevElem, 'source');
+        const dev: VMRedirectedDevice = { // see https://libvirt.org/formatdomain.html#elementsRedir
+            bus: get_attr(redirdevElem, 'bus'),
+            type: get_attr(redirdevElem, 'type'),
+            bootOrder: get_attr(redirdevElem, 'boot', 'order'),
+            address: {
+                type: get_attr(addressElem, 'type'),
+                bus: get_attr(addressElem, 'bus'),
+                port: get_attr(addressElem, 'port'),
+            },
+            source: {
+                mode: get_attr(sourceElem, 'mode'),
+                host: get_attr(sourceElem, 'host'),
+                service: get_attr(sourceElem, 'service'),
+            },
+        };
+        redirdevs.push(dev);
     }
+
     return redirdevs;
 }
 
-// TODO Parse more attributes. Right now it parses only necessary
-export function parseDumpxmlForHostDevices(devicesElem: Element): VMHostDevice[] {
+export function parseDumpxmlForHostDevices(devicesElem: Element | undefined): VMHostDevice[] {
     const hostdevs: VMHostDevice[] = [];
-    const hostdevElems = devicesElem.getElementsByTagName('hostdev');
+    for (const hostdevElem of get_children(devicesElem, 'hostdev')) {
+        const type = get_attr(hostdevElem, 'type');
+        const mode = get_attr(hostdevElem, 'mode');
+        const bootOrder = get_attr(hostdevElem, 'boot', 'order');
+        const driver = get_attr(hostdevElem, 'driver', 'name');
+        const sourceElem = get_child(hostdevElem, 'source');
+        const addressElem = get_child(sourceElem, 'address');
 
-    if (hostdevElems) {
-        for (let i = 0; i < hostdevElems.length; i++) {
-            const hostdevElem = hostdevElems[i];
-            const bootElem = getSingleOptionalElem(hostdevElem, 'boot');
-            const driverElem = getSingleOptionalElem(hostdevElem, 'driver');
-            const type = hostdevElem.getAttribute('type');
-            const mode = hostdevElem.getAttribute('mode');
-            const bootOrder = bootElem?.getAttribute('order');
-            const driver = driverElem?.getAttribute('name');
-
-            switch (type) {
-            case "usb": {
-                const addressElem = getSingleOptionalElem(hostdevElem, 'address');
-                const sourceElem = getSingleOptionalElem(hostdevElem, 'source');
-                const sourceAddressElem = sourceElem ? getSingleOptionalElem(sourceElem, 'address') : null;
-
-                let vendorElem;
-                let productElem;
-                if (sourceElem) {
-                    vendorElem = sourceElem.getElementsByTagName('vendor')[0];
-                    productElem = sourceElem.getElementsByTagName('product')[0];
-                }
-                const dev: VMHostDeviceUsb = {
-                    type,
-                    mode,
-                    bootOrder,
-                    driver,
+        switch (type) {
+        case "usb": {
+            const dev: VMHostDeviceUsb = {
+                type,
+                mode,
+                bootOrder,
+                driver,
+                address: {
+                    port: get_attr(hostdevElem, 'address', 'port'),
+                },
+                source: {
+                    vendor: {
+                        id: get_attr(sourceElem, 'vendor', 'id'),
+                    },
+                    product: {
+                        id: get_attr(sourceElem, 'product', 'id'),
+                    },
+                    device: get_attr(sourceElem, 'address', 'device'),
+                    bus: get_attr(sourceElem, 'address', 'bus'),
+                },
+            };
+            hostdevs.push(dev);
+            break;
+        }
+        case "pci": {
+            const dev: VMHostDevicePci = {
+                type,
+                mode,
+                bootOrder,
+                driver,
+                source: {
                     address: {
-                        port: addressElem?.getAttribute('port'),
+                        domain: get_attr(addressElem, 'domain'),
+                        bus: get_attr(addressElem, 'bus'),
+                        slot: get_attr(addressElem, 'slot'),
+                        func: get_attr(addressElem, 'function'),
                     },
-                    source: {
-                        vendor: {
-                            id: vendorElem?.getAttribute('id'),
-                        },
-                        product: {
-                            id: productElem?.getAttribute('id'),
-                        },
-                        device: sourceAddressElem?.getAttribute('device'),
-                        bus: sourceAddressElem?.getAttribute('bus'),
-                    },
-                };
-                hostdevs.push(dev);
-                break;
-            }
-            case "pci": {
-                const sourceElem = hostdevElem.getElementsByTagName('source')[0];
-                const addressElem = sourceElem.getElementsByTagName('address')[0];
+                },
+            };
+            hostdevs.push(dev);
+            break;
+        }
+        case "scsi": {
+            const protocol = get_attr(sourceElem, 'protocol');
+            let name;
+            if (protocol === "iscsi")
+                name = get_attr(sourceElem, 'name');
 
-                const dev: VMHostDevicePci = {
-                    type,
-                    mode,
-                    bootOrder,
-                    driver,
-                    source: {
-                        address: {
-                            domain: addressElem.getAttribute('domain'),
-                            bus: addressElem.getAttribute('bus'),
-                            slot: addressElem.getAttribute('slot'),
-                            func: addressElem.getAttribute('function'),
-                        },
+            const dev: VMHostDeviceScsi = {
+                type,
+                mode,
+                bootOrder,
+                driver,
+                source: {
+                    protocol,
+                    name,
+                    address: {
+                        bus: get_attr(addressElem, 'bus'),
+                        target: get_attr(addressElem, 'target'),
+                        unit: get_attr(addressElem, 'unit'),
                     },
-                };
-                hostdevs.push(dev);
-                break;
-            }
-            case "scsi": {
-                const sourceElem = hostdevElem.getElementsByTagName('source')[0];
-                const addressElem = getSingleOptionalElem(sourceElem, 'address');
-                const adapterElem = getSingleOptionalElem(sourceElem, 'adapter');
-                const protocol = sourceElem.getAttribute('protocol');
-                let name;
-                if (protocol === "iscsi")
-                    name = sourceElem.getAttribute('name');
-
-                const dev: VMHostDeviceScsi = {
-                    type,
-                    mode,
-                    bootOrder,
-                    driver,
-                    source: {
-                        protocol,
-                        name,
-                        address: {
-                            bus: addressElem?.getAttribute('bus'),
-                            target: addressElem?.getAttribute('target'),
-                            unit: addressElem?.getAttribute('unit'),
-                        },
-                        adapter: {
-                            name: adapterElem?.getAttribute('name'),
-                        },
+                    adapter: {
+                        name: get_attr(sourceElem, 'adapter', 'name'),
                     },
-                };
-                hostdevs.push(dev);
-                break;
-            }
-            case "scsi_host": {
-                const sourceElem = hostdevElem.getElementsByTagName('source')[0];
-
-                const dev: VMHostDeviceScsiHost = {
-                    type,
-                    mode,
-                    bootOrder,
-                    driver,
-                    source: {
-                        protocol: sourceElem.getAttribute('protocol'),
-                        wwpn: sourceElem.getAttribute('wwpn'),
+                },
+            };
+            hostdevs.push(dev);
+            break;
+        }
+        case "scsi_host": {
+            const dev: VMHostDeviceScsiHost = {
+                type,
+                mode,
+                bootOrder,
+                driver,
+                source: {
+                    protocol: get_attr(sourceElem, 'protocol'),
+                    wwpn: get_attr(sourceElem, 'wwpn'),
+                },
+            };
+            hostdevs.push(dev);
+            break;
+        }
+        case "mdev": {
+            const dev: VMHostDeviceMdev = {
+                type,
+                mode,
+                bootOrder,
+                driver,
+                source: {
+                    address: {
+                        uuid: get_attr(addressElem, 'uuid'),
                     },
-                };
-                hostdevs.push(dev);
-                break;
-            }
-            case "mdev": {
-                const sourceElem = hostdevElem.getElementsByTagName('source')[0];
-                const addressElem = sourceElem.getElementsByTagName('address')[0];
-
-                const dev: VMHostDeviceMdev = {
-                    type,
-                    mode,
-                    bootOrder,
-                    driver,
-                    source: {
-                        address: {
-                            uuid: addressElem.getAttribute('uuid'),
-                        },
-                    },
-                };
-                hostdevs.push(dev);
-                break;
-            }
-            case "storage": {
-                const sourceElem = hostdevElem.getElementsByTagName('source')[0];
-                const blockElem = sourceElem.getElementsByTagName('block')[0];
-
-                const dev: VMHostDeviceStorage = {
-                    type,
-                    mode,
-                    bootOrder,
-                    driver,
-                    source: {
-                        block: blockElem.childNodes[0].nodeValue
-                    },
-                };
-                hostdevs.push(dev);
-                break;
-            }
-            case "misc": {
-                const sourceElem = hostdevElem.getElementsByTagName('source')[0];
-                const charElem = sourceElem.getElementsByTagName('char')[0];
-
-                const dev: VMHostDeviceMisc = {
-                    type,
-                    mode,
-                    bootOrder,
-                    driver,
-                    source: {
-                        char: charElem.childNodes[0].nodeValue
-                    },
-                };
-                hostdevs.push(dev);
-                break;
-            }
-            case "net": {
-                const sourceElem = hostdevElem.getElementsByTagName('source')[0];
-                const interfaceElem = sourceElem.getElementsByTagName('interface')[0];
-
-                const dev: VMHostDeviceNet = {
-                    type,
-                    mode,
-                    bootOrder,
-                    driver,
-                    source: {
-                        interface: interfaceElem.childNodes[0].nodeValue
-                    },
-                };
-                hostdevs.push(dev);
-                break;
-            }
-            }
+                },
+            };
+            hostdevs.push(dev);
+            break;
+        }
+        case "storage": {
+            const dev: VMHostDeviceStorage = {
+                type,
+                mode,
+                bootOrder,
+                driver,
+                source: {
+                    block: get_text(sourceElem, 'block'),
+                },
+            };
+            hostdevs.push(dev);
+            break;
+        }
+        case "misc": {
+            const dev: VMHostDeviceMisc = {
+                type,
+                mode,
+                bootOrder,
+                driver,
+                source: {
+                    char: get_text(sourceElem, 'char'),
+                },
+            };
+            hostdevs.push(dev);
+            break;
+        }
+        case "net": {
+            const dev: VMHostDeviceNet = {
+                type,
+                mode,
+                bootOrder,
+                driver,
+                source: {
+                    interface: get_text(sourceElem, 'interface'),
+                },
+            };
+            hostdevs.push(dev);
+            break;
+        }
         }
     }
+
     return hostdevs;
 }
 
 function parsePortForwards(interfaceElem: Element): VMInterfacePortForward[] {
-    const portForwards: VMInterfacePortForward[] = [];
-    const forwardElems = interfaceElem.getElementsByTagName('portForward');
-    if (forwardElems) {
-        for (let i = 0; i < forwardElems.length; i++) {
-            const forwardElem = forwardElems[i];
-            const range: VMInterfacePortForwardRange[] = [];
-            const rangeElems = forwardElem.getElementsByTagName('range');
-            if (rangeElems) {
-                for (let j = 0; j < rangeElems.length; j++) {
-                    const rangeElem = rangeElems[j];
-                    range.push({
-                        start: rangeElem.getAttribute("start"),
-                        end: rangeElem.getAttribute("end"),
-                        to: rangeElem.getAttribute("to"),
-                        exclude: rangeElem.getAttribute("exclude"),
-                    });
+    return get_children(interfaceElem, 'portForward').map(forwardElem => (
+        {
+            address: get_attr(forwardElem, "address"),
+            dev: get_attr(forwardElem, "dev"),
+            proto: get_attr(forwardElem, "proto"),
+            range: get_children(forwardElem, 'range').map(rangeElem => (
+                {
+                    start: get_attr(rangeElem, "start"),
+                    end: get_attr(rangeElem, "end"),
+                    to: get_attr(rangeElem, "to"),
+                    exclude: get_attr(rangeElem, "exclude"),
                 }
-            }
-            const address = forwardElem.getAttribute("address");
-            const dev = forwardElem.getAttribute("dev");
-            const proto = forwardElem.getAttribute("proto");
-            portForwards.push({
-                address,
-                dev,
-                proto,
-                range,
-            });
+            )),
         }
-    }
-
-    return portForwards;
+    ));
 }
 
-export function parseDumpxmlForInterfaces(devicesElem: Element): VMInterface[] {
+export function parseDumpxmlForInterfaces(devicesElem: Element | undefined): VMInterface[] {
     const interfaces: VMInterface[] = [];
-    const interfaceElems = devicesElem.getElementsByTagName('interface');
-    if (interfaceElems) {
-        for (let i = 0; i < interfaceElems.length; i++) {
-            const interfaceElem = interfaceElems[i];
+    for (const interfaceElem of get_children(devicesElem, 'interface')) {
+        const sourceElem = get_child(interfaceElem, 'source');
+        const addressElem = get_child(interfaceElem, 'address');
 
-            const targetElem = interfaceElem.getElementsByTagName('target')[0];
-            const macElem = getSingleOptionalElem(interfaceElem, 'mac');
-            const modelElem = getSingleOptionalElem(interfaceElem, 'model');
-            const backendElem = getSingleOptionalElem(interfaceElem, 'backend');
-            const aliasElem = getSingleOptionalElem(interfaceElem, 'alias');
-            const sourceElem = getSingleOptionalElem(interfaceElem, 'source');
-            const driverElem = getSingleOptionalElem(interfaceElem, 'driver');
-            const virtualportElem = getSingleOptionalElem(interfaceElem, 'virtualport');
-            const addressElem = getSingleOptionalElem(interfaceElem, 'address');
-            const linkElem = getSingleOptionalElem(interfaceElem, 'link');
-            const mtuElem = getSingleOptionalElem(interfaceElem, 'mtu');
-            const localElem = addressElem ? getSingleOptionalElem(addressElem, 'local') : null;
-            const bootElem = getSingleOptionalElem(interfaceElem, 'boot');
-
-            const networkInterface: VMInterface = { // see https://libvirt.org/formatdomain.html#elementsNICS
-                type: interfaceElem.getAttribute('type') || "", // Only one required parameter
-                managed: interfaceElem.getAttribute('managed'),
-                name: interfaceElem.getAttribute('name'), // Name of interface
-                target: targetElem?.getAttribute('dev'),
-                mac: macElem?.getAttribute('address'), // MAC address
-                model: modelElem?.getAttribute('type'), // Device model
-                backend: backendElem?.getAttribute('type'), // User mode backend, such as "passt"
-                aliasName: aliasElem?.getAttribute('name'),
-                virtualportType: virtualportElem?.getAttribute('type'),
-                driverName: driverElem?.getAttribute('name'),
-                state: linkElem ? linkElem.getAttribute('state') : 'up', // State of interface, up/down (plug/unplug)
-                mtu: mtuElem?.getAttribute('size'),
-                bootOrder: bootElem?.getAttribute('order'),
-                source: {
-                    bridge: sourceElem?.getAttribute('bridge'),
-                    network: sourceElem?.getAttribute('network'),
-                    portgroup: sourceElem?.getAttribute('portgroup'),
-                    dev: sourceElem?.getAttribute('dev'),
-                    mode: sourceElem?.getAttribute('mode'),
-                    address: sourceElem?.getAttribute('address'),
-                    port: sourceElem?.getAttribute('port'),
-                    local: {
-                        address: localElem?.getAttribute('address'),
-                        port: localElem?.getAttribute('port'),
-                    },
+        const networkInterface: VMInterface = { // see https://libvirt.org/formatdomain.html#elementsNICS
+            type: get_attr(interfaceElem, 'type') || "", // Only one required parameter
+            managed: get_attr(interfaceElem, 'managed'),
+            name: get_attr(interfaceElem, 'name'), // Name of interface
+            target: get_attr(interfaceElem, 'target', 'dev'),
+            mac: get_attr(interfaceElem, 'mac', 'address'), // MAC address
+            model: get_attr(interfaceElem, 'model', 'type'), // Device model
+            backend: get_attr(interfaceElem, 'backend', 'type'), // User mode backend, such as "passt"
+            aliasName: get_attr(interfaceElem, 'alias', 'name'),
+            virtualportType: get_attr(interfaceElem, 'virtualport', 'type'),
+            driverName: get_attr(interfaceElem, 'driver', 'name'),
+            state: get_attr(interfaceElem, 'link', 'state') || 'up', // State of interface, up/down (plug/unplug)
+            mtu: get_attr(interfaceElem, 'mtu', 'size'),
+            bootOrder: get_attr(interfaceElem, 'boot', 'order'),
+            source: {
+                bridge: get_attr(sourceElem, 'bridge'),
+                network: get_attr(sourceElem, 'network'),
+                portgroup: get_attr(sourceElem, 'portgroup'),
+                dev: get_attr(sourceElem, 'dev'),
+                mode: get_attr(sourceElem, 'mode'),
+                address: get_attr(sourceElem, 'address'),
+                port: get_attr(sourceElem, 'port'),
+                local: {
+                    address: get_attr(sourceElem, 'local', 'address'),
+                    port: get_attr(sourceElem, 'local', 'port'),
                 },
-                address: {
-                    bus: addressElem?.getAttribute('bus'),
-                    function: addressElem?.getAttribute('function'),
-                    slot: addressElem?.getAttribute('slot'),
-                    domain: addressElem?.getAttribute('domain'),
-                },
-                portForward: parsePortForwards(interfaceElem),
-            };
-            interfaces.push(networkInterface);
-        }
+            },
+            address: {
+                bus: get_attr(addressElem, 'bus'),
+                function: get_attr(addressElem, 'function'),
+                slot: get_attr(addressElem, 'slot'),
+                domain: get_attr(addressElem, 'domain'),
+            },
+            portForward: parsePortForwards(interfaceElem),
+        };
+        interfaces.push(networkInterface);
     }
+
     return interfaces;
 }
 
@@ -1076,14 +1005,12 @@ function parseNetDumpxmlForIp(ipElems: HTMLCollection): NetworkIp[] {
 export function parseNodeDeviceDumpxml(nodeDevice: string): NodeDeviceXML | null {
     const deviceElem = getElem(nodeDevice);
 
-    const name = deviceElem.getElementsByTagName("name")[0].childNodes[0].nodeValue;
-    const pathElem = getSingleOptionalElem(deviceElem, 'path');
-    const path = pathElem?.childNodes[0].nodeValue;
-    const parentElem = getSingleOptionalElem(deviceElem, 'parent');
-    const parentName = parentElem?.childNodes[0].nodeValue;
-    const capabilityElem = deviceElem.getElementsByTagName("capability")[0];
+    const name = get_text(deviceElem, "name");
+    const path = get_text(deviceElem, "path");
+    const parentName = get_text(deviceElem, "parent");
+    const capabilityElem = get_child(deviceElem, "capability");
 
-    const type = capabilityElem.getAttribute("type");
+    const type = get_attr(capabilityElem, "type");
     if (!type)
         return null;
 
@@ -1092,74 +1019,44 @@ export function parseNodeDeviceDumpxml(nodeDevice: string): NodeDeviceXML | null
     };
 
     if (capability.type == 'net')
-        capability.interface = capabilityElem.getElementsByTagName("interface")[0].childNodes[0].nodeValue;
+        capability.interface = get_text(capabilityElem, "interface");
     else if (capability.type == 'storage')
-        capability.block = capabilityElem.getElementsByTagName("block")[0].childNodes[0].nodeValue;
+        capability.block = get_text(capabilityElem, "block");
     else if (capability.type == 'misc')
-        capability.char = capabilityElem.getElementsByTagName("char")[0].childNodes[0].nodeValue;
+        capability.char = get_text(capabilityElem, "char");
     else if (capability.type == 'usb_device' || capability.type == 'pci') {
         capability.product = {};
         capability.vendor = {};
 
-        const productElem = capabilityElem.getElementsByTagName("product")[0];
-        const vendorElem = capabilityElem.getElementsByTagName("vendor")[0];
+        const productElem = get_child(capabilityElem, "product");
+        const vendorElem = get_child(capabilityElem, "vendor");
         if (productElem) {
-            capability.product.id = productElem.getAttribute("id");
-            capability.product._value = productElem.childNodes[0]?.nodeValue;
+            capability.product.id = get_attr(productElem, "id");
+            capability.product._value = get_text(productElem);
         }
         if (vendorElem) {
-            capability.vendor.id = vendorElem.getAttribute("id");
-            capability.vendor._value = vendorElem.childNodes[0]?.nodeValue;
+            capability.vendor.id = get_attr(vendorElem, "id");
+            capability.vendor._value = get_text(vendorElem);
         }
 
         if (capability.type == "pci") {
-            const domainElem = capabilityElem.getElementsByTagName("domain")[0];
-            const busElem = capabilityElem.getElementsByTagName("bus")[0];
-            const functionElem = capabilityElem.getElementsByTagName("function")[0];
-            const slotElem = capabilityElem.getElementsByTagName("slot")[0];
-
-            capability.domain = domainElem.childNodes[0]?.nodeValue;
-            capability.bus = busElem.childNodes[0]?.nodeValue;
-            capability.function = functionElem.childNodes[0]?.nodeValue;
-            capability.slot = slotElem.childNodes[0]?.nodeValue;
+            capability.domain = get_text(capabilityElem, "domain");
+            capability.bus = get_text(capabilityElem, "bus");
+            capability.function = get_text(capabilityElem, "function");
+            capability.slot = get_text(capabilityElem, "slot");
         } else if (capability.type == "usb_device") {
-            const deviceElem = capabilityElem.getElementsByTagName("device")[0];
-            const busElem = capabilityElem.getElementsByTagName("bus")[0];
-
-            capability.device = deviceElem.childNodes[0]?.nodeValue;
-            capability.bus = busElem.childNodes[0]?.nodeValue;
+            capability.device = get_text(capabilityElem, "device");
+            capability.bus = get_text(capabilityElem, "bus");
         }
     } else if (capability.type == 'scsi') {
-        capability.bus = {};
-        capability.lun = {};
-        capability.target = {};
-
-        const busElem = capabilityElem.getElementsByTagName("bus")[0];
-        const lunElem = capabilityElem.getElementsByTagName("lun")[0];
-        const targetElem = capabilityElem.getElementsByTagName("target")[0];
-
-        if (busElem)
-            capability.bus._value = busElem.childNodes[0]?.nodeValue;
-        if (lunElem)
-            capability.lun._value = lunElem.childNodes[0]?.nodeValue;
-        if (targetElem)
-            capability.target._value = targetElem.childNodes[0]?.nodeValue;
+        capability.bus = { _value: get_text(capabilityElem, "bus") };
+        capability.lun = { _value: get_text(capabilityElem, "lun") };
+        capability.target = { _value: get_text(capabilityElem, "target") };
     } else if (capability.type == 'scsi_host') {
-        capability.host = {};
-        capability.uniqueId = {};
-
-        const hostElem = capabilityElem.getElementsByTagName("host")[0];
-        const unique_idElem = capabilityElem.getElementsByTagName("unique_id")[0];
-
-        if (hostElem)
-            capability.host._value = hostElem.childNodes[0]?.nodeValue;
-        if (unique_idElem)
-            capability.uniqueId._value = unique_idElem.childNodes[0]?.nodeValue;
+        capability.host = { _value: get_text(capabilityElem, "host") };
+        capability.uniqueId = { _value: get_text(capabilityElem, "unique_id") };
     } else if (capability.type == 'mdev') {
-        const uuidElem = capabilityElem.getElementsByTagName("uuid")[0];
-
-        if (uuidElem)
-            capability.uuid = uuidElem.childNodes[0]?.nodeValue;
+        capability.uuid = get_text(capabilityElem, "uuid");
     }
 
     return { name, path, parent: parentName, capability };
@@ -1174,44 +1071,41 @@ export function parseStoragePoolDumpxml(
 
     const result: StoragePool = {
         connectionName,
-        type: storagePoolElem.getAttribute('type') || "",
-        name: storagePoolElem.getElementsByTagName('name')[0].childNodes[0].nodeValue || "",
+        type: get_attr(storagePoolElem, 'type') || "",
+        name: get_text(storagePoolElem, 'name') || "",
         id: objPath,
-        uuid: storagePoolElem.getElementsByTagName("uuid")[0].childNodes[0].nodeValue,
-        capacity: storagePoolElem.getElementsByTagName('capacity')[0].childNodes[0].nodeValue,
-        available: storagePoolElem.getElementsByTagName('available')[0].childNodes[0].nodeValue,
-        allocation: storagePoolElem.getElementsByTagName('allocation')[0].childNodes[0].nodeValue,
+        uuid: get_text(storagePoolElem, "uuid"),
+        capacity: get_text(storagePoolElem, 'capacity'),
+        available: get_text(storagePoolElem, 'available'),
+        allocation: get_text(storagePoolElem, 'allocation'),
         volumes: [],
     };
 
     // Fetch path property if target is contained for this type of pool
     if (['dir', 'fs', 'netfs', 'logical', 'disk', 'iscsi', 'scsi', 'mpath', 'zfs'].indexOf(result.type) > -1) {
-        const targetElem = storagePoolElem.getElementsByTagName('target')[0];
-        result.target = { path: getSingleOptionalElem(targetElem, 'path')?.childNodes[0].nodeValue };
+        result.target = { path: get_text(storagePoolElem, 'target', 'path') };
     }
-    const sourceElem = storagePoolElem.getElementsByTagName('source')[0];
+    const sourceElem = get_child(storagePoolElem, 'source');
     if (sourceElem) {
         result.source = {};
 
-        const hostElem = sourceElem.getElementsByTagName('host');
-        if (hostElem[0])
-            result.source.host = { name: hostElem[0].getAttribute('name') };
+        const hostElem = get_child(sourceElem, 'host');
+        if (hostElem)
+            result.source.host = { name: get_attr(hostElem, 'name') };
 
-        const deviceElem = sourceElem.getElementsByTagName('device');
-        if (deviceElem[0])
-            result.source.device = { path: deviceElem[0].getAttribute('path') };
+        const deviceElem = get_child(sourceElem, 'device');
+        if (deviceElem)
+            result.source.device = { path: get_attr(deviceElem, 'path') };
 
-        const dirElem = sourceElem.getElementsByTagName('dir');
-        if (dirElem[0])
-            result.source.dir = { path: dirElem[0].getAttribute('path') };
+        const dirElem = get_child(sourceElem, 'dir');
+        if (dirElem)
+            result.source.dir = { path: get_attr(dirElem, 'path') };
 
-        const sourceNameElem = sourceElem.getElementsByTagName('name');
-        if (sourceNameElem[0])
-            result.source.name = sourceNameElem[0].childNodes[0].nodeValue;
+        result.source.name = get_text(sourceElem, 'name');
 
-        const formatElem = sourceElem.getElementsByTagName('format');
-        if (formatElem[0])
-            result.source.format = { type: formatElem[0].getAttribute('type') };
+        const formatElem = get_child(sourceElem, 'format');
+        if (formatElem)
+            result.source.format = { type: get_attr(formatElem, 'type') };
     }
 
     return result;
@@ -1223,26 +1117,15 @@ export function parseStorageVolumeDumpxml(
     objPath?: string)
 : StorageVolume {
     const storageVolumeElem = getElem(storageVolumeXml);
-    const type = storageVolumeElem.getAttribute('type');
-    const name = storageVolumeElem.getElementsByTagName('name')[0].childNodes[0].nodeValue || "";
-    const id = objPath;
-    const targetElem = storageVolumeElem.getElementsByTagName('target')[0];
-    const path = getSingleOptionalElem(targetElem, 'path')?.childNodes[0].nodeValue;
-    const capacity = storageVolumeElem.getElementsByTagName('capacity')[0].childNodes[0].nodeValue;
-    const allocation = storageVolumeElem.getElementsByTagName('allocation')[0].childNodes[0].nodeValue;
-    const physicalElem = storageVolumeElem.getElementsByTagName('physical')[0];
-    const physical = physicalElem ? physicalElem.childNodes[0].nodeValue : NaN;
-    const formatElem = storageVolumeElem.getElementsByTagName('format')[0];
-    const format = formatElem?.getAttribute('type');
     return {
         connectionName,
-        name,
-        id,
-        type,
-        path,
-        capacity,
-        allocation,
-        physical,
-        format,
+        name: get_text(storageVolumeElem, 'name') || "",
+        id: objPath,
+        type: get_attr(storageVolumeElem, 'type'),
+        path: get_text(storageVolumeElem, 'target', 'path'),
+        capacity: get_text(storageVolumeElem, 'capacity'),
+        allocation: get_text(storageVolumeElem, 'allocation'),
+        physical: get_text(storageVolumeElem, 'physical') || NaN,
+        format: get_attr(storageVolumeElem, 'target', 'format', 'type'),
     };
 }

--- a/src/libvirtApi/domain.ts
+++ b/src/libvirtApi/domain.ts
@@ -982,7 +982,7 @@ function domainGetCapabilities({
     arch: optString,
     model: optString,
 }): Promise<DomainCapabilities> {
-    async function get() {
+    async function get(): Promise<DomainCapabilities> {
         const [capsXML] =
             await call<[string]>(
                 connectionName,
@@ -991,8 +991,8 @@ function domainGetCapabilities({
                 { timeout, type: 'ssssu' });
 
         const domCaps = getElem(capsXML);
-        const caps: DomainCapabilities = {
-            loaderElems: getDomainCapLoader(domCaps),
+        return {
+            loader: getDomainCapLoader(domCaps),
             maxVcpu: getDomainCapMaxVCPU(domCaps),
             cpuModels: getDomainCapCPUCustomModels(domCaps),
             cpuHostModel: getDomainCapCPUHostModel(domCaps),
@@ -1001,7 +1001,6 @@ function domainGetCapabilities({
             supportsTPM: getDomainCapSupportsTPM(domCaps),
             interfaceBackends: getDomainCapInterfaceBackends(domCaps),
         };
-        return caps;
     }
 
     const key = `${arch}/${model}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -405,8 +405,16 @@ export interface VMDiskStat {
     allocation: number,
 }
 
+export interface DomainLoaderCapabilities {
+    supported: boolean,
+    firmware_values: string[],
+    type_values: string[],
+    readonly_values: string[],
+    secure_values: string[],
+}
+
 export interface DomainCapabilities {
-    loaderElems: HTMLCollection | undefined;
+    loader: DomainLoaderCapabilities;
     maxVcpu: optString;
     cpuModels: string[];
     cpuHostModel: optString;


### PR DESCRIPTION
- [x] #2465 

This is the kind of API that I like, and IMO it is easy enough to implement.

I have unfairly dismissed XPath in the past, probably because the docs that I found made it look very complex. I can be convince to give it another shot. But we really need to get rid of the 50 copies of `getElementsByTagName("foo")[0].childNodes[0].nodeValue` as well.

Also see the thread in https://github.com/cockpit-project/cockpit-machines/pull/2465#discussion_r2667362922