### PR TITLE
Test speed ups

### DIFF
--- a/test/check-machines-disks
+++ b/test/check-machines-disks
@@ -776,6 +776,8 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
 
         used_targets = ['vda']
 
+        args = self.createVm("subVmTest1")
+
         # Preparations for testing ISCSI pools
         target_iqn = "iqn.2019-09.cockpit.lan"
         self.prepareStorageDeviceOnISCSI(target_iqn)
@@ -789,8 +791,6 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         testlib.wait(lambda: "unit:0:0:0" in self.machine.execute(cmd), delay=3)
 
         self.addCleanup(self.machine.execute, "virsh pool-destroy iscsi-pool; virsh pool-undefine iscsi-pool")
-
-        args = self.createVm("subVmTest1")
 
         # Remove images pool so that we get the iscsi-pool pool first on the list
         m.execute("virsh pool-destroy images; virsh pool-undefine images")
@@ -837,6 +837,9 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
 
         used_targets = ['vda']
 
+        # Start the virtual machine as creating a nfs volume is quite expensive
+        args = self.createVm("subVmTest1")
+
         m.execute("if selinuxenabled 2>/dev/null; then setsebool -P virt_use_nfs 1; fi")
 
         # HACK: NFS produces dozens of permissive=1 SELinux issues; setroubleshoot runs massively parallel
@@ -859,8 +862,6 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         """)
         # And create a volume on it in order to test use existing volume dialog
         m.execute("virsh vol-create-as --pool nfs-pool --name nfs-volume-0 --capacity 1M --format qcow2")
-
-        args = self.createVm("subVmTest1")
 
         # Wait for the system to completely start
         self.waitGuestBooted(args['logfile'])
@@ -900,6 +901,9 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         dev = self.add_ram_disk(2)
         used_targets = ['vda']
 
+        args = self.createVm("subVmTest1")
+        self.addCleanup(m.execute, "virsh destroy subVmTest1")
+
         self.machine.execute(f"""
             virsh pool-define-as pool-disk disk - - {dev} - {os.path.join(self.vm_tmpdir, 'poolDiskImages')}
             virsh pool-build pool-disk --overwrite
@@ -915,9 +919,6 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
             virsh vol-create-as loop-disk {existing_disk} 1M
             virsh vol-create-as loop-disk {existing_disk2} 1M""")
         self.addCleanup(m.execute, f"wipefs -a {loop_dev}")
-
-        args = self.createVm("subVmTest1")
-        self.addCleanup(m.execute, "virsh destroy subVmTest1")
 
         # Wait for the system to completely start
         self.waitGuestBooted(args['logfile'])
@@ -993,6 +994,8 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         used_targets = ['vda']
         transient_targets = []
 
+        self.createVm("subVmTest1")
+
         # prepare libvirt storage pools
         v1 = os.path.join(self.vm_tmpdir, "vm_one")
         v2 = os.path.join(self.vm_tmpdir, "vm_two")
@@ -1009,8 +1012,6 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         m.execute("virsh vol-create-as myPoolTwo mydiskofpooltwo_permanent --capacity 50M --format qcow2")
 
         testlib.wait(lambda: "mydiskofpooltwo_permanent" in m.execute("virsh vol-list myPoolTwo"))
-
-        self.createVm("subVmTest1")
 
         self.login_and_go("/machines")
         self.waitPageInit()
@@ -1485,6 +1486,8 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         b = self.browser
         m = self.machine
 
+        args = self.createVm("subVmTest1")
+
         # prepare libvirt storage pools
         p1 = os.path.join(self.vm_tmpdir, "vm_one")
         m.execute(f"mkdir --mode 777 {p1}")
@@ -1495,8 +1498,6 @@ class TestMachinesDisks(machineslib.VirtualMachinesCase):
         testlib.wait(lambda: "mydiskofpoolone_1" in m.execute("virsh vol-list myPoolOne"))
         testlib.wait(lambda: "mydiskofpoolone_2" in m.execute("virsh vol-list myPoolOne"))
         testlib.wait(lambda: "mydiskofpoolone_3" in m.execute("virsh vol-list myPoolOne"))
-
-        args = self.createVm("subVmTest1")
 
         vdc_path = f"{p1}/mydiskofpoolone_1"
         vdd_path = f"{p1}/mydiskofpoolone_2"

--- a/test/check-machines-lifecycle
+++ b/test/check-machines-lifecycle
@@ -31,7 +31,7 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
         self.addCleanup(self.machine.execute, f"semanage login -d -s sysadm_u {user}")
         self._testBasic(user, superuser=False, libvirt_group_member=True)
 
-    def testBasicAdminUser(self):
+    def testBasicAdminUserUnprivileged(self):
         # The group in debian based distro should be sudo
         if "ubuntu" in self.machine.image or "debian" in self.machine.image:
             user_group = "sudo"
@@ -41,7 +41,15 @@ class TestMachinesLifecycle(machineslib.VirtualMachinesCase):
 
         # Check NON-PRIVILEGED user won't see any VMs even though they are in wheel group
         self._testBasic(user, superuser=False, expect_empty_list=True)
-        self.machine.execute("virsh destroy subVmTest1; virsh undefine subVmTest1")
+
+    def testBasicAdminUser(self):
+        # The group in debian based distro should be sudo
+        if "ubuntu" in self.machine.image or "debian" in self.machine.image:
+            user_group = "sudo"
+        else:
+            user_group = "wheel"
+        user = self.createUser(user_group=user_group)
+
         # Check wheel group PRIVILEGED user will see VMs and can do operations on them
         self._testBasic(user)
 


### PR DESCRIPTION
Our baseline is: 1231s without retries.

| Test | Old time | New time | Diff |
| ---     | -------        | ----------     | ----- |
| TestMachinesDisks.testAddDiskNFS | 95s | 79s | -16s |
| TestMachinesDisks.testAddDiskSCSI | 52s | 42s| -10s|
| TestMachinesDisks.testAddDiskDirPool| 52s | 46s | -6s|
