### PR TITLE
test: Drop Ubuntu 24.04 test workarounds

### DIFF
--- a/src/components/vm/consoles/spice.tsx
+++ b/src/components/vm/consoles/spice.tsx
@@ -15,7 +15,7 @@ import { Split, SplitItem } from "@patternfly/react-core/dist/esm/layouts/Split/
 
 import { useDialogs } from 'dialogs';
 
-import { canReplaceSpice, ReplaceSpiceDialog } from '../vmReplaceSpiceDialog.jsx';
+import { ReplaceSpiceDialog } from '../vmReplaceSpiceDialog.jsx';
 import { LaunchViewerButton, connection_address } from './common';
 
 const _ = cockpit.gettext;
@@ -72,18 +72,16 @@ const Spice = ({
                         {_("Start the virtual machine to launch remote viewer.")}
                     </EmptyStateBody>
                 }
-                { canReplaceSpice() &&
-                    <EmptyStateFooter>
-                        <EmptyStateActions>
-                            <Button
-                                variant="link"
-                                onClick={replace_spice}
-                            >
-                                {_("Replace with VNC")}
-                            </Button>
-                        </EmptyStateActions>
-                    </EmptyStateFooter>
-                }
+                <EmptyStateFooter>
+                    <EmptyStateActions>
+                        <Button
+                            variant="link"
+                            onClick={replace_spice}
+                        >
+                            {_("Replace with VNC")}
+                        </Button>
+                    </EmptyStateActions>
+                </EmptyStateFooter>
             </EmptyState>
             { !isExpanded && <SpiceFooter vm={vm} spice={spice} /> }
         </>

--- a/src/components/vm/usesSpice.tsx
+++ b/src/components/vm/usesSpice.tsx
@@ -11,14 +11,14 @@ import { ExclamationTriangleIcon } from "@patternfly/react-icons";
 import cockpit from 'cockpit';
 import { useDialogs } from 'dialogs.jsx';
 
-import { canReplaceSpice, ReplaceSpiceDialog } from './vmReplaceSpiceDialog.jsx';
+import { ReplaceSpiceDialog } from './vmReplaceSpiceDialog.jsx';
 
 const _ = cockpit.gettext;
 
 export const VmUsesSpice = ({ vm, vms } : { vm: VM, vms?: VM[] }) => {
     const Dialogs = useDialogs();
 
-    if (!vm.hasSpice || vm.capabilities?.supportsSpice || !canReplaceSpice())
+    if (!vm.hasSpice || vm.capabilities?.supportsSpice)
         return null;
 
     const onReplace = () => Dialogs.show(<ReplaceSpiceDialog vm={vm} vms={vms} />);

--- a/src/components/vm/vmActions.tsx
+++ b/src/components/vm/vmActions.tsx
@@ -25,7 +25,7 @@ import { DeleteDialog } from "./deleteDialog.jsx";
 import { MigrateDialog } from './vmMigrateDialog.jsx';
 import { RenameDialog } from './vmRenameDialog.jsx';
 import { EditDescriptionDialog } from './vmEditDescriptionDialog.jsx';
-import { canReplaceSpice, ReplaceSpiceDialog } from './vmReplaceSpiceDialog.jsx';
+import { ReplaceSpiceDialog } from './vmReplaceSpiceDialog.jsx';
 import {
     domainCanReset,
     domainCanInstall,
@@ -409,7 +409,7 @@ export const VmActions = ({
         dropdownItems.push(<Divider key="separator-migrate" />);
     }
 
-    if (vm.inactiveXML?.hasSpice && canReplaceSpice()) {
+    if (vm.inactiveXML?.hasSpice) {
         dropdownItems.push(
             <DropdownItem key={`${id}-replace-spice`}
                           id={`${id}-replace-spice`}

--- a/src/components/vm/vmReplaceSpiceDialog.tsx
+++ b/src/components/vm/vmReplaceSpiceDialog.tsx
@@ -7,8 +7,6 @@
 import cockpit from 'cockpit';
 import React, { useState } from 'react';
 
-import { appState } from "../../state";
-
 import type { VM } from '../../types';
 
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
@@ -32,10 +30,6 @@ import { virtXmlEdit } from '../../libvirtApi/domain.js';
 import './vmReplaceSpiceDialog.css';
 
 const _ = cockpit.gettext;
-
-export function canReplaceSpice(): boolean {
-    return !!appState.virtXmlCapabilities?.convert_to_vnc;
-}
 
 interface DialogError {
     dialogError: string;

--- a/src/libvirtApi/common.ts
+++ b/src/libvirtApi/common.ts
@@ -48,7 +48,7 @@ import {
     parseDumpxmlForCapabilities
 } from "../libvirt-xml-parse.js";
 
-import type { ConnectionName, VM, OSInfo, VirtInstallCapabilities, VirtXmlCapabilities } from '../types';
+import type { ConnectionName, VM, OSInfo, VirtInstallCapabilities } from '../types';
 
 /**
  * Calculates disk statistics.
@@ -379,18 +379,6 @@ export async function getVirtInstallCapabilities(): Promise<VirtInstallCapabilit
         unattendedSupported: !!unattended_out,
         unattendedUserLogin: !!unattended_out && unattended_out.includes('user-login'),
     };
-}
-
-export async function getVirtXmlCapabilities(): Promise<VirtXmlCapabilities | null> {
-    try {
-        const help_text = await cockpit.spawn(["virt-xml", "--help"]);
-        return {
-            convert_to_vnc: help_text.includes("--convert-to-vnc"),
-        };
-    } catch (exc) {
-        console.error("Failed to query virt-xml capabilities:", String(exc));
-        return null;
-    }
 }
 
 export function getApiData({

--- a/src/state.ts
+++ b/src/state.ts
@@ -10,7 +10,7 @@ import { superuser } from "superuser.js";
 
 import type {
     ConnectionName, VM, VMState, UIVM, UIVMProps,
-    HypervisorCapabilities, VirtInstallCapabilities, VirtXmlCapabilities,
+    HypervisorCapabilities, VirtInstallCapabilities,
     NodeDevice, NodeInterface,
     StoragePool,
     Network,
@@ -20,7 +20,6 @@ import {
     getApiData,
     getLibvirtVersion,
     getVirtInstallCapabilities,
-    getVirtXmlCapabilities,
 } from "./libvirtApi/common.js";
 import { domainGetAll, domainGetByName } from './libvirtApi/domain';
 import {
@@ -104,7 +103,6 @@ export class AppState extends EventEmitter<AppStateEvents> {
     nodeMaxMemory: number = 0;
     hypervisorCapabilities: HypervisorCapabilities | null = null;
     virtInstallCapabilities: VirtInstallCapabilities | null = null;
-    virtXmlCapabilities: VirtXmlCapabilities | null = null;
 
     setNodeMaxMemory(memory: number) {
         this.nodeMaxMemory = memory;
@@ -302,7 +300,6 @@ export class AppState extends EventEmitter<AppStateEvents> {
 
             // get these in the background, it takes quite long
             getVirtInstallCapabilities().then(caps => { this.virtInstallCapabilities = caps; this.#update() });
-            getVirtXmlCapabilities().then(caps => { this.virtXmlCapabilities = caps; this.#update() });
 
             await Promise.allSettled(
                 [

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,10 +46,6 @@ export interface VirtInstallCapabilities {
     unattendedUserLogin?: boolean | undefined,
 }
 
-export interface VirtXmlCapabilities {
-    convert_to_vnc: boolean;
-}
-
 /** Virtual Machines **/
 
 export type VMDiskDevice = "floppy" | "disk" | "cdrom" | "lun";

--- a/test/check-machines-consoles
+++ b/test/check-machines-consoles
@@ -568,19 +568,14 @@ fullscreen=0
 
         assert_state("This machine has a SPICE graphical console that can not be shown here.")
 
-        if self.machine.image in ["ubuntu-2404"]:
-            # virt-xml in older Ubuntus does not have the
-            # --convert-to-vnc option and Cockpit will omit the button
-            b.wait_not_present(".consoles-card .pf-v6-c-empty-state button:contains(Replace with VNC)")
-        else:
-            b.click(".consoles-card .pf-v6-c-empty-state button:contains(Replace with VNC)")
-            b.wait_text(".pf-v6-c-modal-box__title-text", f"Replace SPICE devices in VM {name}")
-            b.click("#replace-spice-dialog-confirm")
-            b.wait_not_present(".pf-v6-c-modal-box")
-            assert_state("Restart this virtual machine to access its graphical console")
-            b.click(f"#vm-{name}-consoles .pf-v6-c-empty-state .pf-v6-c-button:contains(Shutdown and restart)")
-            b.click("#vm-restart-dialog-force-restart")
-            b.wait_visible(".vm-console-vnc canvas")
+        b.click(".consoles-card .pf-v6-c-empty-state button:contains(Replace with VNC)")
+        b.wait_text(".pf-v6-c-modal-box__title-text", f"Replace SPICE devices in VM {name}")
+        b.click("#replace-spice-dialog-confirm")
+        b.wait_not_present(".pf-v6-c-modal-box")
+        assert_state("Restart this virtual machine to access its graphical console")
+        b.click(f"#vm-{name}-consoles .pf-v6-c-empty-state .pf-v6-c-button:contains(Shutdown and restart)")
+        b.click("#vm-restart-dialog-force-restart")
+        b.wait_visible(".vm-console-vnc canvas")
 
     @testlib.skipImage('No virtio video', "arch", "opensuse-*", "rhel-8-*")
     def testScaleResize(self):
@@ -712,7 +707,7 @@ fullscreen=0
 
         b2.select_PF("#vm-console-vnc-scaling", "Remote resizing")
 
-        if m.image not in ["ubuntu-2404", "debian-trixie"]:
+        if m.image not in ["debian-trixie"]:
             # Cockpit will make a non-shared connection.  The embedded
             # console will be forcefully disconnected.
             b.wait_in_text(".consoles-card", "Disconnected")

--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -2606,7 +2606,6 @@ class TestMachinesCreate(machineslib.VirtualMachinesCase):
         finally:
             m.execute(f"for f in {plugins}; do mv {self.vm_tmpdir}/qemu/$(basename $f) $f; done")
 
-    @testlib.skipImage('SPICE conversion not supported', "ubuntu-2404")
     def testReplaceSpice(self):
         m = self.machine
         b = self.browser
@@ -2839,7 +2838,6 @@ class TestMachinesCreate(machineslib.VirtualMachinesCase):
 
     # we need this test to create a SPICE VM to simulate the host change to "no spice support"
     @testlib.skipImage('SPICE not supported on RHEL', "rhel-*", "centos-*", "fedora-eln")
-    @testlib.skipImage('SPICE conversion not supported', "ubuntu-2404")
     def testNoSpiceAlert(self):
         b = self.browser
 

--- a/test/check-machines-nics
+++ b/test/check-machines-nics
@@ -925,7 +925,7 @@ class TestMachinesNICs(machineslib.VirtualMachinesCase):
                     self.browser.wait_not_present(f"#vm-subVmTest1-network-{self.nic_num}-mac")
                 self.browser.wait_not_present(".pf-v6-c-modal-box")
 
-    @testlib.skipImage('PASST not supported', "rhel-8-*", "ubuntu-2404")
+    @testlib.skipImage('PASST not supported', "rhel-8-*")
     def testPortForwards(self):
         b = self.browser
 


### PR DESCRIPTION
Cockpit no longer tests on Ubuntu 24.04.