### PR TITLE
create: Allow URLs with "?foo=bar" query parameters

### DIFF
--- a/src/components/create-vm-dialog/autoDetectOS.py
+++ b/src/components/create-vm-dialog/autoDetectOS.py
@@ -2,6 +2,7 @@
 
 import json
 import sys
+from urllib.parse import urlparse
 
 import gi
 
@@ -14,7 +15,7 @@ loader = Libosinfo.Loader()
 loader.process_default_path()
 db = loader.get_db()
 
-url_type_media = sys.argv[1].endswith(".iso")
+url_type_media = urlparse(sys.argv[1]).path.endswith(".iso")
 
 os = None
 res = {}

--- a/src/scripts/install_machine.py
+++ b/src/scripts/install_machine.py
@@ -9,6 +9,7 @@ import tempfile
 import traceback
 import xml.etree.ElementTree as ET
 from contextlib import contextmanager
+from urllib.parse import urlparse
 
 
 def virsh(connection, *args):
@@ -138,7 +139,7 @@ def prepare_installation_source(args):
     elif args['sourceType'] in ['disk_image', 'cloud']:
         params.append("--import")
     elif ((args['source'][0] == '/' and os.path.isfile(args['source'])) or
-            (args['sourceType'] == 'url' and args['source'].endswith(".iso"))):
+            (args['sourceType'] == 'url' and urlparse(args['source']).path.endswith(".iso"))):
         params += ['--cdrom', args['source']]
     else:
         params += ['--location', args['source']]

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -956,7 +956,7 @@ class TestMachinesCreate(machineslib.VirtualMachinesCase):
         VALID_DISK_IMAGE_PATH = '/var/lib/libvirt/images/example.img'
         NOVELL_MOCKUP_ISO_PATH = '/var/lib/libvirt/novell.iso'
         PATH_WITH_SPACE = '/var/lib/libvirt/novell with spaces.iso'
-        ISO_URL = 'https://archive.fedoraproject.org/pub/archive/fedora/linux/releases/28/Server/x86_64/os/images/boot.iso'
+        ISO_URL = 'https://archive.fedoraproject.org/pub/archive/fedora/linux/releases/28/Server/x86_64/os/images/boot.iso?foo=bar'
         TREE_URL = 'https://archive.fedoraproject.org/pub/archive/fedora/linux/releases/28/Server/x86_64/os'
 
         # LINUX can be filtered if 3 years old


### PR DESCRIPTION
We need to detect whether the path of the URL ends with ".iso" but the end of the path is not always at the end of the URL.

Fixes #1933