### PR TITLE
all: Replace per-object error states with toast notifications

### DIFF
--- a/src/components/common/stateIcon.tsx
+++ b/src/components/common/stateIcon.tsx
@@ -4,37 +4,26 @@
  * Copyright (C) 2020 Red Hat, Inc.
  */
 import React from 'react';
-import cockpit from 'cockpit';
 
-import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex";
 import { Label, LabelProps } from "@patternfly/react-core/dist/esm/components/Label";
-import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
-import { ErrorCircleOIcon, PendingIcon } from '@patternfly/react-icons';
+import { PendingIcon } from '@patternfly/react-icons';
 
 import {
     rephraseUI,
 } from "../../helpers.js";
 
-import type { DetailedError } from '../../types';
-
 import "./stateIcon.scss";
-
-const _ = cockpit.gettext;
 
 interface StateIconProps {
     state: string,
     valueId: string,
-    error: DetailedError | null | undefined,
-    dismissError: () => void,
     additionalState?: React.ReactNode,
 }
 
 export const StateIcon = ({
     state,
     valueId,
-    error,
-    dismissError,
     additionalState
 }: StateIconProps) => {
     if (state === undefined) {
@@ -52,18 +41,6 @@ export const StateIcon = ({
 
     const label = (
         <Flex spaceItems={{ default: "spaceItemsXs" }}>
-            {error &&
-            <Label color="red"
-                icon={<ErrorCircleOIcon />}
-                className="resource-state-text"
-                closeBtnAriaLabel={_("Close")}
-                onClose={dismissError}
-                id={`${valueId}-error`}>
-                <>
-                    {_("Failed")}
-                    <Button variant="link" isInline>{_("view more...")}</Button>
-                </>
-            </Label>}
             <Label {...(stateMap[state] && stateMap[state].color) ? { color: stateMap[state].color } : {}}
                    icon={stateMap[state] && stateMap[state].icon}
                    className={"resource-state-text resource-state--" + (state || "").toLowerCase().replace(' ', '-')}
@@ -74,12 +51,5 @@ export const StateIcon = ({
         </Flex>
     );
 
-    if (error)
-        return (
-            <Popover headerContent={error.text} bodyContent={error.detail} className="ct-popover-alert">
-                {label}
-            </Popover>
-        );
-    else
-        return label;
+    return label;
 };

--- a/src/components/networks/network.tsx
+++ b/src/components/networks/network.tsx
@@ -50,14 +50,9 @@ export const getNetworkRow = ({ network } : { network: Network }) => {
         </span>
     );
     const state = (
-        <StateIcon error={network.error} state={network.active ? _("active") : _("inactive") }
-                   valueId={`${idPrefix}-state`}
-            dismissError={() => appState.updateNetwork(
-                network,
-                {
-                    error: null
-                }
-            )}
+        <StateIcon
+            state={network.active ? _("active") : _("inactive") }
+            valueId={`${idPrefix}-state`}
         />
     );
     const cols = [
@@ -83,48 +78,39 @@ const NetworkActions = ({ network } : { network: Network }) => {
     const Dialogs = useDialogs();
     const [operationInProgress, setOperationInProgress] = useState(false);
 
-    const onActivate = () => {
+    const onActivate = async () => {
         setOperationInProgress(true);
-        networkActivate({ connectionName: network.connectionName, objPath: network.id })
-                .then(() => appState.updateNetwork(network, { error: null }))
-                .finally(() => setOperationInProgress(false))
-                .catch(exc => {
-                    appState.updateNetwork(
-                        network,
-                        {
-                            error: {
-                                text: cockpit.format(_("Network $0 failed to get activated"), network.name),
-                                detail: exc.message,
-                            }
-                        });
-                });
+        try {
+            await networkActivate({ connectionName: network.connectionName, objPath: network.id });
+        } catch (exc) {
+            appState.addNotification({
+                text: cockpit.format(_("Network $0 failed to get activated"), network.name),
+                detail: String(exc),
+                resourceId: network.id,
+            });
+        }
+        setOperationInProgress(false);
     };
 
-    const onDeactivate = () => {
+    const onDeactivate = async () => {
         setOperationInProgress(true);
-        networkDeactivate({ connectionName: network.connectionName, objPath: network.id })
-                .then(() => appState.updateNetwork(network, { error: null }))
-                .finally(() => setOperationInProgress(false))
-                .catch(exc => {
-                    appState.updateNetwork(
-                        network,
-                        {
-                            error: {
-                                text: cockpit.format(_("Network $0 failed to get deactivated"), network.name),
-                                detail: exc.message,
-                            }
-                        });
-                });
+        try {
+            await networkDeactivate({ connectionName: network.connectionName, objPath: network.id });
+        } catch (exc) {
+            appState.addNotification({
+                text: cockpit.format(_("Network $0 failed to get deactivated"), network.name),
+                detail: String(exc),
+                resourceId: network.id,
+            });
+        }
+        setOperationInProgress(false);
     };
 
     const id = networkId(network.name, network.connectionName);
-    const deleteHandler = (network: Network): Promise<void> => {
-        if (network.active) {
-            return networkDeactivate({ connectionName: network.connectionName, objPath: network.id })
-                    .then(() => networkUndefine({ connectionName: network.connectionName, objPath: network.id }));
-        } else {
-            return networkUndefine({ connectionName: network.connectionName, objPath: network.id });
-        }
+    const deleteHandler = async (network: Network): Promise<void> => {
+        if (network.active)
+            await networkDeactivate({ connectionName: network.connectionName, objPath: network.id });
+        await networkUndefine({ connectionName: network.connectionName, objPath: network.id });
     };
     const dialogProps = {
         title: _("Delete network?"),

--- a/src/components/storagePools/storagePool.tsx
+++ b/src/components/storagePools/storagePool.tsx
@@ -49,9 +49,10 @@ export const getStoragePoolRow = ({ storagePool, vms } : { storagePool: StorageP
     );
 
     const state = (
-        <StateIcon error={storagePool.error} state={storagePool.active ? _("active") : _("inactive") }
-                   valueId={`${idPrefix}-state`}
-                   dismissError={() => appState.updateStoragePool(storagePool, { error: null })} />
+        <StateIcon
+            state={storagePool.active ? _("active") : _("inactive") }
+            valueId={`${idPrefix}-state`}
+        />
     );
 
     const tabRenderers = [
@@ -101,42 +102,36 @@ class StoragePoolActions extends React.Component<StoragePoolActionsProps, Storag
         this.onDeactivate = this.onDeactivate.bind(this);
     }
 
-    onActivate() {
+    async onActivate() {
         const storagePool = this.props.storagePool;
 
         this.setState({ operationInProgress: true });
-        storagePoolActivate({ connectionName: storagePool.connectionName, objPath: storagePool.id })
-                .catch(exc => {
-                    appState.updateStoragePool(
-                        storagePool,
-                        {
-                            error: {
-                                text: cockpit.format(_("Storage pool $0 failed to get activated"), storagePool.name),
-                                detail: exc.message,
-                            }
-                        }
-                    );
-                })
-                .finally(() => this.setState({ operationInProgress: false }));
+        try {
+            await storagePoolActivate({ connectionName: storagePool.connectionName, objPath: storagePool.id });
+        } catch (exc) {
+            appState.addNotification({
+                text: cockpit.format(_("Storage pool $0 failed to get activated"), storagePool.name),
+                detail: String(exc),
+                resourceId: storagePool.id,
+            });
+        }
+        this.setState({ operationInProgress: false });
     }
 
-    onDeactivate() {
+    async onDeactivate() {
         const storagePool = this.props.storagePool;
 
         this.setState({ operationInProgress: true });
-        storagePoolDeactivate({ connectionName: storagePool.connectionName, objPath: storagePool.id })
-                .catch(exc => {
-                    appState.updateStoragePool(
-                        storagePool,
-                        {
-                            error: {
-                                text: cockpit.format(_("Storage pool $0 failed to get deactivated"), storagePool.name),
-                                detail: exc.message,
-                            }
-                        }
-                    );
-                })
-                .finally(() => this.setState({ operationInProgress: false }));
+        try {
+            await storagePoolDeactivate({ connectionName: storagePool.connectionName, objPath: storagePool.id });
+        } catch (exc) {
+            appState.addNotification({
+                text: cockpit.format(_("Storage pool $0 failed to get deactivated"), storagePool.name),
+                detail: String(exc),
+                resourceId: storagePool.id,
+            });
+        }
+        this.setState({ operationInProgress: false });
     }
 
     render() {

--- a/src/components/vm/overview/vmOverviewCard.tsx
+++ b/src/components/vm/overview/vmOverviewCard.tsx
@@ -163,10 +163,8 @@ export class VmOverviewCard extends React.Component<VmOverviewCardProps, VmOverv
                             <DescriptionListTerm>{_("State")}</DescriptionListTerm>
                             <DescriptionListDescription>
                                 <StateIcon
-                                    error={vm.error}
                                     state={vm.state}
                                     valueId={`${idPrefix}-${vm.connectionName}-state`}
-                                    dismissError={() => appState.updateVm(vm, { error: null })}
                                 />
                             </DescriptionListDescription>
                         </DescriptionListGroup>

--- a/src/components/vm/vmActions.tsx
+++ b/src/components/vm/vmActions.tsx
@@ -51,18 +51,14 @@ function isOperationInProgress(vm: VM) {
     return vm.state == vm.operationInProgressFromState;
 }
 
-function setVmError(vm: VM, msg: string, ex: unknown) {
+function showVmError(vm: VM, msg: string, ex: unknown) {
     console.warn(msg, ":", String(ex));
-    appState.updateVm(
-        vm,
-        {
-            operationInProgressFromState: undefined,
-            error: {
-                text: msg,
-                detail: String(ex),
-            }
-        }
-    );
+    appState.updateVm(vm, { operationInProgressFromState: undefined });
+    appState.addNotification({
+        text: msg,
+        detail: String(ex),
+        resourceId: vm.id,
+    });
 }
 
 export async function vmStart(vm: VM) {
@@ -70,7 +66,7 @@ export async function vmStart(vm: VM) {
     try {
         await vmDomainMethod<void>(vm, 'Create', 'u', 0);
     } catch (ex) {
-        setVmError(vm, cockpit.format(_("VM $0 failed to start"), vm.name), ex);
+        showVmError(vm, cockpit.format(_("VM $0 failed to start"), vm.name), ex);
     }
 }
 
@@ -90,7 +86,7 @@ export async function vmReboot(vm: VM) {
     try {
         await vmDomainMethod<void>(vm, 'Reboot', 'u', 0);
     } catch (ex) {
-        setVmError(vm, cockpit.format(_("VM $0 failed to reboot"), vm.name), ex);
+        showVmError(vm, cockpit.format(_("VM $0 failed to reboot"), vm.name), ex);
     }
 }
 
@@ -98,7 +94,7 @@ export async function vmForceReboot(vm: VM) {
     try {
         await vmDomainMethod<void>(vm, 'Reset', 'u', 0);
     } catch (ex) {
-        setVmError(vm, cockpit.format(_("VM $0 failed to force reboot"), vm.name), ex);
+        showVmError(vm, cockpit.format(_("VM $0 failed to force reboot"), vm.name), ex);
     }
 }
 
@@ -109,7 +105,7 @@ export async function vmShutdown(vm: VM) {
         if (!vm.persistent)
             cockpit.location.go(["vms"]);
     } catch (ex) {
-        setVmError(vm, cockpit.format(_("VM $0 failed to shutdown"), vm.name), ex);
+        showVmError(vm, cockpit.format(_("VM $0 failed to shutdown"), vm.name), ex);
     }
 }
 
@@ -117,7 +113,7 @@ export async function vmPause(vm: VM) {
     try {
         await vmDomainMethod<void>(vm, 'Suspend', '');
     } catch (ex) {
-        setVmError(vm, cockpit.format(_("VM $0 failed to pause"), vm.name), ex);
+        showVmError(vm, cockpit.format(_("VM $0 failed to pause"), vm.name), ex);
     }
 }
 
@@ -125,7 +121,7 @@ export async function vmResume(vm: VM) {
     try {
         await vmDomainMethod<void>(vm, 'Resume', '');
     } catch (ex) {
-        setVmError(vm, cockpit.format(_("VM $0 failed to resume"), vm.name), ex);
+        showVmError(vm, cockpit.format(_("VM $0 failed to resume"), vm.name), ex);
     }
 }
 
@@ -135,7 +131,7 @@ export async function vmForceOff(vm: VM) {
         if (!vm.persistent)
             cockpit.location.go(["vms"]);
     } catch (ex) {
-        setVmError(vm, cockpit.format(_("VM $0 failed to force shutdown"), vm.name), ex);
+        showVmError(vm, cockpit.format(_("VM $0 failed to force shutdown"), vm.name), ex);
     }
 }
 
@@ -143,7 +139,7 @@ export async function onSendNMI(vm: VM) {
     try {
         await vmDomainMethod<void>(vm, 'InjectNMI', 'u', 0);
     } catch (ex) {
-        setVmError(vm, cockpit.format(_("VM $0 failed to send NMI"), vm.name), ex);
+        showVmError(vm, cockpit.format(_("VM $0 failed to send NMI"), vm.name), ex);
     }
 }
 
@@ -509,7 +505,7 @@ export const VmRestartDialog = ({ vm } : { vm: VM }) => {
             await vmDomainMethod<void>(vm, force ? 'Destroy' : 'Shutdown', 'u', 0);
         } catch (ex) {
             off();
-            setVmError(vm, cockpit.format(_("VM $0 failed to shutdown"), vm.name), ex);
+            showVmError(vm, cockpit.format(_("VM $0 failed to shutdown"), vm.name), ex);
         }
     }
 

--- a/src/components/vms/hostvmslist.tsx
+++ b/src/components/vms/hostvmslist.tsx
@@ -65,19 +65,12 @@ const VmState = ({
         state = vm.state;
     }
 
-    const dismissError = () => {
-        if (vm.isUi)
-            appState.setUiVm(vm.connectionName, vm.name, { error: undefined });
-        else
-            appState.updateVm(vm, { error: null });
-    };
-
     return (
-        <StateIcon dismissError={dismissError}
-            error={vm.error}
+        <StateIcon
             state={state}
             valueId={`${vmId(vm.name)}-${vm.connectionName}-state`}
-            additionalState={!vm.isUi && <><VmNeedsShutdown vm={vm} /><VmUsesSpice vm={vm} vms={vms} /></>} />
+            additionalState={!vm.isUi && <><VmNeedsShutdown vm={vm} /><VmUsesSpice vm={vm} vms={vms} /></>}
+        />
     );
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,11 +52,6 @@ export interface VirtXmlCapabilities {
 
 /** Virtual Machines **/
 
-export interface DetailedError {
-    text: string;
-    detail: string;
-}
-
 export type VMDiskDevice = "floppy" | "disk" | "cdrom" | "lun";
 
 export interface VMDisk {
@@ -421,7 +416,6 @@ export interface VM extends VMXML {
     persistent: boolean;
     autostart: boolean;
 
-    error?: DetailedError | null;
     installInProgress?: boolean;
 
     // An operation (shut down or start) has been initiated from this
@@ -504,8 +498,6 @@ export interface StoragePool {
     persistent?: boolean;
     autostart?: boolean;
     volumes: StorageVolume[];
-
-    error?: DetailedError | null | undefined;
 }
 
 export type StoragePoolCapabilites = Record<string, { supported: optString}>;
@@ -554,7 +546,6 @@ export interface Network extends NetworkXML {
     active?: boolean;
     persistent?: boolean;
     autostart?: boolean;
-    error?: DetailedError | null;
 }
 
 /** Node Devices **/

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -2857,9 +2857,9 @@ class TestMachinesCreate(machineslib.VirtualMachinesCase):
             b.wait_visible(f"#vm-{vmName}-uses-spice")
             # and indeed startup fails
             b.click(f"#vm-{vmName}-system-run")
-            b.wait_in_text(f"#vm-{vmName}-system-state-error", "Failed")
-            b.click(f"#vm-{vmName}-system-state-error button[aria-label=Close]")
-            b.wait_not_present(f"#vm-{vmName}-system-state-error")
+            b.wait_in_text(".pf-m-toast .pf-v6-c-alert", f"VM {vmName} failed to start")
+            b.click(".pf-m-toast .pf-v6-c-alert .pf-v6-c-alert__action button")
+            b.wait_not_present(".pf-m-toast")
 
             b.click(f"#vm-{vmName}-uses-spice")
             b.wait_in_text(".pf-v6-c-popover", "Uses SPICE")

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -291,18 +291,17 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
 
         # Try to run subVmTest1 - it will fail because of inactive default network
         tryRunDomain('subVmTest1', 'system')
-        b.wait_visible("#vm-subVmTest1-system-state-error")
-        if run_pixel_tests:
-            b.assert_pixels("tr[data-row-id=vm-subVmTest1-system]", "vm-state-error")
-        b.click('#vm-subVmTest1-system-state-error button:contains("view more")')
-        b.wait_in_text(".pf-v6-c-popover", "VM subVmTest1 failed to start")
-        b.click('#vm-subVmTest1-system-state-error button[aria-label=Close]')
+        b.wait_in_text(".pf-m-toast .pf-v6-c-alert", "VM subVmTest1 failed to start")
+        b.click('.pf-m-toast .pf-v6-c-alert button:contains("show more")')
+        b.wait_in_text(".pf-m-toast .pf-v6-c-alert", "network 'default' is not active")
+        b.click(".pf-m-toast .pf-v6-c-alert .pf-v6-c-alert__action button")
+        b.wait_not_present(".pf-m-toast")
 
         # Try to run subVmTest2
         tryRunDomain('subVmTest2', 'system')
-        b.click('#vm-subVmTest2-system-state-error button:contains("view more")')
-        b.wait_in_text(".pf-v6-c-popover", "VM subVmTest2 failed to start")
-        b.click('#vm-subVmTest2-system-state-error button[aria-label=Close]')
+        b.wait_in_text(".pf-m-toast .pf-v6-c-alert", "VM subVmTest2 failed to start")
+        b.click(".pf-m-toast .pf-v6-c-alert .pf-v6-c-alert__action button")
+        b.wait_not_present(".pf-m-toast")
 
     def testCloneSessionConnection(self):
         self.testClone(connectionName='session')

--- a/test/check-machines-networks
+++ b/test/check-machines-networks
@@ -231,9 +231,10 @@ class TestMachinesNetworks(machineslib.VirtualMachinesCase):
                     b.wait_not_present("#create-network-dialog")
 
             def verify_expected_error_on_head(self, error_message):
-                b.click(f'#network-{self.name}-system-state-error button:contains("view more")')
-                b.wait_in_text(".pf-v6-c-popover", error_message)
-                b.click(f'#network-{self.name}-system-state-error button[aria-label=Close]')
+                b.click('.pf-m-toast .pf-v6-c-alert button:contains("show more")')
+                b.wait_in_text(".pf-m-toast .pf-v6-c-alert", error_message)
+                b.click(".pf-m-toast .pf-v6-c-alert .pf-v6-c-alert__action button")
+                b.wait_not_present(".pf-m-toast")
 
             def verify_dialog(self):
                 # Check that the defined network is now visible
@@ -838,8 +839,9 @@ class TestMachinesNetworks(machineslib.VirtualMachinesCase):
         self.waitNetworkRow("test_network2_clash", connectionName)
         m.execute("virsh net-start test_network2")
         b.click(f"#activate-network-test_network2_clash-{connectionName}")
-        b.wait_visible(f"#network-test_network2_clash-{connectionName}-state-error")
-        b.wait_in_text(f"#network-test_network2_clash-{connectionName}-state-error", "Failed")
+        b.wait_in_text(".pf-m-toast .pf-v6-c-alert", "Network test_network2_clash failed to get activated")
+        b.click(".pf-m-toast .pf-v6-c-alert .pf-v6-c-alert__action button")
+        b.wait_not_present(".pf-m-toast")
 
         # error should disappear if resolved
         b.wait_visible(f"#deactivate-network-test_network2-{connectionName}")
@@ -848,7 +850,6 @@ class TestMachinesNetworks(machineslib.VirtualMachinesCase):
         b.wait_visible(f"#activate-network-test_network2-{connectionName}")
         b.click(f"#activate-network-test_network2_clash-{connectionName}")
         b.wait_in_text(f"#network-test_network2_clash-{connectionName}-state", "active")
-        b.wait_not_present(f"#network-test_network2_clash-{connectionName}-state-error")
 
         # check "X" button of the deletion dialog
         self.dropdownAction(f"#network-test_network2-{connectionName}-action-kebab",


### PR DESCRIPTION
Demo: https://youtu.be/isa7JEGGpPc

For example, when starting a VM fails, this fact is no longer stored in the VM object and shown by the StateIcon component.  Instead a toas notification is shown with the same information.

The let's us avoid the putting a "Failed" label into the space where the state is shown, which improves layout (because the size of the state display doesn't change so much), and it also avoids having a hard-to-discover clickable Label.

The Popup with the error message was also questionably placed, since it was centered over all status icons and not just the "Failed" one.

Also, we have CSS to increase the size of the text in a status label, but there is a bug where this only happens for the first label.  So we would end up with "Failed" in a bigger font than "Shut off", for example.  (If there was only a single "Shut off" label, it would have the bigger font.)