### PR TITLE
test: Reload dbus after creating users

### DIFF
--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -31,6 +31,14 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
         user_name = f"test_{user_group if user_group else 'none'}_user"
         self.machine.execute(f"useradd{' -G ' + user_group if user_group else ''} {user_name}")
         self.machine.execute(f"echo '{user_name}:foobar' | chpasswd")
+        # If at any time prior a user with the same user id existed as
+        # the one that we have just created, the classic dbus-daemon
+        # might still use the groups of that old user when making
+        # policy decisions. (The modern dbus-broker does not seem to
+        # have that problem.) So let's reload it to stop that from
+        # happening.
+        if self.machine.image.startswith("rhel-8-10"):
+            self.machine.execute("systemctl reload dbus")
         # user libvirtd instance tends to SIGABRT with "Failed to find user record for uid .." on shutdown during cleanup
         # so make sure that there are no leftover user processes that bleed into the next test
         self.addCleanup(self.machine.execute, f"pkill -u {user_name} || true; while pgrep -u {user_name}; do sleep 0.5; done")


### PR DESCRIPTION
Cherry-picked from main commit 2b98ece9bea3 ("test: Reload dbus after creating users").

Hopefully fixes an issue on the AWS runners: https://cockpit-ci-logs.s3.us-east-1.amazonaws.com/ec2-full-20260709-211235-cockpit-project-cockpit-machines-8fd602fd-rhel-8-10/log.html#42-2