### PR TITLE
test: don't wait for virt-install to exit on rhel-10

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1419,7 +1419,7 @@ class TestMachinesCreate(machineslib.VirtualMachinesCase):
             # well.  (On some OSes the created VM crashes in the
             # kernel, on others, the BIOS can't find a bootable
             # device. Maybe that's the difference.)
-            if self.create_and_run and self.machine.image.startswith(('opensuse-tumbleweed', 'rhel-10')):
+            if self.create_and_run and self.machine.image.startswith('opensuse-tumbleweed'):
                 self.machine.execute(f"while {virt_install_cmd}; do sleep 1; done", timeout=300)
 
         def fill(self):


### PR DESCRIPTION
This unblocks rhel-10-2 image refresh https://github.com/cockpit-project/bots/pull/8752

Same fix as previously for centos-10 #2420