### PR TITLE
test: Drop NFS kernel oops workaround

### DIFF
--- a/test/check-machines-storage-pools
+++ b/test/check-machines-storage-pools
@@ -9,8 +9,6 @@ import testlib
 from dialoglib import DialogHelpers
 
 
-@testlib.skipImage("NFS kernel oops https://bugzilla.redhat.com/show_bug.cgi?id=2344326",
-                   "fedora-42", "fedora-43")
 @testlib.nondestructive
 class TestMachinesStoragePools(machineslib.VirtualMachinesCase):
 


### PR DESCRIPTION
According to the bugzilla commit this was fixed in 2025-09-28.