### PR TITLE
disks: Use virt-xml to attach and edit disks

### DIFF
--- a/src/components/storagePools/storageVolumeCreateBody.tsx
+++ b/src/components/storagePools/storageVolumeCreateBody.tsx
@@ -52,7 +52,7 @@ export function update_VolumeCreate(field: DialogField<VolumeCreateValue>, stora
 
 export function validate_VolumeCreate(field: DialogField<VolumeCreateValue>) {
     field.sub("name").validate(v => {
-        if (!v)
+        if (!v.trim())
             return _("Please enter new volume name");
     });
     field.sub("newSize").validate(v => {

--- a/src/components/vm/disks/diskAdd.tsx
+++ b/src/components/vm/disks/diskAdd.tsx
@@ -23,9 +23,9 @@ import {
     VolumeCreate, init_VolumeCreate, update_VolumeCreate, validate_VolumeCreate,
     type VolumeCreateValue,
 } from '../../storagePools/storageVolumeCreateBody.jsx';
-import { domainAttachDisk, domainGet, virtXmlHotEdit, domainIsRunning } from '../../../libvirtApi/domain.js';
+import { domainGet, virtXmlHotAdd, virtXmlHotEdit, domainIsRunning } from '../../../libvirtApi/domain.js';
 import { storagePoolGetAll } from '../../../libvirtApi/storagePool.js';
-import { storageVolumeCreateAndAttach } from '../../../libvirtApi/storageVolume.js';
+import { storageVolumeCreate } from '../../../libvirtApi/storageVolume.js';
 import { appState } from '../../../state';
 
 import {
@@ -55,8 +55,8 @@ function clearSerial(serial: string): string {
 
 function getFilteredVolumes(vmStoragePool: StoragePool, disks: Record<string, VMDisk>): StorageVolume[] {
     const usedDiskPaths = Object.getOwnPropertyNames(disks)
-            .filter(target => disks[target].source && (disks[target].source.file || disks[target].source.volume))
-            .map(target => (disks[target].source && (disks[target].source.file || disks[target].source.volume)));
+            .map(target => (disks[target].source && (disks[target].source.file || disks[target].source.volume || disks[target].source.dev)))
+            .filter(Boolean);
 
     const filteredVolumes = (vmStoragePool.volumes || []).filter(volume => !usedDiskPaths.includes(volume.path) && !usedDiskPaths.includes(volume.name));
 
@@ -387,7 +387,7 @@ function validate_CustomPath(field: DialogField<CustomPathValue>) {
     const { _fileInfoCache } = field.get();
     field.sub("file").validate_async(0, async file => {
         if (!file)
-            return _("Path can not be empty");
+            return _("Path cannot be empty");
 
         const { usesBackingFile } = await getFileInfo(file, _fileInfoCache);
         if (usesBackingFile)
@@ -648,56 +648,75 @@ export const AddDisk = ({
             if (!target)
                 throw new DialogError(_("Failed to add disk"), _("Can not determine guest device name"));
 
-            const hotplug = domainIsRunning(vm.state);
-
             const common = {
-                permanent: values.permanent,
-                hotplug,
-                vmId: vm.id,
-                cacheMode: values.additional_options.cache_mode,
-                busType: values.additional_options.bus_type,
-                serial: values.additional_options.serial,
+                target,
+                // Using "cache=default" is mostly the same as
+                // omitting cache altogether, except when
+                // "type=block". In that case, "cache=default" is an
+                // error and omitting "cache" gives the real default
+                // for block devices, which is "cache=none". So we
+                // omit "cache" when the user selects "default" to
+                // cover both cases.
+                cache: values.additional_options.cache_mode == "default" ? null : values.additional_options.cache_mode,
+                bus: values.additional_options.bus_type,
+                serial: values.additional_options.serial === "" ? null : values.additional_options.serial,
+                driver: {
+                    // virt-install does this by default for the OS
+                    // disk, but virt-xml does not when adding
+                    // additional ones. Cockpit-machines has been
+                    // doing it since 078628b75167, so we keep doing it.
+                    discard: "unmap",
+                },
             };
 
             if (values.mode === CREATE_NEW && typeof values.create_new != "string") {
                 const params = values.create_new;
                 const size = convertToUnit(params.volume.newSize.size, params.volume.newSize.unit, 'MiB');
-                await storageVolumeCreateAndAttach({
+                await storageVolumeCreate({
                     connectionName: vm.connectionName,
-                    target,
                     poolName: params.pool.name,
-                    volumeName: params.volume.name,
-                    format: params.volume.format,
+                    volName: params.volume.name,
                     size,
-                    ...common
+                    format: params.volume.format,
                 });
+                await virtXmlHotAdd(
+                    vm,
+                    "disk",
+                    {
+                        vol: params.pool.name + "/" + params.volume.name,
+                        format: params.volume.format,
+                        ...common,
+                    },
+                    values.permanent,
+                );
             } else if (values.mode == CUSTOM_PATH) {
                 const params = values.custom_path;
                 const file_info = await getFileInfo(params.file, params._fileInfoCache);
-                await domainAttachDisk({
-                    connectionName: vm.connectionName,
-                    target,
-                    type: "file",
-                    file: params.file,
-                    device: params.device,
-                    format: file_info.format,
-                    shareable: false,
-                    ...common
-                });
+                await virtXmlHotAdd(
+                    vm,
+                    "disk",
+                    {
+                        path: params.file,
+                        format: file_info.format,
+                        device: params.device,
+                        ...common,
+                    },
+                    values.permanent,
+                );
             } else if (values.mode == USE_EXISTING && typeof values.use_existing != "string") {
                 const params = values.use_existing;
                 const { device, format } = getPoolFormatAndDevice(params.pool._storagePool, params.volume);
-                await domainAttachDisk({
-                    connectionName: vm.connectionName,
-                    target,
-                    type: "volume",
-                    device,
-                    format,
-                    poolName: params.pool.name,
-                    volumeName: params.volume,
-                    shareable: false,
-                    ...common
-                });
+                await virtXmlHotAdd(
+                    vm,
+                    "disk",
+                    {
+                        vol: params.pool.name + "/" + params.volume,
+                        format,
+                        device,
+                        ...common,
+                    },
+                    values.permanent,
+                );
             }
 
             // force reload of VM data, events are not reliable (i.e. for a down VM)

--- a/src/components/vm/disks/diskEdit.tsx
+++ b/src/components/vm/disks/diskEdit.tsx
@@ -26,8 +26,10 @@ import {
     DialogCancelButton,
 } from 'cockpit/dialog';
 
-import { domainUpdateDiskAttributes } from '../../../libvirtApi/domain.js';
-import { diskBusTypes, diskCacheModes, getDiskPrettyName, getDiskFullName } from '../../../helpers.js';
+import { virtXmlEdit } from "../../../libvirtApi/domain.js";
+import {
+    diskBusTypes, diskCacheModes, getDiskPrettyName, getDiskFullName, getNextAvailableTarget
+} from '../../../helpers.js';
 import { NeedsShutdownAlert } from '../../common/needsShutdown.jsx';
 
 const _ = cockpit.gettext;
@@ -171,17 +173,45 @@ const EditDisk = ({
 
     async function save(values: EditDiskValues) {
         const existingTargets = Object.getOwnPropertyNames(vm.disks);
+        let newTarget: string | undefined = disk.target;
+        let address = null;
+
+        if (values.bus.type != disk.bus) {
+            newTarget = getNextAvailableTarget(existingTargets, values.bus.type);
+            if (!newTarget)
+                throw new DialogError(cockpit.format(_("No free targets for bus type $0."), values.bus.type));
+
+            // HACK - virt-xml will not reset the address when
+            // changing the bus type, and we need to add
+            // "xpath0.delete=./address" explicitly. However, not all
+            // versions of virt-xml that we care about support xpath
+            // yet, so we reset the address explicitly to something
+            // acceptable.
+            //
+            // See https://github.com/virt-manager/virt-manager/issues/430
+
+            if (values.bus.type == "virtio") {
+                address = { type: "pci" };
+            } else if (values.bus.type == "usb") {
+                address = { type: "usb", bus: 0 };
+            } else if (values.bus.type == "scsi" || values.bus.type == "sata") {
+                address = { type: "drive", bus: 0 };
+            }
+        }
 
         try {
-            await domainUpdateDiskAttributes({
+            await virtXmlEdit(
                 vm,
-                target: disk.target,
-                readonly: values.access.mode == "readonly",
-                shareable: disk.shareable,
-                busType: values.bus.type,
-                cache: values.cache,
-                existingTargets
-            });
+                "disk",
+                { target: disk.target },
+                {
+                    target: newTarget,
+                    bus: values.bus.type,
+                    address,
+                    cache: values.cache,
+                    readonly: (values.access.mode == "readonly") ? "yes" : "no",
+                }
+            );
         } catch (ex) {
             throw DialogError.fromError(_("Disk settings could not be saved"), ex);
         }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -659,7 +659,12 @@ interface DiskMapFile {
     source: optString;
 }
 
-type DiskMap = DiskMapVolume | DiskMapFile;
+interface DiskMapBlock {
+    type: "block";
+    source: optString;
+}
+
+type DiskMap = DiskMapVolume | DiskMapFile | DiskMapBlock;
 
 function getVmDisksMap(vms: VM[], connectionName: ConnectionName): Record<string, Array<DiskMap>> {
     const vmDisksMap: Record<string, Array<DiskMap>> = {};
@@ -678,6 +683,8 @@ function getVmDisksMap(vms: VM[], connectionName: ConnectionName): Record<string
                 vmDisksMap[vm.name].push({ type: 'volume', pool: diskProps.source.pool, volume: diskProps.source.volume });
             else if (diskProps.type == 'file')
                 vmDisksMap[vm.name].push({ type: 'file', source: diskProps.source.file });
+            else if (diskProps.type == 'block')
+                vmDisksMap[vm.name].push({ type: 'block', source: diskProps.source.dev });
             /* Other disk types should be handled as well when we allow their creation from cockpit UI */
         }
     }
@@ -718,22 +725,21 @@ export function getStorageVolumesUsage(vms: VM[], storagePool: StoragePool): Sto
 
     // And make it a dictionary of volumeName -> array of Domains using volume
     const isVolumeUsed: Record<string, Array<string>> = {};
-    for (const i in volumes) {
-        const volumeName = volumes[i].name;
-        const targetPath = storagePool.target ? storagePool.target.path : '';
-        const volumePath = [targetPath, volumeName].join('/');
-        isVolumeUsed[volumeName] = [];
+    for (const vol of volumes) {
+        isVolumeUsed[vol.name] = [];
 
         for (const vmName in vmDisksMap) {
             const disks = vmDisksMap[vmName];
 
-            for (const i in disks) {
-                const disk = disks[i];
-                if (disk.type == 'volume' && disk.volume == volumeName && disk.pool == storagePool.name)
-                    isVolumeUsed[volumeName].push(vmName);
+            for (const disk of disks) {
+                if (disk.type == 'volume' && disk.volume == vol.name && disk.pool == storagePool.name)
+                    isVolumeUsed[vol.name].push(vmName);
 
-                if (disk.type == 'file' && disk.source == volumePath)
-                    isVolumeUsed[volumeName].push(vmName);
+                if (disk.type == 'file' && disk.source == vol.path)
+                    isVolumeUsed[vol.name].push(vmName);
+
+                if (disk.type == 'block' && disk.source == vol.path)
+                    isVolumeUsed[vol.name].push(vmName);
             }
         }
     }

--- a/src/libvirt-xml-create.ts
+++ b/src/libvirt-xml-create.ts
@@ -6,66 +6,6 @@
 
 import type { optString } from './types';
 
-export function getDiskXML(
-    type: string,
-    file: string | undefined,
-    device: string,
-    poolName: string | undefined,
-    volumeName: string | undefined,
-    format: string,
-    target: string,
-    cacheMode: string,
-    shareable: boolean | undefined,
-    busType: string,
-    serial: string,
-): string {
-    const doc = document.implementation.createDocument('', '', null);
-
-    const diskElem = doc.createElement('disk');
-    diskElem.setAttribute('type', type);
-    diskElem.setAttribute('device', device);
-
-    const driverElem = doc.createElement('driver');
-    driverElem.setAttribute('name', 'qemu');
-    if (format && ['qcow2', 'raw'].includes(format))
-        driverElem.setAttribute('type', format);
-    driverElem.setAttribute('cache', cacheMode);
-    driverElem.setAttribute('discard', 'unmap');
-    diskElem.appendChild(driverElem);
-
-    const sourceElem = doc.createElement('source');
-    if (type === 'file') {
-        if (file)
-            sourceElem.setAttribute('file', file);
-    } else {
-        if (volumeName)
-            sourceElem.setAttribute('volume', volumeName);
-        if (poolName)
-            sourceElem.setAttribute('pool', poolName);
-    }
-    diskElem.appendChild(sourceElem);
-
-    const targetElem = doc.createElement('target');
-    targetElem.setAttribute('dev', target);
-    targetElem.setAttribute('bus', busType);
-    diskElem.appendChild(targetElem);
-
-    if (shareable) {
-        const shareableElem = doc.createElement('shareable');
-        diskElem.appendChild(shareableElem);
-    }
-
-    if (serial) {
-        const serialElem = doc.createElement('serial');
-        serialElem.appendChild(doc.createTextNode(serial));
-        diskElem.appendChild(serialElem);
-    }
-
-    doc.appendChild(diskElem);
-
-    return new XMLSerializer().serializeToString(doc.documentElement);
-}
-
 export interface NetworkSpec {
     name: string,
     forwardMode: string,

--- a/src/libvirt-xml-update.ts
+++ b/src/libvirt-xml-update.ts
@@ -6,10 +6,8 @@
 
 import cockpit from 'cockpit';
 
-import { optString } from './types';
-
 import { getDoc, getDocElement, getSingleOptionalElem } from './libvirt-xml-parse.js';
-import { getNextAvailableTarget, BootOrderDevice } from './helpers.js';
+import { BootOrderDevice } from './helpers.js';
 
 export function changeMedia({
     domXml,
@@ -64,70 +62,6 @@ export function changeMedia({
     }
 
     return deviceXml ? s.serializeToString(deviceXml) : domXml;
-}
-
-export function updateDisk({
-    doc,
-    diskTarget,
-    readonly,
-    shareable,
-    busType,
-    existingTargets,
-    cache
-} : {
-    doc: XMLDocument,
-    diskTarget: optString,
-    readonly: boolean,
-    shareable: boolean,
-    busType: optString,
-    existingTargets: string[],
-    cache: optString,
-}): boolean {
-    const domainElem = getDocElement(doc);
-    const deviceElem = domainElem.getElementsByTagName("devices")[0];
-    const disks = deviceElem.getElementsByTagName("disk");
-
-    for (let i = 0; i < disks.length; i++) {
-        const disk = disks[i];
-        const target = disk.getElementsByTagName("target")[0].getAttribute("dev");
-        if (target == diskTarget) {
-            let shareAbleElem = getSingleOptionalElem(disk, "shareable");
-            if (!shareAbleElem && shareable) {
-                shareAbleElem = doc.createElement("shareable");
-                disk.appendChild(shareAbleElem);
-            } else if (shareAbleElem && !shareable) {
-                shareAbleElem.remove();
-            }
-
-            let readOnlyElem = getSingleOptionalElem(disk, "readonly");
-            if (!readOnlyElem && readonly) {
-                readOnlyElem = doc.createElement("readonly");
-                disk.appendChild(readOnlyElem);
-            } else if (readOnlyElem && !readonly) {
-                readOnlyElem.remove();
-            }
-
-            const targetElem = disk.getElementsByTagName("target")[0];
-            const oldBusType = targetElem.getAttribute("bus");
-            if (busType && oldBusType !== busType) {
-                targetElem.setAttribute("bus", busType);
-                const newTarget = getNextAvailableTarget(existingTargets, busType);
-                if (!newTarget)
-                    throw new Error("updateBootOrder: no free target");
-                targetElem.setAttribute("dev", newTarget);
-
-                const addressElem = getSingleOptionalElem(disk, "address");
-                if (addressElem)
-                    addressElem.remove();
-            }
-
-            const driverElem = disk.getElementsByTagName("driver")[0];
-            if (cache)
-                driverElem.setAttribute("cache", cache);
-        }
-    }
-
-    return true;
 }
 
 export function updateBootOrder(doc: XMLDocument, devices: BootOrderDevice[]): boolean {

--- a/src/libvirtApi/domain.ts
+++ b/src/libvirtApi/domain.ts
@@ -60,7 +60,6 @@ import {
 import {
     changeMedia,
     updateBootOrder,
-    updateDisk,
     updateMaxMemory,
 } from '../libvirt-xml-update.js';
 import { storagePoolRefresh } from './storagePool.js';
@@ -1202,32 +1201,4 @@ export async function domainSetOSFirmware({
 
         return true;
     });
-}
-
-export async function domainUpdateDiskAttributes({
-    vm,
-    target,
-    readonly,
-    shareable,
-    busType,
-    existingTargets,
-    cache
-} : {
-    vm: VM,
-    target: optString,
-    readonly: boolean,
-    shareable: boolean,
-    busType: optString,
-    existingTargets: string[],
-    cache: optString,
-}): Promise<void> {
-    await domainModifyXML(vm, doc => updateDisk({
-        doc,
-        diskTarget: target,
-        readonly,
-        shareable,
-        busType,
-        existingTargets,
-        cache
-    }));
 }

--- a/src/libvirtApi/domain.ts
+++ b/src/libvirtApi/domain.ts
@@ -26,9 +26,6 @@ import type { BootOrderDevice } from '../helpers.js';
 import installVmScript from '../scripts/install_machine.py';
 
 import {
-    getDiskXML,
-} from '../libvirt-xml-create.js';
-import {
     setVmCreateInProgress,
     updateImageDownloadProgress,
     clearVmUiState,
@@ -356,68 +353,6 @@ export async function ensureBalloonPolling(vm: VM) {
             vm.hasPollingMemBalloonFailure = true;
         }
     }
-}
-
-function domainAttachDevice({
-    connectionName,
-    vmId,
-    permanent,
-    hotplug,
-    xmlDesc
-} : {
-    connectionName: ConnectionName,
-    vmId: string,
-    permanent: boolean,
-    hotplug: boolean,
-    xmlDesc: string,
-}): Promise<void> {
-    let flags = Enum.VIR_DOMAIN_AFFECT_CURRENT;
-    if (hotplug)
-        flags |= Enum.VIR_DOMAIN_AFFECT_LIVE;
-    if (permanent)
-        flags |= Enum.VIR_DOMAIN_AFFECT_CONFIG;
-
-    // Error handling is done from the calling side
-    return call(connectionName, vmId, 'org.libvirt.Domain', 'AttachDevice', [xmlDesc, flags], { timeout, type: 'su' });
-}
-
-export interface DiskSpec {
-    type: string,
-    file?: string,
-    device: string,
-    poolName?: string | undefined,
-    volumeName?: string | undefined,
-    format: string,
-    target: string,
-    vmId: string,
-    permanent: boolean,
-    hotplug: boolean,
-    cacheMode: string,
-    shareable?: boolean,
-    busType: string,
-    serial: string,
-}
-
-export function domainAttachDisk({
-    connectionName,
-    type,
-    file,
-    device,
-    poolName,
-    volumeName,
-    format,
-    target,
-    vmId,
-    permanent,
-    hotplug,
-    cacheMode,
-    shareable,
-    busType,
-    serial,
-} : { connectionName: ConnectionName } & DiskSpec): Promise<void> {
-    const xmlDesc = getDiskXML(type, file, device, poolName, volumeName, format, target, cacheMode, shareable, busType, serial);
-
-    return domainAttachDevice({ connectionName, vmId, permanent, hotplug, xmlDesc });
 }
 
 export function domainAttachHostDevices({

--- a/src/libvirtApi/storageVolume.ts
+++ b/src/libvirtApi/storageVolume.ts
@@ -18,7 +18,6 @@ import type {
 import { getVolumeXML } from '../libvirt-xml-create.js';
 import { parseStorageVolumeDumpxml } from '../libvirt-xml-parse.js';
 import { storagePoolRefresh } from './storagePool.js';
-import { domainAttachDisk } from './domain.js';
 import { call, timeout } from './helpers.js';
 
 export async function storageVolumeCreate({
@@ -40,42 +39,6 @@ export async function storageVolumeCreate({
                                         [poolName], { timeout, type: 's' });
     await call(connectionName, path, 'org.libvirt.StoragePool', 'StorageVolCreateXML', [volXmlDesc, 0], { timeout, type: 'su' });
     await storagePoolRefresh({ connectionName, objPath: path });
-}
-
-export interface StorageVolumeCreateAndAttachParams {
-    connectionName: ConnectionName,
-    poolName: string,
-    volumeName: string,
-    size: number,
-    format: string,
-    target: string,
-    vmId: string,
-    permanent: boolean,
-    hotplug: boolean,
-    cacheMode: string,
-    busType: string,
-    serial: string,
-}
-
-export async function storageVolumeCreateAndAttach({
-    connectionName,
-    poolName,
-    volumeName,
-    size,
-    format,
-    target,
-    vmId,
-    permanent,
-    hotplug,
-    cacheMode,
-    busType,
-    serial,
-}: StorageVolumeCreateAndAttachParams): Promise<void> {
-    const volXmlDesc = getVolumeXML(volumeName, size, format);
-    const [storagePoolPath] = await call<[string]>(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'StoragePoolLookupByName', [poolName], { timeout, type: 's' });
-    await call(connectionName, storagePoolPath, 'org.libvirt.StoragePool', 'StorageVolCreateXML', [volXmlDesc, 0], { timeout, type: 'su' });
-    await storagePoolRefresh({ connectionName, objPath: storagePoolPath });
-    await domainAttachDisk({ connectionName, type: "volume", device: "disk", poolName, volumeName, format, target, vmId, permanent, hotplug, cacheMode, busType, serial });
 }
 
 export async function storageVolumeDelete({

--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -722,7 +722,9 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
                 volume_xml = m.execute(f"virsh vol-dumpxml {self.volume_name} {self.pool_name} ")
                 detect_format_cmd = "echo \"{0}\" | xmllint --xpath '{1}' -"
 
-                b.wait_in_text(f'#vm-{self.vm_name}-disks-{self.expected_target}-source-volume', self.volume_name)
+                source = "dev" if self.pool_type in ["disk", "iscsi"] else "file"
+                path = m.execute(f"virsh vol-path --pool {self.pool_name} {self.volume_name}").strip()
+                b.wait_in_text(f'#vm-{self.vm_name}-disks-{self.expected_target}-source-{source}', path)
 
                 expected_format = self.getExpectedFormat(self.pool_type, self.expected_volume_format)
                 # Unknown pool format isn't present in xml anymore

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -416,8 +416,7 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
                 b.wait_not_present(f"#vm-{vmName}-disks-adddisk-dialog-modal-window")
 
             self.expandDiskRow("vdb")
-            b.wait_visible(f"#vm-{vmName}-disks-vdb-source-volume")
-            b.wait_visible(f"#vm-{vmName}-disks-vdb-source-pool")
+            b.wait_visible(f"#vm-{vmName}-disks-vdb-source-file")
 
         secondDiskVolName = "mydisk"
         poolName = "images"
@@ -429,9 +428,8 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
 
         b.wait_in_text(f"#vm-{name}-delete-modal-dialog .pf-v6-c-modal-box__body", f"The VM {name} is running")
         b.wait_in_text(f"#vm-{name}-delete-modal-dialog ul li:first-child .disk-source-file", img2)
-        # virsh attach-disk does not create disks of type volume
-        b.wait_in_text(f"#vm-{name}-delete-modal-dialog .disk-source-volume", secondDiskVolName)
-        b.wait_in_text(f"#vm-{name}-delete-modal-dialog .disk-source-pool", poolName)
+        b.wait_in_text(f"#vm-{name}-delete-modal-dialog ul li:nth-child(2) .disk-source-file",
+                       secondDiskPoolPath + secondDiskVolName)
         b.assert_pixels(f"#vm-{name}-delete-modal-dialog", "vm-delete-dialog", skip_layouts=["rtl"])
         b.click(f"#vm-{name}-delete-modal-dialog button:contains(Delete)")
         b.wait_not_present(f"#vm-{name}-delete-modal-dialog")
@@ -558,7 +556,6 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
                        f"Could not delete all storage for {name}")
         b.click("button.alert-link.more-button")
         b.wait_in_text(".pf-v6-c-alert-group li .pf-v6-c-alert .pf-v6-c-alert__description", args['image'])
-        b.wait_in_text(".pf-v6-c-alert-group li .pf-v6-c-alert .pf-v6-c-alert__description", secondDiskVolName)
         # Close the notification
         b.click(".pf-v6-c-alert-group li .pf-v6-c-alert button.pf-m-plain")
 

--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -588,7 +588,7 @@ class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
 
             def cancel(self):
                 b.click(self.cancel_button())
-                b.wait_not_present("#create-storage-pool-dialog")
+                b.wait_not_present("#create-volume-dialog-modal")
 
             def create(self):
                 b.click(self.apply_button())


### PR DESCRIPTION
This is a revival of  #394, finally.

------

### Machines: Pool volumes are now added as disks of type "file" or "block"

Previously, pool volumes were added with type "volume".  This has various problems, such as preventing to take external snapshots.  Cockpit now follows `virt-install`,`virt-xml`, and `virt-manager` and does not use type "volume" anymore for newly added disks.
