### PR TITLE
test: Fedora ELN does not support SPICE

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -2844,7 +2844,7 @@ class TestMachinesCreate(machineslib.VirtualMachinesCase):
 
         vmName = "subVmTest1"
 
-        if not m.image.startswith(("rhel-", "centos-")):
+        if not m.image.startswith(("rhel-", "centos-", "fedora-eln")):
             self.createVm(vmName, graphics="spice", running=False)
         else:
             self.createVm(vmName, graphics="vnc", running=False)


### PR DESCRIPTION
Fedora ELN rebuilds Fedora with only RHEL packages and with the RHEL configuration so SPICE is also not supported there.

Closes: #2762