### PR TITLE
build: Fix coverage reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,9 +177,13 @@ else
 VM_INSTALL = --upload $(NODE_CACHE):/var/tmp --build $(TARFILE) --script $(CURDIR)/test/vm.install
 endif
 
+ifeq ($(NODE_ENV),development)
+VM_NO_REBUILD = --build-options '--define "rebuild_bundle 0"'
+endif
+
 # build a VM with locally built distro pkgs installed
 $(VM_IMAGE): $(TARFILE) $(NODE_CACHE) packaging/debian/rules packaging/debian/control packaging/arch/PKGBUILD bots
-	bots/image-customize --fresh $(VM_CUSTOMIZE_FLAGS) $(VM_INSTALL) $(TEST_OS)
+	bots/image-customize --fresh $(VM_CUSTOMIZE_FLAGS) $(VM_NO_REBUILD) $(VM_INSTALL) $(TEST_OS)
 
 # convenience target for the above
 vm: $(VM_IMAGE)

--- a/packaging/cockpit-machines.spec.in
+++ b/packaging/cockpit-machines.spec.in
@@ -10,8 +10,9 @@ License:        LGPL-2.1-or-later AND MIT
 URL:            https://github.com/cockpit-project/cockpit-machines
 
 # distributions which ship nodejs-esbuild can rebuild the bundle during package build
+# allow override from command line (e.g. for development builds)
 %if 0%{?fedora} >= 42
-%define rebuild_bundle 1
+%{!?rebuild_bundle: %define rebuild_bundle 1}
 %endif
 
 Source0: https://github.com/cockpit-project/%{name}/releases/download/%{version}/%{name}-%{version}.tar.xz
@@ -28,7 +29,7 @@ BuildRequires: gettext
 %if 0%{?rhel} && 0%{?rhel} <= 8
 BuildRequires: libappstream-glib-devel
 %endif
-%if %{defined rebuild_bundle}
+%if 0%{?rebuild_bundle}
 BuildRequires: /usr/bin/node
 BuildRequires: nodejs-esbuild
 %endif
@@ -74,12 +75,12 @@ Cockpit component for managing libvirt virtual machines.
 
 %prep
 %setup -q -n %{name}
-%if %{defined rebuild_bundle}
+%if 0%{?rebuild_bundle}
 %setup -q -D -T -a 1 -n %{name}
 %endif
 
 %build
-%if %{defined rebuild_bundle}
+%if 0%{?rebuild_bundle}
 rm -rf dist
 # HACK: node module packaging is broken in Fedora ≤ 43; should be in
 # common location, not major version specific one


### PR DESCRIPTION
We need to build the bundle with NODE_ENV=development.  This is achieved by building it outside the test VM with that option, and then switching rebuilding off inside the test VM.