### PR TITLE
test: Wait a bit after filtering the OSes

### DIFF
--- a/test/check-machines-create
+++ b/test/check-machines-create
@@ -1288,6 +1288,12 @@ class TestMachinesCreate(machineslib.VirtualMachinesCase):
             else:
                 b.wait_in_text("#os-select li button", "No results found")
 
+            # Wait a bit for the TypeaheadSelect to settle
+            # down. Otherwise it might focus itself again while we
+            # take a pixel test.
+            #
+            time.sleep(1.0)
+
             return self
 
         def checkRhelIsDownloadable(self):


### PR DESCRIPTION
The TypeaheadSelect component might asynchronously put the focus back into the input element after a subsequent pixel test has removed it.