### PR TITLE
docs: fix two typos in HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -41,7 +41,7 @@ set to upload code changes to `~/.local/share/cockpit/` instead of
 Cockpit Machines uses [ESLint](https://eslint.org/) to automatically check
 JavaScript code style in `.jsx` and `.js` files.
 
-eslint is executed as part of `test/static-code`, aka. `make codecheck`.
+eslint is executed as part of `test/common/static-code`, aka. `make codecheck`.
 
 For developer convenience, the ESLint can be started explicitly by:
 
@@ -58,7 +58,7 @@ Rules configuration can be found in the `.eslintrc.json` file.
 Cockpit uses [Stylelint](https://stylelint.io/) to automatically check CSS code
 style in `.css` and `scss` files.
 
-stylelint is executed as part of `test/static-code`, aka. `make codecheck`.
+stylelint is executed as part of `test/common/static-code`, aka. `make codecheck`.
 
 For developer convenience, the Stylelint can be started explicitly by:
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -7,7 +7,7 @@ repository checkout.
 
 For development, you usually want to run your module straight out of the git
 tree. To do that, run `make devel-install`, which links your checkout to the
-location were `cockpit-bridge` looks for packages. If you prefer to do this
+location where `cockpit-bridge` looks for packages. If you prefer to do this
 manually:
 
 ```
@@ -58,7 +58,7 @@ Rules configuration can be found in the `.eslintrc.json` file.
 Cockpit uses [Stylelint](https://stylelint.io/) to automatically check CSS code
 style in `.css` and `scss` files.
 
-styleint is executed as part of `test/static-code`, aka. `make codecheck`.
+stylelint is executed as part of `test/static-code`, aka. `make codecheck`.
 
 For developer convenience, the Stylelint can be started explicitly by:
 


### PR DESCRIPTION
## Summary

Two one-word typo fixes in `HACKING.md`. Documentation only - no code, no user-facing strings, no translatable text touched.

- **HACKING.md** (line 10): `links your checkout to the location were cockpit-bridge looks for packages` -> `... the location where cockpit-bridge looks for packages`
- **HACKING.md** (line 61): `styleint is executed as part of test/static-code` -> `stylelint is executed as part of test/static-code` (matches the parallel `eslint is executed as part of ...` sentence 20 lines above, and the tool is Stylelint everywhere else in the section)

Both survive because `.github/workflows/codespell.yml` runs `codespell src`, so it never looks at top-level Markdown - and `were` is a real word that codespell would not flag anyway.

### Deliberately NOT changed

Nothing under `src/` was touched. In particular I left `src/components/vm/vmReplaceSpiceDialog.tsx` alone: the translatable string `_("Please see $0 how to reconfigure your VM manually.")` on the line below the comment there is an existing msgid with translations in all 21 `po/*.po` catalogues, and rewording it would invalidate every one of them.

No functional changes - documentation only.