### PR TITLE
xml: Clean up network parsing

### DIFF
--- a/src/components/create-vm-dialog/pxe-helpers.tsx
+++ b/src/components/create-vm-dialog/pxe-helpers.tsx
@@ -83,7 +83,7 @@ function getVirtualNetworkDescription(virtualNetwork: Network): string {
 
     if (forward) {
         mode = forward.mode;
-        dev = virtualNetwork.interface && virtualNetwork.interface.interface.dev;
+        dev = forward.dev;
     }
 
     if (mode || dev) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -556,12 +556,7 @@ export interface NetworkXML {
     mtu: optString;
     forward?: {
         mode: string;
-    };
-    // FIXME - this should certainly be forward.interface.dev instead of interface.interface.dev
-    interface?: {
-        interface: {
-            dev: optString;
-        };
+        dev: optString;
     };
 }
 


### PR DESCRIPTION
This was missed in the recent big parsing rewrite.

- Use the new helpers.

- Make it type clean.

- Rename interface.interface.dev to forward.dev