### PR TITLE
test: wait on "add network interface" button to be stable

### DIFF
--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -112,6 +112,8 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
         m.execute("virsh attach-interface --domain subVmTest1 --type network --source default --model virtio "
                   "--mac 52:54:00:4b:73:6f --live", timeout=300)
         b.wait_in_text("#vm-subVmTest1-network-3-mac", "52:54:00:4b:73:6f")
+        # add network interface is initialized as expected in the pixel tests
+        b.wait_visible("#vm-subVmTest1-add-iface-button:not(:disabled)")
         # vNIC which is only attached to live config cannot be edited
         b.wait_visible("#vm-subVmTest1-network-3-edit-dialog[aria-disabled=true]")
         # validate css is correct even if edit button is disabled


### PR DESCRIPTION
In a recent test run the pixel test took an image of the "Add network interface" button disabled causing a pixel test failure.

---

See https://github.com/cockpit-project/cockpit-machines/issues/2561