### PR TITLE
tests: Don't skip selinux related tests on openSUSE

### DIFF
--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -23,7 +23,7 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
         user = self.createUser(user_group='libvirt')
         self._testBasic(user, superuser=False, libvirt_group_member=True)
 
-    @testlib.skipImage("No SELinux", "debian-*", "ubuntu-*", "arch", "opensuse*")
+    @testlib.skipImage("No SELinux", "debian-*", "ubuntu-*", "arch")
     @testlib.skipImage("crashes C bridge", "rhel-8*")
     def testBasicSysadmU(self):
         user = self.createUser(user_group='libvirt')


### PR DESCRIPTION
Tumbleweed used to use apparmor and has now switched to selinux by default. The VM has selinux enabled out of the box. It no longer makes sense to skip selinux related tests.