### PR TITLE
Drop unneeded admin session cleanup

### DIFF
--- a/test/machineslib.py
+++ b/test/machineslib.py
@@ -494,13 +494,6 @@ class VirtualMachinesCase(VirtualMachinesCaseHelpers, storagelib.StorageHelpers,
         else:
             m.execute("systemctl reset-failed libvirtd; systemctl try-restart libvirtd")
 
-        # user libvirtd instance tends to SIGABRT with "Failed to find user record for uid .." on shutdown
-        # during cleanup so make sure that there are no leftover user processes that bleed into the next test
-        self.addCleanup(m.execute, """
-            pkill -u admin || true;
-            while [ -n "$(pgrep -au admin | grep -v 'systemd --user')" ]; do sleep 0.5; done
-        """)
-
         # FIXME: report downstream; AppArmor noisily denies some operations, but they are not required for us
         self.allow_journal_messages(r'.* type=1400 .* apparmor="DENIED" operation="capable" profile="\S*libvirtd.* capname="sys_rawio".*')  # noqa: E501
         # AppArmor doesn't like the non-standard path for our storage pools


### PR DESCRIPTION
It's not entirely clear if this breaks but running this reproducer on debian-trixie reproduces the same issue

```
systemctl reset-failed user@1002.service 2>/dev/null
systemctl stop user@1002.service 2>/dev/null

for i in 1 2 3 4 5 6; do
    echo "--- attempt $i ---"
    systemctl start user@1002.service
    loginctl terminate-user 1002 2>/dev/null || true
    loginctl kill-user 1002 2>/dev/null || true
    pkill -9 -u admin | grep -v "systemd --user" || true
    ps aux | grep admin
while pgrep -u admin; do sleep 0.2; done
    sleep 0.3
done

systemctl show user@1002.service -p Result -p ActiveState
```