### PR TITLE
api: Don't poll VM usage in domainGetAll

### DIFF
--- a/src/libvirtApi/domain.ts
+++ b/src/libvirtApi/domain.ts
@@ -81,7 +81,6 @@ import { snapshotGetAll } from './snapshot.js';
 import { downloadRhelImage, getRhelImageUrl } from './rhel-images.js';
 import { DBusProps, get_boolean_prop, call, Enum, timeout } from './helpers.js';
 import { CLOUD_IMAGE, DOWNLOAD_AN_OS, LOCAL_INSTALL_MEDIA_SOURCE, needsRHToken } from "../components/create-vm-dialog/createVmDialogUtils.js";
-import { pollUsageNow } from './common';
 
 export const domainCanInstall = (vmState: VMState, hasInstallPhase: boolean) => vmState != 'running' && hasInstallPhase;
 export const domainCanReset = (vmState: VMState) => vmState == 'running' || vmState == 'blocked' || vmState == 'paused';
@@ -955,7 +954,6 @@ export async function domainGetAll({ connectionName } : { connectionName: Connec
                                                   { timeout, type: 'u' });
         appState.deleteUnlistedVMs(connectionName, objPaths);
         await Promise.all(objPaths.map(path => domainGet({ connectionName, id: path })));
-        pollUsageNow();
     } catch (ex) {
         console.warn('GET_ALL_VMS action failed:', String(ex));
         throw ex;


### PR DESCRIPTION
The calls to ensureUsagePolling already make sure that this is done during initialization.

Fixes #2428