### PR TITLE
test: wait on the vm detail page to load

### DIFF
--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -228,6 +228,8 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
         def plugAndUnplugNICs():
             mac_address = b.text("#vm-subVmTest1-network-1-mac")
 
+            # Edit dialog loads asynchronous, wait on it to load first so we don't misclick.
+            b.wait_visible("#vm-subVmTest1-network-1-edit-dialog:not(:disabled)")
             b.wait_in_text("#vm-subVmTest1-network-1-state", "up")
             b.wait_in_text("#vm-subVmTest1-iface-1-unplug", "Unplug")
 


### PR DESCRIPTION
The curious flake:

https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-2512-b79922ee-20260126-034701-arch/log.html


Seems like a misclick? Which is strange as we click by `id` but lets wait on page to load first, as we touched the test it should run retries.