### PR TITLE
packit: Enable main-builds COPR

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -49,6 +49,13 @@ jobs:
         - sh -exc "curl -L --fail -O https://github.com/cockpit-project/${PACKIT_UPSTREAM_PACKAGE_NAME}/releases/download/${PACKIT_PROJECT_VERSION}/${PACKIT_PROJECT_NAME_VERSION}.tar.xz"
         - sh -exc "curl -L --fail -O https://github.com/cockpit-project/${PACKIT_UPSTREAM_PACKAGE_NAME}/releases/download/${PACKIT_PROJECT_VERSION}/${PACKIT_UPSTREAM_PACKAGE_NAME}-node-${PACKIT_PROJECT_VERSION}.tar.xz"
 
+  - job: copr_build
+    trigger: commit
+    branch: "^main$"
+    owner: "@cockpit"
+    project: "main-builds"
+    preserve_project: True
+
   - job: propose_downstream
     trigger: release
     dist_git_branches:


### PR DESCRIPTION
This is useful for testing landed PRs quickly.

---

@ochosi FYI, as discussed in Matrix.